### PR TITLE
Fix circular definition of max().

### DIFF
--- a/minizinc/lib/redefinitions-2.0.mzn
+++ b/minizinc/lib/redefinitions-2.0.mzn
@@ -1,0 +1,2 @@
+predicate array_int_maximum(var int: m, array[int] of var int: x);
+predicate array_int_minimum(var int: m, array[int] of var int: x);


### PR DESCRIPTION
For our solver we define `int_min` in terms of `array_int_minimum`. However, the standard definition of `array_int_minimum` is in terms of `int_min`. So, when compiling a mzn file with a `max` constraint, MiniZinc crashes and reports a stack overflow.

The fix is to indicate to MiniZinc we support `array_int_minimum` natively.