### PR TITLE
Added check to ensure notification is run once per var per timestamp

### DIFF
--- a/include/core/types.hpp
+++ b/include/core/types.hpp
@@ -11,6 +11,8 @@ using Timestamp = u_int64_t;
 using IdBase = size_t;  // IDs are mainly used for vector lookups, so they must
                         // be of size_t.
 
+static Timestamp NULL_TIMESTAMP = Timestamp(0);
+
 struct Id {
   IdBase id;
   Id() = delete;

--- a/include/propagation/propagationGraph.hpp
+++ b/include/propagation/propagationGraph.hpp
@@ -32,6 +32,9 @@ class PropagationGraph {
   // Map from VarID -> vector of InvariantID
   std::vector<std::vector<InvariantDependencyData>> m_listeningInvariants;
 
+  // The last time when an intVar was commited to
+  std::vector<Timestamp> m_varsLastCommit;
+
   std::queue<VarId> m_modifiedVariables;
 
  public:

--- a/src/propagation/propagationGraph.cpp
+++ b/src/propagation/propagationGraph.cpp
@@ -8,11 +8,13 @@ PropagationGraph::PropagationGraph(size_t expectedSize) {
   m_definingInvariant.reserve(expectedSize);
   m_variablesDefinedByInvariant.reserve(expectedSize);
   m_listeningInvariants.reserve(expectedSize);
+  m_varsLastCommit.reserve(expectedSize);
 
   // Initialise nullID
   m_definingInvariant.push_back(InvariantId(NULL_ID));
   m_variablesDefinedByInvariant.push_back({});
   m_listeningInvariants.push_back({});
+  m_varsLastCommit.push_back(NULL_TIMESTAMP);
 }
 
 PropagationGraph::~PropagationGraph() {}
@@ -25,6 +27,10 @@ void PropagationGraph::notifyMaybeChanged([[maybe_unused]] const Timestamp& t,
     // m_intVars.at(id)->invalidate(t);
     // m_propGraph.notifyMaybeChanged(t, id);
   // }
+  if (m_varsLastCommit.at(id) == t) {
+    return;
+  }
+  m_varsLastCommit[id] = t;
   m_modifiedVariables.push(id);
 }
 
@@ -37,8 +43,10 @@ void PropagationGraph::registerInvariant(InvariantId id) {
 void PropagationGraph::registerVar(VarId id) {
   assert(id.id == m_listeningInvariants.size());
   assert(id.id == m_definingInvariant.size());
+  assert(id.id == m_varsLastCommit.size());
   m_listeningInvariants.push_back({});
   m_definingInvariant.push_back(InvariantId(NULL_ID));
+  m_varsLastCommit.push_back(NULL_TIMESTAMP);
 }
 
 void PropagationGraph::registerInvariantDependsOnVar(InvariantId dependee,


### PR DESCRIPTION
A vector in PropagationGraph keeps track of the last timestamp `maybeNotify` was called on a variable.

This idea should work, but I might have missed something :thinking: 