### PR TITLE
allVariablesFree in the invariant graph builder was incorrect.

### DIFF
--- a/src/invariantgraph/invariantGraphBuilder.cpp
+++ b/src/invariantgraph/invariantGraphBuilder.cpp
@@ -262,6 +262,7 @@ invariantgraph::InvariantGraphBuilder::makeVariableDefiningNode(
   NODE_REGISTRATION(BoolEqNode);
   NODE_REGISTRATION(BoolLeNode);
   NODE_REGISTRATION(BoolLtNode);
+  NODE_REGISTRATION(BoolNotNode);
   NODE_REGISTRATION(BoolXorNode);
   NODE_REGISTRATION(IntAbsNode);
   NODE_REGISTRATION(IntEqNode);


### PR DESCRIPTION
This PR fixes that. It also reverts to selecting invariants before the implicit constraints. This is done since we want to go with Max's conclusion that it works well. This change won't affect the benchmarks I already did for the thesis.

In future, it can be checked if certain implicit constraints need to have priority over invariants.