### PR TITLE
Disallow any constraints with 'var set' or 'float' variables.

### DIFF
--- a/minizinc/lib/redefinitions.mzn
+++ b/minizinc/lib/redefinitions.mzn
@@ -7,8 +7,6 @@ predicate int_lt(var int: a, var int: b) = int_lin_le([1, -1], [a, b], -1);
 predicate int_ne(var int: a, var int: b) = int_lin_ne([1, -1], [a, b], 0);
 predicate int_plus(var int: a, var int: b, var int: c) = int_lin_eq([1, 1, -1], [a, b, c], 0);
 
-% predicate set_in(var int: x, set of int: S) = abort("Set variables are unsupported");
-
 %%%%%%%%%%%%%%%%%%%%
 % Bool constraints %
 %%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
To make the solver a bit more robust, indicate we want to abort flattening for any float or set variable constraints.