### PR TITLE
Fixed a bug in alldiff which used getNewValue instead of getValue.

### DIFF
--- a/src/constraints/allDifferent.cpp
+++ b/src/constraints/allDifferent.cpp
@@ -71,17 +71,7 @@ VarId AllDifferent::getNextDependency(Timestamp t, Engine&) {
 
 void AllDifferent::notifyCurrentDependencyChanged(Timestamp t, Engine& e) {
   auto index = static_cast<size_t>(m_state.getValue(t));
-  assert(index < m_variables.size());
-
-  VarId varId = m_variables.at(index);
-
-  Int oldValue = m_localValues.at(index).getValue(t);
-  Int newValue = e.getNewValue(varId);
-
-  signed char dec = decreaseCount(t, oldValue);
-  signed char inc = increaseCount(t, newValue);
-  m_localValues.at(index).setValue(t, newValue);
-  incValue(t, e, m_violationId, static_cast<Int>(dec + inc));
+  notifyIntChanged(t, e, index);
 }
 
 void AllDifferent::commit(Timestamp t, Engine& e) {

--- a/src/invariants/linear.cpp
+++ b/src/invariants/linear.cpp
@@ -36,7 +36,11 @@ void Linear::recompute(Timestamp t, Engine& e) {
 
 void Linear::notifyIntChanged(Timestamp t, Engine& e, LocalId i) {
   auto newValue = e.getValue(t, m_X[i]);
-  incValue(t, e, m_b, (newValue - m_localX.at(i).getValue(t)) * m_A[i]);
+  Int delta = newValue - m_localX.at(i).getValue(t);
+  if (delta == 0) {
+    return;
+  }
+  incValue(t, e, m_b, delta * m_A.at(i));
   m_localX.at(i).setValue(t, newValue);
 }
 
@@ -52,12 +56,7 @@ VarId Linear::getNextDependency(Timestamp t, Engine&) {
 void Linear::notifyCurrentDependencyChanged(Timestamp t, Engine& e) {
   assert(m_state.getValue(t) != -1);
   Int idx = m_state.getValue(t);
-  Int delta = e.getValue(t, m_X.at(idx)) - m_localX.at(idx).getValue(t);
-  if (delta == 0) {
-    return;
-  }
-  incValue(t, e, m_b, delta * m_A.at(idx));
-  m_localX.at(idx).setValue(t, e.getValue(t, m_X.at(idx)));
+  notifyIntChanged(t, e, idx);
 }
 
 void Linear::commit(Timestamp t, Engine& e) {

--- a/test/constraints/tAllDifferent.cpp
+++ b/test/constraints/tAllDifferent.cpp
@@ -8,8 +8,8 @@
 #include "core/propagationEngine.hpp"
 #include "core/savedInt.hpp"
 #include "core/types.hpp"
-#include "gtest/gtest.h"
 #include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using ::testing::AtLeast;
 using ::testing::Return;
@@ -27,43 +27,43 @@ class MockAllDifferent : public AllDifferent {
 
   MockAllDifferent(VarId violationId, std::vector<VarId>&& t_variables)
       : AllDifferent(violationId, std::vector<VarId>{t_variables}) {
-          ON_CALL(*this, recompute)
-              .WillByDefault([this](Timestamp timestamp, Engine& engine) {
-                return AllDifferent::recompute(timestamp, engine);
-              });
-          ON_CALL(*this, getNextDependency)
-              .WillByDefault([this](Timestamp t, Engine& engine) {
-                return AllDifferent::getNextDependency(t, engine);
-              });
+    ON_CALL(*this, recompute)
+        .WillByDefault([this](Timestamp timestamp, Engine& engine) {
+          return AllDifferent::recompute(timestamp, engine);
+        });
+    ON_CALL(*this, getNextDependency)
+        .WillByDefault([this](Timestamp t, Engine& engine) {
+          return AllDifferent::getNextDependency(t, engine);
+        });
 
-          ON_CALL(*this, notifyCurrentDependencyChanged)
-              .WillByDefault([this](Timestamp t, Engine& engine) {
-                AllDifferent::notifyCurrentDependencyChanged(t, engine);
-              });
+    ON_CALL(*this, notifyCurrentDependencyChanged)
+        .WillByDefault([this](Timestamp t, Engine& engine) {
+          AllDifferent::notifyCurrentDependencyChanged(t, engine);
+        });
 
-          ON_CALL(*this, notifyIntChanged)
-              .WillByDefault([this](Timestamp t, Engine& engine, LocalId id) {
-                AllDifferent::notifyIntChanged(t, engine, id);
-              });
+    ON_CALL(*this, notifyIntChanged)
+        .WillByDefault([this](Timestamp t, Engine& engine, LocalId id) {
+          AllDifferent::notifyIntChanged(t, engine, id);
+        });
 
-          ON_CALL(*this, commit).WillByDefault([this](Timestamp t, Engine& engine) {
-            AllDifferent::commit(t, engine);
-          });
+    ON_CALL(*this, commit).WillByDefault([this](Timestamp t, Engine& engine) {
+      AllDifferent::commit(t, engine);
+    });
   }
 
-MOCK_METHOD(void, recompute, (Timestamp timestamp, Engine& engine), (override));
+  MOCK_METHOD(void, recompute, (Timestamp timestamp, Engine& engine),
+              (override));
 
-MOCK_METHOD(VarId, getNextDependency, (Timestamp, Engine&), (override));
-MOCK_METHOD(void, notifyCurrentDependencyChanged, (Timestamp, Engine& engine),
-            (override));
+  MOCK_METHOD(VarId, getNextDependency, (Timestamp, Engine&), (override));
+  MOCK_METHOD(void, notifyCurrentDependencyChanged, (Timestamp, Engine& engine),
+              (override));
 
-MOCK_METHOD(void, notifyIntChanged, (Timestamp t, Engine& engine, LocalId id),
-            (override));
-MOCK_METHOD(void, commit, (Timestamp timestamp, Engine& engine), (override));
+  MOCK_METHOD(void, notifyIntChanged, (Timestamp t, Engine& engine, LocalId id),
+              (override));
+  MOCK_METHOD(void, commit, (Timestamp timestamp, Engine& engine), (override));
 
-private:
+ private:
 };
-
 
 class AllDifferentTest : public ::testing::Test {
  protected:
@@ -101,21 +101,23 @@ class AllDifferentTest : public ::testing::Test {
 
     VarId viol = engine->makeIntVar(0, 0, numArgs);
 
-    auto invariant = engine->makeInvariant<MockAllDifferent>(
-        viol, std::vector<VarId>{args});
+    auto invariant =
+        engine->makeInvariant<MockAllDifferent>(viol, std::vector<VarId>{args});
 
     EXPECT_TRUE(invariant->m_initialized);
-    
-    EXPECT_CALL(*invariant, recompute(testing::_, testing::_)).Times(AtLeast(1));
+
+    EXPECT_CALL(*invariant, recompute(testing::_, testing::_))
+        .Times(AtLeast(1));
 
     EXPECT_CALL(*invariant, commit(testing::_, testing::_)).Times(AtLeast(1));
 
     engine->mode = propMode;
 
     engine->close();
-    
+
     if (engine->mode == PropagationEngine::PropagationMode::TOP_DOWN) {
-      EXPECT_CALL(*invariant, getNextDependency(testing::_, testing::_)).Times(0);
+      EXPECT_CALL(*invariant, getNextDependency(testing::_, testing::_))
+          .Times(0);
       EXPECT_CALL(*invariant,
                   notifyCurrentDependencyChanged(testing::_, testing::_))
           .Times(0);
@@ -123,15 +125,11 @@ class AllDifferentTest : public ::testing::Test {
                   notifyIntChanged(testing::_, testing::_, testing::_))
           .Times(1);
     } else if (engine->mode == PropagationEngine::PropagationMode::BOTTOM_UP) {
-      EXPECT_CALL(*invariant,
-                  getNextDependency(testing::_, testing::_)).Times(numArgs + 1);
+      EXPECT_CALL(*invariant, getNextDependency(testing::_, testing::_))
+          .Times(numArgs + 1);
       EXPECT_CALL(*invariant,
                   notifyCurrentDependencyChanged(testing::_, testing::_))
           .Times(1);
-
-      EXPECT_CALL(*invariant,
-                  notifyIntChanged(testing::_, testing::_, testing::_))
-          .Times(0);
     } else if (engine->mode == PropagationEngine::PropagationMode::MIXED) {
       EXPECT_EQ(0, 1);  // TODO: define the test case for mixed mode.
     }
@@ -152,7 +150,8 @@ class AllDifferentTest : public ::testing::Test {
 
 TEST_F(AllDifferentTest, Init) {
   EXPECT_EQ(engine->getCommittedValue(violationId), 1);
-  EXPECT_EQ(engine->getValue(engine->getTmpTimestamp(violationId), violationId), 1);
+  EXPECT_EQ(engine->getValue(engine->getTmpTimestamp(violationId), violationId),
+            1);
 }
 
 TEST_F(AllDifferentTest, Recompute) {
@@ -258,11 +257,11 @@ TEST_F(AllDifferentTest, CreateAllDifferent) {
 
   VarId viol = engine->makeIntVar(0, 0, numArgs);
 
-  auto invariant = engine->makeInvariant<MockAllDifferent>(
-      viol, std::vector<VarId>{args});
+  auto invariant =
+      engine->makeInvariant<MockAllDifferent>(viol, std::vector<VarId>{args});
 
   EXPECT_TRUE(invariant->m_initialized);
-  
+
   EXPECT_CALL(*invariant, recompute(testing::_, testing::_)).Times(AtLeast(1));
 
   EXPECT_CALL(*invariant, commit(testing::_, testing::_)).Times(AtLeast(1));


### PR DESCRIPTION
Started moving to using notifyIntCanged in notifyCurrentDependencyChanged