### PR TITLE
Recompute and commit moved to Engine

### DIFF
--- a/include/core/engine.hpp
+++ b/include/core/engine.hpp
@@ -58,20 +58,22 @@ class Engine {
     inline Invariant& getInvariant(InvariantId& i) {
       return *(m_invariants.at(i.id));
     }
-    inline void recomputeAndCommit(const Timestamp& t, Engine& e) {
-      for (auto invariantPtr : m_invariants) {
-        if (invariantPtr == nullptr) {
-          continue;
-        }
-        invariantPtr->recompute(t, e);
-        invariantPtr->commit(t, e);
-      }
-      for (size_t i = 1; i < m_intVars.size(); ++i) {
-        m_intVars[i].commit();
-      }
+    std::vector<IntVar>::iterator intVarBegin() {
+      return m_intVars.begin();
+    }
+    std::vector<IntVar>::iterator intVarEnd() {
+      return m_intVars.end();
+    }
+    std::vector<std::shared_ptr<Invariant>>::iterator invariantBegin() {
+      return m_invariants.begin();
+    }
+    std::vector<std::shared_ptr<Invariant>>::iterator invariantEnd() {
+      return m_invariants.end();
     }
   } m_store;
 
+
+  void recomputeAndCommit();
  public:
   Engine(/* args */);
 

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -16,12 +16,25 @@ void Engine::open() {
   m_isOpen = true;
 }
 
+void Engine::recomputeAndCommit() {
+  for (auto iter = m_store.invariantBegin(); iter != m_store.invariantEnd(); ++iter) {
+    if ((*iter) == nullptr) {
+      continue;
+    }
+    (*iter)->recompute(m_currentTime, *this);
+    (*iter)->commit(m_currentTime, *this);
+  }
+  for (auto iter = m_store.intVarBegin(); iter != m_store.intVarEnd(); ++iter) {
+    iter->commit();
+  }
+}
+
 void Engine::close() {
   m_isOpen = false;
   // TODO: topological sort of the propGraph
   
   // compute and initialise all variables and invariants
-  m_store.recomputeAndCommit(m_currentTime, *this);
+  recomputeAndCommit();
 }
 
 //---------------------Notificaion/Modification---------------------


### PR DESCRIPTION
Moved the functionality from store to engine.
Engine can now retrieve iterators from store (the code is a bit ugly... :disappointed: )