### PR TITLE
Added symmetric references to the Invariant and VarView classes

### DIFF
--- a/benchmark/artificial/bElementLinearTree.cpp
+++ b/benchmark/artificial/bElementLinearTree.cpp
@@ -52,7 +52,7 @@ class ElementLinearTree : public benchmark::Fixture {
           decisionVars.push_back(var);
         }
       }
-      engine->makeInvariant<Linear>(cur.id, linearInputs);
+      engine->makeInvariant<Linear>(*engine, cur.id, linearInputs);
       linearInputs.clear();
     }
 #ifndef NDEBUG
@@ -107,8 +107,8 @@ class ElementLinearTree : public benchmark::Fixture {
                         << ", each non-leaf node having " << linearArgumentCount
                         << " children");
 
-    engine->makeInvariant<ElementVar>(elementOutputVar, elementIndexVar,
-                                      elementInputVars);
+    engine->makeInvariant<ElementVar>(*engine, elementOutputVar,
+                                      elementIndexVar, elementInputVars);
     engine->close();
     genDecisionVarIndex = std::mt19937(rd());
     genDecisionVarValue = std::mt19937(rd());
@@ -167,7 +167,7 @@ BENCHMARK_DEFINE_F(ElementLinearTree, probe_single_index_var)
       benchmark::Counter(probes, benchmark::Counter::kIsRate);
 }
 
-//*
+/*
 
 static void arguments(benchmark::internal::Benchmark* benchmark) {
   for (int treeCount = 2; treeCount <= 10; treeCount += 2) {

--- a/benchmark/artificial/bElementVarTree.cpp
+++ b/benchmark/artificial/bElementVarTree.cpp
@@ -55,7 +55,8 @@ class ElementVarTree : public benchmark::Fixture {
         }
       }
 
-      engine->makeInvariant<ElementVar>(cur.id, indexVar, elementInputs);
+      engine->makeInvariant<ElementVar>(*engine, cur.id, indexVar,
+                                        elementInputs);
       elementInputs.clear();
     }
   }
@@ -185,7 +186,7 @@ BENCHMARK_DEFINE_F(ElementVarTree, commit_all)(benchmark::State& st) {
   commit(std::ref(st), indexDecisionVars.size());
 }
 
-//*
+/*
 
 static void arguments(benchmark::internal::Benchmark* benchmark) {
   for (int treeHeight = 2; treeHeight <= 10; treeHeight += 2) {

--- a/benchmark/artificial/bFoldableBinaryTree.cpp
+++ b/benchmark/artificial/bFoldableBinaryTree.cpp
@@ -31,7 +31,8 @@ class FoldableBinaryTree : public benchmark::Fixture {
       vars.push_back(left);
       vars.push_back(right);
 
-      engine->makeInvariant<Linear>(prev, std::vector<VarId>{left, right});
+      engine->makeInvariant<Linear>(*engine, prev,
+                                    std::vector<VarId>{left, right});
       if (level == treeHeight - 1) {
         decisionVars.push_back(left);
       }
@@ -229,7 +230,7 @@ BENCHMARK_DEFINE_F(FoldableBinaryTree, commit_move_all)
 BENCHMARK_DEFINE_F(FoldableBinaryTree, commit_move_all_query_rnd)
 (benchmark::State& st) { commitRnd(std::ref(st), decisionVars.size()); }
 
-//*
+/*
 
 // -----------------------------------------
 // Probing

--- a/benchmark/artificial/bLinearAllDifferent.cpp
+++ b/benchmark/artificial/bLinearAllDifferent.cpp
@@ -52,12 +52,12 @@ class LinearAllDifferent : public benchmark::Fixture {
     for (size_t i = 0; i < varCount - 1; i += increment) {
       linearOutputVars.push_back(engine->makeIntVar(i, 0, 2 * (varCount - 1)));
       engine->makeInvariant<Linear>(
-          linearOutputVars.back(),
+          *engine.get(), linearOutputVars.back(),
           std::vector<VarId>{decisionVars.at(i), decisionVars.at(i + 1)});
     }
 
     violation = engine->makeIntVar(0, 0, varCount);
-    engine->makeConstraint<AllDifferent>(violation, linearOutputVars);
+    engine->makeConstraint<AllDifferent>(*engine, violation, linearOutputVars);
 
     engine->close();
 
@@ -146,7 +146,7 @@ BENCHMARK_DEFINE_F(LinearAllDifferent, commit_single_swap)
       benchmark::Counter(commits, benchmark::Counter::kIsRate);
 }
 
-//*
+/*
 
 static void arguments(benchmark::internal::Benchmark* benchmark) {
   for (int overlapping = 0; overlapping <= 1; ++overlapping) {

--- a/benchmark/artificial/bLinearTree.cpp
+++ b/benchmark/artificial/bLinearTree.cpp
@@ -52,7 +52,7 @@ class LinearTree : public benchmark::Fixture {
           decisionVars.push_back(var);
         }
       }
-      engine->makeInvariant<Linear>(cur.id, linearInputs);
+      engine->makeInvariant<Linear>(*engine, cur.id, linearInputs);
       linearInputs.clear();
     }
 #ifndef NDEBUG
@@ -248,7 +248,7 @@ BENCHMARK_DEFINE_F(LinearTree, commit_all_query_rnd)
 BENCHMARK_DEFINE_F(LinearTree, probe_all_query_rnd)
 (benchmark::State& st) { probeRnd(std::ref(st), decisionVars.size()); }
 
-//*
+/*
 
 static void arguments(benchmark::internal::Benchmark* benchmark) {
   for (int treeHeight = 2; treeHeight <= 12; treeHeight += 2) {

--- a/benchmark/bAllInterval.cpp
+++ b/benchmark/bAllInterval.cpp
@@ -40,12 +40,13 @@ class AllInterval : public benchmark::Fixture {
 
     for (int i = 1; i < n; ++i) {
       violationVars.push_back(engine->makeIntVar(i, 0, n - 1));
-      engine->makeInvariant<AbsDiff>(violationVars.back(), inputVars[i - 1],
-                                     inputVars[i]);
+      engine->makeInvariant<AbsDiff>(*engine, violationVars.back(),
+                                     inputVars[i - 1], inputVars[i]);
     }
 
     totalViolation = engine->makeIntVar(0, 0, n);
-    engine->makeConstraint<AllDifferent>(totalViolation, violationVars);
+    engine->makeConstraint<AllDifferent>(*engine, totalViolation,
+                                         violationVars);
 
     engine->close();
 
@@ -134,7 +135,7 @@ BENCHMARK_DEFINE_F(AllInterval, commit_single_swap)(benchmark::State& st) {
       commits, benchmark::Counter::kIsRate | benchmark::Counter::kInvert);
 }
 
-//*
+/*
 static void arguments(benchmark::internal::Benchmark* benchmark) {
   for (int n = 10; n <= 100; n += 10) {
     for (int mode = 0; mode <= 3; ++mode) {

--- a/benchmark/bCarSequencing.cpp
+++ b/benchmark/bCarSequencing.cpp
@@ -107,7 +107,7 @@ class CarSequencing : public benchmark::Fixture {
 
     std::vector<VarId> violations;
     engine->makeConstraint<AllDifferent>(
-        violations.emplace_back(engine->makeIntVar(0, 0, numCars - 1)),
+        *engine, violations.emplace_back(engine->makeIntVar(0, 0, numCars - 1)),
         sequence);
 
     for (size_t o = 0; o < numOptions; ++o) {
@@ -116,12 +116,12 @@ class CarSequencing : public benchmark::Fixture {
         std::vector<VarId> optionRun;
         for (Int car = start; car < start + blockSize.at(o) - 1; ++car) {
           optionRun.emplace_back(engine->makeIntView<ElementConst>(
-              sequence.at(car), carOption.at(o)));
+              *engine, sequence.at(car), carOption.at(o)));
         }
         VarId sum = engine->makeIntVar(0, 0, blockSize.at(o));
-        engine->makeInvariant<Linear>(sum, optionRun);
-        violations.emplace_back(
-            engine->makeIntView<LessEqualConst>(sum, maxCarsInBlock.at(o)));
+        engine->makeInvariant<Linear>(*engine, sum, optionRun);
+        violations.emplace_back(engine->makeIntView<LessEqualConst>(
+            *engine, sum, maxCarsInBlock.at(o)));
       }
     }
 
@@ -131,7 +131,7 @@ class CarSequencing : public benchmark::Fixture {
       maxViol += engine->upperBound(viol);
     }
     totalViolation = engine->makeIntVar(0, 0, maxViol);
-    engine->makeInvariant<Linear>(totalViolation, violations);
+    engine->makeInvariant<Linear>(*engine, totalViolation, violations);
 
     engine->close();
   }
@@ -183,7 +183,7 @@ BENCHMARK_DEFINE_F(CarSequencing, probe_all_swap)(benchmark::State& st) {
       benchmark::Counter(probes, benchmark::Counter::kIsRate);
 }
 
-//*
+/*
 
 static void arguments(benchmark::internal::Benchmark* benchmark) {
   for (int numCars = 20; numCars <= 150; numCars += 20) {

--- a/benchmark/bGolombRuler.cpp
+++ b/benchmark/bGolombRuler.cpp
@@ -70,7 +70,8 @@ class GolombRuler : public benchmark::Fixture {
         std::vector<VarId> vars{marks.at(j), marks.at(i)};
 
         engine->makeInvariant<Linear>(
-            differences.emplace_back(engine->makeIntVar(0, 0, ub)), coef, vars);
+            *engine, differences.emplace_back(engine->makeIntVar(0, 0, ub)),
+            coef, vars);
       }
     }
 
@@ -79,10 +80,10 @@ class GolombRuler : public benchmark::Fixture {
         engine->makeIntVar(0, 0, pairCount + 2 * ub + pairCount * ub);
     engine->makeConstraint<AllDifferent>(
         // violations.emplace_back(engine->makeIntVar(0, 0, pairCount - 1)),
-        totalViolation, differences);
+        *engine, totalViolation, differences);
 
     // Sum violations
-    // engine->makeInvariant<Linear>(totalViolation, violations);
+    // engine->makeInvariant<Linear>(*engine, totalViolation, violations);
 
     engine->close();
 
@@ -156,7 +157,7 @@ BENCHMARK_DEFINE_F(GolombRuler, probe_single)(benchmark::State& st) {
       benchmark::Counter(probes, benchmark::Counter::kIsRate);
 }
 
-//*
+/*
 
 static void arguments(benchmark::internal::Benchmark* benchmark) {
   for (int markCount = 6; markCount <= 20; markCount += 2) {

--- a/benchmark/bMagicSquare.cpp
+++ b/benchmark/bMagicSquare.cpp
@@ -66,8 +66,8 @@ class MagicSquare : public benchmark::Fixture {
       for (Int i = 0; i < n; ++i) {
         const VarId rowSum = engine->makeIntVar(0, 0, n2 * n);
         const VarId rowViol = engine->makeIntVar(0, 0, n2 * n);
-        engine->makeInvariant<Linear>(rowSum, ones, square[i]);
-        engine->makeConstraint<Equal>(rowViol, rowSum, magicSumVar);
+        engine->makeInvariant<Linear>(*engine, rowSum, ones, square[i]);
+        engine->makeConstraint<Equal>(*engine, rowViol, rowSum, magicSumVar);
         violations.push_back(rowViol);
       }
     }
@@ -84,8 +84,8 @@ class MagicSquare : public benchmark::Fixture {
           assert(square[j].size() == static_cast<size_t>(n));
           col.push_back(square[j][i]);
         }
-        engine->makeInvariant<Linear>(colSum, ones, col);
-        engine->makeConstraint<Equal>(colViol, colSum, magicSumVar);
+        engine->makeInvariant<Linear>(*engine, colSum, ones, col);
+        engine->makeConstraint<Equal>(*engine, colViol, colSum, magicSumVar);
         violations.push_back(colViol);
       }
     }
@@ -101,8 +101,9 @@ class MagicSquare : public benchmark::Fixture {
         assert(square[j].size() == static_cast<size_t>(n));
         diag.push_back(square[j][j]);
       }
-      engine->makeInvariant<Linear>(downDiagSum, ones, diag);
-      engine->makeConstraint<Equal>(downDiagViol, downDiagSum, magicSumVar);
+      engine->makeInvariant<Linear>(*engine, downDiagSum, ones, diag);
+      engine->makeConstraint<Equal>(*engine, downDiagViol, downDiagSum,
+                                    magicSumVar);
       violations.push_back(downDiagViol);
     }
 
@@ -117,15 +118,16 @@ class MagicSquare : public benchmark::Fixture {
         assert(square[n - j - 1].size() == static_cast<size_t>(n));
         diag.push_back(square[n - j - 1][j]);
       }
-      engine->makeInvariant<Linear>(upDiagSum, ones, diag);
-      engine->makeConstraint<Equal>(upDiagViol, upDiagSum, magicSumVar);
+      engine->makeInvariant<Linear>(*engine, upDiagSum, ones, diag);
+      engine->makeConstraint<Equal>(*engine, upDiagViol, upDiagSum,
+                                    magicSumVar);
       violations.push_back(upDiagViol);
     }
 
     std::vector<Int> ones{};
     ones.assign(violations.size(), 1);
     totalViolation = engine->makeIntVar(0, 0, n2 * n2 * 2 + 2 * n2);
-    engine->makeInvariant<Linear>(totalViolation, ones, violations);
+    engine->makeInvariant<Linear>(*engine, totalViolation, ones, violations);
     engine->close();
   }
 
@@ -179,7 +181,7 @@ BENCHMARK_DEFINE_F(MagicSquare, probe_all_swap)(benchmark::State& st) {
       benchmark::Counter(probes, benchmark::Counter::kIsRate);
 }
 
-//*
+/*
 static void arguments(benchmark::internal::Benchmark* benchmark) {
   for (int n = 4; n <= 16; n += 2) {
     for (int mode = 0; mode <= 3; ++mode) {

--- a/benchmark/bNQueens.cpp
+++ b/benchmark/bNQueens.cpp
@@ -42,22 +42,24 @@ class Queens : public benchmark::Fixture {
     for (Int i = 0; i < n; ++i) {
       const VarId q = engine->makeIntVar(i, 0, n - 1);
       queens.push_back(q);
-      q_offset_minus.push_back(engine->makeIntView<IntOffsetView>(q, -i));
-      q_offset_plus.push_back(engine->makeIntView<IntOffsetView>(q, i));
+      q_offset_minus.push_back(
+          engine->makeIntView<IntOffsetView>(*engine, q, -i));
+      q_offset_plus.push_back(
+          engine->makeIntView<IntOffsetView>(*engine, q, i));
     }
 
     violation1 = engine->makeIntVar(0, 0, n);
     violation2 = engine->makeIntVar(0, 0, n);
     violation3 = engine->makeIntVar(0, 0, n);
 
-    engine->makeConstraint<AllDifferent>(violation1, queens);
-    engine->makeConstraint<AllDifferent>(violation2, q_offset_minus);
-    engine->makeConstraint<AllDifferent>(violation3, q_offset_plus);
+    engine->makeConstraint<AllDifferent>(*engine, violation1, queens);
+    engine->makeConstraint<AllDifferent>(*engine, violation2, q_offset_minus);
+    engine->makeConstraint<AllDifferent>(*engine, violation3, q_offset_plus);
 
     totalViolation = engine->makeIntVar(0, 0, 3 * n);
 
     engine->makeInvariant<Linear>(
-        totalViolation, std::vector<Int>{1, 1, 1},
+        *engine, totalViolation, std::vector<Int>{1, 1, 1},
         std::vector<VarId>{violation1, violation2, violation3});
 
     engine->close();
@@ -196,7 +198,7 @@ BENCHMARK_DEFINE_F(Queens, solve)(benchmark::State& st) {
   logDebug(instanceToString());
 }
 
-//*
+/*
 static void arguments(benchmark::internal::Benchmark* benchmark) {
   for (int n = 16; n <= 1024; n *= 2) {
     for (int mode = 0; mode <= 3; ++mode) {

--- a/benchmark/bTSPTW.cpp
+++ b/benchmark/bTSPTW.cpp
@@ -64,30 +64,34 @@ class TSPTW : public benchmark::Fixture {
     // Ignore index 0
     for (int i = 1; i < n; ++i) {
       // timeToPrev[i] = dist[i][pred[i]]
-      timeToPrev[i] = engine->makeIntView<ElementConst>(pred[i], dist[i]);
+      timeToPrev[i] =
+          engine->makeIntView<ElementConst>(*engine, pred[i], dist[i]);
       // arrivalPrev[i] = arrivalTime[pred[i]]
     }
 
     // Ignore index 0
     for (int i = 1; i < n; ++i) {
       // arrivalPrev[i] = arrivalTime[pred[i]]
-      engine->makeInvariant<ElementVar>(arrivalPrev[i], pred[i], arrivalTime);
+      engine->makeInvariant<ElementVar>(*engine, arrivalPrev[i], pred[i],
+                                        arrivalTime);
       // arrivalTime[i] = arrivalPrev[i] + timeToPrev[i]
       engine->makeInvariant<Linear>(
-          arrivalTime[i], std::vector<VarId>({arrivalPrev[i], timeToPrev[i]}));
+          *engine, arrivalTime[i],
+          std::vector<VarId>({arrivalPrev[i], timeToPrev[i]}));
     }
 
     // totalDist = sum(timeToPrev)
     totalDist = engine->makeIntVar(0, 0, MAX_TIME);
-    engine->makeInvariant<Linear>(totalDist, timeToPrev);
+    engine->makeInvariant<Linear>(*engine, totalDist, timeToPrev);
 
     VarId leqConst = engine->makeIntVar(100, 100, 100);
     for (int i = 0; i < n; ++i) {
-      engine->makeConstraint<LessEqual>(violation[i], arrivalTime[i], leqConst);
+      engine->makeConstraint<LessEqual>(*engine, violation[i], arrivalTime[i],
+                                        leqConst);
     }
 
     totalViolation = engine->makeIntVar(0, 0, MAX_TIME * n);
-    engine->makeInvariant<Linear>(totalViolation, violation);
+    engine->makeInvariant<Linear>(*engine, totalViolation, violation);
 
     engine->close();
     assert(std::all_of(pred.begin(), pred.end(), [&](const VarId p) {

--- a/include/constraints/allDifferent.hpp
+++ b/include/constraints/allDifferent.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <cassert>
+#include <limits>
 #include <vector>
 
 #include "constraint.hpp"
 #include "core/types.hpp"
+#include "variables/committableInt.hpp"
 #include "variables/intVar.hpp"
 
 class CommittableInt;  // forward declare
@@ -20,16 +22,17 @@ class AllDifferent : public Constraint {
   signed char decreaseCount(Timestamp ts, Int value);
 
  public:
-  explicit AllDifferent(VarId violationId, std::vector<VarId> variables);
+  explicit AllDifferent(Engine&, VarId violationId,
+                        std::vector<VarId> variables);
 
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void close(Timestamp, Engine&) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  void commit(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void close(Timestamp) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
 };
 
 inline signed char AllDifferent::increaseCount(Timestamp ts, Int value) {

--- a/include/constraints/allDifferentExcept.hpp
+++ b/include/constraints/allDifferentExcept.hpp
@@ -7,6 +7,7 @@
 #include "constraint.hpp"
 #include "constraints/allDifferent.hpp"
 #include "core/types.hpp"
+#include "variables/committableInt.hpp"
 #include "variables/intVar.hpp"
 
 class CommittableInt;  // forward declare
@@ -20,11 +21,12 @@ class AllDifferentExcept : public AllDifferent {
   bool isIgnored(Int) const;
 
  public:
-  explicit AllDifferentExcept(VarId violationId, std::vector<VarId> variables,
+  explicit AllDifferentExcept(Engine&, VarId violationId,
+                              std::vector<VarId> variables,
                               const std::vector<Int>& ignored);
 
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
 };
 
 inline bool AllDifferentExcept::isIgnored(const Int val) const {

--- a/include/constraints/boolEqual.hpp
+++ b/include/constraints/boolEqual.hpp
@@ -11,13 +11,13 @@ class BoolEqual : public Constraint {
   const VarId _x, _y;
 
  public:
-  explicit BoolEqual(VarId violationId, VarId x, VarId y);
+  explicit BoolEqual(Engine&, VarId violationId, VarId x, VarId y);
 
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  void commit(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
 };

--- a/include/constraints/boolLessEqual.hpp
+++ b/include/constraints/boolLessEqual.hpp
@@ -11,13 +11,13 @@ class BoolLessEqual : public Constraint {
   const VarId _x, _y;
 
  public:
-  explicit BoolLessEqual(VarId violationId, VarId x, VarId y);
+  explicit BoolLessEqual(Engine&, VarId violationId, VarId x, VarId y);
 
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  void commit(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
 };

--- a/include/constraints/boolLessThan.hpp
+++ b/include/constraints/boolLessThan.hpp
@@ -11,13 +11,13 @@ class BoolLessThan : public Constraint {
   const VarId _x, _y;
 
  public:
-  explicit BoolLessThan(VarId violationId, VarId x, VarId y);
+  explicit BoolLessThan(Engine&, VarId violationId, VarId x, VarId y);
 
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  void commit(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
 };

--- a/include/constraints/constraint.hpp
+++ b/include/constraints/constraint.hpp
@@ -9,10 +9,10 @@ class Constraint : public Invariant {
  private:
  protected:
   const VarId _violationId;
-  explicit Constraint(VarId violationId, Int nullState = -1)
-      : Invariant(nullState), _violationId(violationId) {}
+  explicit Constraint(Engine& engine, VarId violationId, Int nullState = -1)
+      : Invariant(engine, nullState), _violationId(violationId) {}
 
  public:
   [[nodiscard]] inline VarId violationId() const;
-  [[nodiscard]] inline Int violationCount(Engine&, Timestamp&) const;
+  [[nodiscard]] inline Int violationCount(Timestamp&) const;
 };

--- a/include/constraints/equal.hpp
+++ b/include/constraints/equal.hpp
@@ -11,13 +11,13 @@ class Equal : public Constraint {
   const VarId _x, _y;
 
  public:
-  explicit Equal(VarId violationId, VarId x, VarId y);
+  explicit Equal(Engine&, VarId violationId, VarId x, VarId y);
 
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  void commit(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
 };

--- a/include/constraints/globalCardinalityClosed.hpp
+++ b/include/constraints/globalCardinalityClosed.hpp
@@ -6,6 +6,7 @@
 
 #include "constraint.hpp"
 #include "core/types.hpp"
+#include "variables/committableInt.hpp"
 #include "variables/intVar.hpp"
 
 class CommittableInt;  // forward declare
@@ -22,20 +23,21 @@ class GlobalCardinalityClosed : public Constraint {
   Int _offset;
   Int increaseCount(Timestamp ts, Int value);
   Int decreaseCount(Timestamp ts, Int value);
-  void updateOutput(Timestamp ts, Engine& engine, Int value);
+  void updateOutput(Timestamp ts, Int value);
 
  public:
-  GlobalCardinalityClosed(VarId violationId, std::vector<VarId> outputs,
-                          std::vector<VarId> inputs, std::vector<Int> cover);
+  GlobalCardinalityClosed(Engine&, VarId violationId,
+                          std::vector<VarId> outputs, std::vector<VarId> inputs,
+                          std::vector<Int> cover);
 
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void close(Timestamp, Engine&) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp t, Engine& e, LocalId id) override;
-  void commit(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine& e) override;
-  void notifyCurrentInputChanged(Timestamp, Engine& e) override;
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void close(Timestamp) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
 };
 
 inline Int GlobalCardinalityClosed::increaseCount(Timestamp ts, Int value) {
@@ -58,12 +60,11 @@ inline Int GlobalCardinalityClosed::decreaseCount(Timestamp ts, Int value) {
   return 1;
 }
 
-inline void GlobalCardinalityClosed::updateOutput(Timestamp ts, Engine& engine,
-                                                  Int value) {
+inline void GlobalCardinalityClosed::updateOutput(Timestamp ts, Int value) {
   if (0 <= value - _offset &&
       value - _offset < static_cast<Int>(_coverVarIndex.size()) &&
       _coverVarIndex[value - _offset] >= 0) {
-    updateValue(ts, engine, _outputs[_coverVarIndex[value - _offset]],
+    updateValue(ts, _outputs[_coverVarIndex[value - _offset]],
                 _counts[_coverVarIndex[value - _offset]].value(ts));
   }
 }

--- a/include/constraints/globalCardinalityConst.hpp
+++ b/include/constraints/globalCardinalityConst.hpp
@@ -6,6 +6,7 @@
 
 #include "constraint.hpp"
 #include "core/types.hpp"
+#include "variables/committableInt.hpp"
 #include "variables/intVar.hpp"
 
 class CommittableInt;  // forward declare
@@ -26,22 +27,24 @@ class GlobalCardinalityConst : public Constraint {
   signed char decreaseCount(Timestamp ts, Int value);
 
  public:
-  GlobalCardinalityConst(VarId violationId, std::vector<VarId> variables,
+  GlobalCardinalityConst(Engine&, VarId violationId,
+                         std::vector<VarId> variables,
                          const std::vector<Int>& cover,
                          const std::vector<Int>& counts);
-  GlobalCardinalityConst(VarId violationId, std::vector<VarId> variables,
+  GlobalCardinalityConst(Engine&, VarId violationId,
+                         std::vector<VarId> variables,
                          const std::vector<Int>& cover,
                          const std::vector<Int>& lowerBound,
                          const std::vector<Int>& upperBound);
 
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void close(Timestamp, Engine&) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp t, Engine& e, LocalId id) override;
-  void commit(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine& e) override;
-  void notifyCurrentInputChanged(Timestamp, Engine& e) override;
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void close(Timestamp) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
 };
 
 template <bool IsClosed>

--- a/include/constraints/lessEqual.hpp
+++ b/include/constraints/lessEqual.hpp
@@ -11,13 +11,13 @@ class LessEqual : public Constraint {
   const VarId _x, _y;
 
  public:
-  explicit LessEqual(VarId violationId, VarId x, VarId y);
+  explicit LessEqual(Engine&, VarId violationId, VarId x, VarId y);
 
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  void commit(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
 };

--- a/include/constraints/lessThan.hpp
+++ b/include/constraints/lessThan.hpp
@@ -11,13 +11,13 @@ class LessThan : public Constraint {
   const VarId _x, _y;
 
  public:
-  explicit LessThan(VarId violationId, VarId x, VarId y);
+  explicit LessThan(Engine&, VarId violationId, VarId x, VarId y);
 
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  void commit(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
 };

--- a/include/constraints/notEqual.hpp
+++ b/include/constraints/notEqual.hpp
@@ -13,13 +13,13 @@ class NotEqual : public Constraint {
   const VarId _x, _y;
 
  public:
-  explicit NotEqual(VarId violationId, VarId x, VarId y);
+  explicit NotEqual(Engine&, VarId violationId, VarId x, VarId y);
 
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  void commit(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
 };

--- a/include/constraints/powDomain.hpp
+++ b/include/constraints/powDomain.hpp
@@ -11,15 +11,15 @@ class PowDomain : public Constraint {
   const VarId _x, _y;
 
  public:
-  explicit PowDomain(VarId violationId, VarId x, VarId y);
+  explicit PowDomain(Engine&, VarId violationId, VarId x, VarId y);
 
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  void commit(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
 
   static bool shouldPost(Engine&, VarId x, VarId y);
 };

--- a/include/core/engine.hpp
+++ b/include/core/engine.hpp
@@ -201,8 +201,8 @@ Engine::makeInvariant(Args&&... args) {
 
   logDebug("Created new invariant with id: " << invariantId);
   T& invariant = static_cast<T&>(_store.invariant(invariantId));
-  invariant.registerVars(*this);
-  invariant.updateBounds(*this, false);
+  invariant.registerVars();
+  invariant.updateBounds(false);
   return invariant;
 }
 
@@ -216,7 +216,7 @@ std::enable_if_t<std::is_base_of<IntView, T>::value, VarId> Engine::makeIntView(
 
   const VarId viewId = _store.createIntViewFromPtr(
       std::make_unique<T>(std::forward<Args>(args)...));
-  _store.intView(viewId).init(viewId, *this);
+  _store.intView(viewId).init(viewId);
   return viewId;
 }
 
@@ -231,8 +231,8 @@ Engine::makeConstraint(Args&&... args) {
   T& constraint = static_cast<T&>(_store.invariant(constraintId));
   registerInvariant(constraintId);  // A constraint is a type of invariant.
   logDebug("Created new Constraint with id: " << constraintId);
-  constraint.registerVars(*this);
-  constraint.updateBounds(*this);
+  constraint.registerVars();
+  constraint.updateBounds();
   return constraint;
 }
 
@@ -271,11 +271,11 @@ inline bool Engine::isPostponed(InvariantId invariantId) const {
 }
 
 inline void Engine::recompute(InvariantId invariantId) {
-  return _store.invariant(invariantId).recompute(_currentTimestamp, *this);
+  return _store.invariant(invariantId).recompute(_currentTimestamp);
 }
 
 inline void Engine::recompute(Timestamp ts, InvariantId invariantId) {
-  return _store.invariant(invariantId).recompute(ts, *this);
+  return _store.invariant(invariantId).recompute(ts);
 }
 
 inline void Engine::updateValue(Timestamp ts, VarId id, Int val) {
@@ -297,9 +297,9 @@ inline void Engine::commitValue(VarId id, Int val) {
 }
 
 inline void Engine::commitInvariantIf(Timestamp ts, InvariantId invariantId) {
-  _store.invariant(invariantId).commit(ts, *this);
+  _store.invariant(invariantId).commit(ts);
 }
 
 inline void Engine::commitInvariant(InvariantId invariantId) {
-  _store.invariant(invariantId).commit(_currentTimestamp, *this);
+  _store.invariant(invariantId).commit(_currentTimestamp);
 }

--- a/include/core/propagationEngine.hpp
+++ b/include/core/propagationEngine.hpp
@@ -174,13 +174,11 @@ inline const std::vector<InvariantId>& PropagationEngine::listeningInvariants(
 }
 
 inline VarId PropagationEngine::nextInput(InvariantId invariantId) {
-  return sourceId(
-      _store.invariant(invariantId).nextInput(_currentTimestamp, *this));
+  return sourceId(_store.invariant(invariantId).nextInput(_currentTimestamp));
 }
 inline void PropagationEngine::notifyCurrentInputChanged(
     InvariantId invariantId) {
-  _store.invariant(invariantId)
-      .notifyCurrentInputChanged(_currentTimestamp, *this);
+  _store.invariant(invariantId).notifyCurrentInputChanged(_currentTimestamp);
 }
 
 inline bool PropagationEngine::hasChanged(Timestamp ts, VarId id) const {

--- a/include/invariants/absDiff.hpp
+++ b/include/invariants/absDiff.hpp
@@ -17,13 +17,13 @@ class AbsDiff : public Invariant {
   const VarId _output, _x, _y;
 
  public:
-  explicit AbsDiff(VarId output, VarId x, VarId y);
+  explicit AbsDiff(Engine&, VarId output, VarId x, VarId y);
 
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  void commit(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
 };

--- a/include/invariants/binaryMax.hpp
+++ b/include/invariants/binaryMax.hpp
@@ -13,12 +13,12 @@ class BinaryMax : public Invariant {
   const VarId _output, _x, _y;
 
  public:
-  explicit BinaryMax(VarId output, VarId x, VarId y);
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
-  void commit(Timestamp, Engine&) override;
+  explicit BinaryMax(Engine& engine, VarId output, VarId x, VarId y);
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
+  void commit(Timestamp) override;
 };

--- a/include/invariants/binaryMin.hpp
+++ b/include/invariants/binaryMin.hpp
@@ -13,12 +13,12 @@ class BinaryMin : public Invariant {
   const VarId _output, _x, _y;
 
  public:
-  explicit BinaryMin(VarId output, VarId x, VarId y);
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
-  void commit(Timestamp, Engine&) override;
+  explicit BinaryMin(Engine&, VarId output, VarId x, VarId y);
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
+  void commit(Timestamp) override;
 };

--- a/include/invariants/boolAnd.hpp
+++ b/include/invariants/boolAnd.hpp
@@ -15,12 +15,12 @@ class BoolAnd : public Invariant {
   const VarId _output, _x, _y;
 
  public:
-  explicit BoolAnd(VarId output, VarId x, VarId y);
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  void commit(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
+  explicit BoolAnd(Engine&, VarId output, VarId x, VarId y);
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
 };

--- a/include/invariants/boolLinear.hpp
+++ b/include/invariants/boolLinear.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <utility>
 #include <vector>
 
 #include "core/types.hpp"
@@ -21,16 +22,17 @@ class BoolLinear : public Invariant {
   std::vector<CommittableInt> _isSatisfied;
 
  public:
-  explicit BoolLinear(VarId output, const std::vector<VarId>& violArray);
-  explicit BoolLinear(VarId output, std::vector<Int> coeffs,
+  explicit BoolLinear(Engine&, VarId output,
+                      const std::vector<VarId>& violArray);
+  explicit BoolLinear(Engine&, VarId output, std::vector<Int> coeffs,
                       std::vector<VarId> violArray);
 
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void close(Timestamp, Engine&) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  void commit(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void close(Timestamp) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
 };

--- a/include/invariants/boolOr.hpp
+++ b/include/invariants/boolOr.hpp
@@ -15,13 +15,13 @@ class BoolOr : public Invariant {
   const VarId _output, _x, _y;
 
  public:
-  explicit BoolOr(VarId output, VarId x, VarId y);
+  explicit BoolOr(Engine&, VarId output, VarId x, VarId y);
 
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  void commit(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
 };

--- a/include/invariants/boolXor.hpp
+++ b/include/invariants/boolXor.hpp
@@ -18,12 +18,12 @@ class BoolXor : public Invariant {
   const VarId _output, _x, _y;
 
  public:
-  explicit BoolXor(VarId output, VarId x, VarId y);
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  void commit(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
+  explicit BoolXor(Engine&, VarId output, VarId x, VarId y);
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
 };

--- a/include/invariants/count.hpp
+++ b/include/invariants/count.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <limits>
+#include <utility>
 #include <vector>
 
 #include "constraints/constraint.hpp"
@@ -26,15 +27,15 @@ class Count : public Invariant {
   signed char count(Timestamp ts, Int value);
 
  public:
-  explicit Count(VarId output, VarId y, std::vector<VarId> varArray);
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void close(Timestamp, Engine&) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  void commit(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
+  explicit Count(Engine&, VarId output, VarId y, std::vector<VarId> varArray);
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void close(Timestamp) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
 };
 
 inline void Count::increaseCount(Timestamp ts, Int value) {

--- a/include/invariants/countConst.hpp
+++ b/include/invariants/countConst.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <utility>
 #include <vector>
 
 #include "core/types.hpp"
@@ -21,14 +22,15 @@ class CountConst : public Invariant {
   std::vector<CommittableInt> _hasCountValue;
 
  public:
-  explicit CountConst(VarId output, Int y, std::vector<VarId> variables);
+  explicit CountConst(Engine&, VarId output, Int y,
+                      std::vector<VarId> variables);
 
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void close(Timestamp, Engine&) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  void commit(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void close(Timestamp) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
 };

--- a/include/invariants/element2dConst.hpp
+++ b/include/invariants/element2dConst.hpp
@@ -37,14 +37,14 @@ class Element2dConst : public Invariant {
   }
 
  public:
-  explicit Element2dConst(VarId output, VarId index1, VarId index2,
+  explicit Element2dConst(Engine&, VarId output, VarId index1, VarId index2,
                           std::vector<std::vector<Int>> matrix, Int offset1 = 1,
                           Int offset2 = 1);
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  void commit(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
 };

--- a/include/invariants/element2dVar.hpp
+++ b/include/invariants/element2dVar.hpp
@@ -37,14 +37,14 @@ class Element2dVar : public Invariant {
   }
 
  public:
-  explicit Element2dVar(VarId output, VarId index1, VarId index2,
+  explicit Element2dVar(Engine&, VarId output, VarId index1, VarId index2,
                         std::vector<std::vector<VarId>> varMatrix,
                         Int offset1 = 1, Int offset2 = 1);
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  void commit(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
 };

--- a/include/invariants/elementVar.hpp
+++ b/include/invariants/elementVar.hpp
@@ -27,13 +27,13 @@ class ElementVar : public Invariant {
   }
 
  public:
-  explicit ElementVar(VarId output, VarId index, std::vector<VarId> varArray,
-                      Int offset = 1);
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  void commit(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
+  explicit ElementVar(Engine&, VarId output, VarId index,
+                      std::vector<VarId> varArray, Int offset = 1);
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
 };

--- a/include/invariants/exists.hpp
+++ b/include/invariants/exists.hpp
@@ -22,12 +22,12 @@ class Exists : public Invariant {
   PriorityList _localPriority;
 
  public:
-  explicit Exists(VarId output, std::vector<VarId> varArray);
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  void commit(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
+  explicit Exists(Engine&, VarId output, std::vector<VarId> varArray);
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
 };

--- a/include/invariants/forAll.hpp
+++ b/include/invariants/forAll.hpp
@@ -21,13 +21,13 @@ class ForAll : public Invariant {
   PriorityList _localPriority;
 
  public:
-  explicit ForAll(VarId output, std::vector<VarId> varArray);
+  explicit ForAll(Engine&, VarId output, std::vector<VarId> varArray);
 
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  void commit(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
 };

--- a/include/invariants/globalCardinalityOpen.hpp
+++ b/include/invariants/globalCardinalityOpen.hpp
@@ -6,6 +6,7 @@
 
 #include "core/types.hpp"
 #include "invariant.hpp"
+#include "variables/committableInt.hpp"
 #include "variables/intVar.hpp"
 
 class CommittableInt;  // forward declare
@@ -21,21 +22,21 @@ class GlobalCardinalityOpen : public Invariant {
   std::vector<CommittableInt> _counts;
   Int _offset;
   void increaseCount(Timestamp ts, Int value);
-  void decreaseCountAndUpdateOutput(Timestamp ts, Engine& engine, Int value);
-  void increaseCountAndUpdateOutput(Timestamp ts, Engine& engine, Int value);
+  void decreaseCountAndUpdateOutput(Timestamp ts, Int value);
+  void increaseCountAndUpdateOutput(Timestamp ts, Int value);
 
  public:
-  GlobalCardinalityOpen(std::vector<VarId> outputs, std::vector<VarId> inputs,
-                        std::vector<Int> cover);
+  GlobalCardinalityOpen(Engine&, std::vector<VarId> outputs,
+                        std::vector<VarId> inputs, std::vector<Int> cover);
 
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void close(Timestamp, Engine&) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp t, Engine& e, LocalId id) override;
-  void commit(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine& e) override;
-  void notifyCurrentInputChanged(Timestamp, Engine& e) override;
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void close(Timestamp) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
 };
 
 inline void GlobalCardinalityOpen::increaseCount(Timestamp ts, Int value) {
@@ -47,23 +48,21 @@ inline void GlobalCardinalityOpen::increaseCount(Timestamp ts, Int value) {
 }
 
 inline void GlobalCardinalityOpen::decreaseCountAndUpdateOutput(Timestamp ts,
-                                                                Engine& engine,
                                                                 Int value) {
   if (0 <= value - _offset &&
       value - _offset < static_cast<Int>(_coverVarIndex.size()) &&
       _coverVarIndex[value - _offset] >= 0) {
-    updateValue(ts, engine, _outputs[_coverVarIndex[value - _offset]],
+    updateValue(ts, _outputs[_coverVarIndex[value - _offset]],
                 _counts[_coverVarIndex[value - _offset]].incValue(ts, -1));
   }
 }
 
 inline void GlobalCardinalityOpen::increaseCountAndUpdateOutput(Timestamp ts,
-                                                                Engine& engine,
                                                                 Int value) {
   if (0 <= value - _offset &&
       value - _offset < static_cast<Int>(_coverVarIndex.size()) &&
       _coverVarIndex[value - _offset] >= 0) {
-    updateValue(ts, engine, _outputs[_coverVarIndex[value - _offset]],
+    updateValue(ts, _outputs[_coverVarIndex[value - _offset]],
                 _counts[_coverVarIndex[value - _offset]].incValue(ts, 1));
   }
 }

--- a/include/invariants/ifThenElse.hpp
+++ b/include/invariants/ifThenElse.hpp
@@ -17,13 +17,13 @@ class IfThenElse : public Invariant {
   const std::array<const VarId, 2> _xy;
 
  public:
-  explicit IfThenElse(VarId output, VarId b, VarId x, VarId y);
+  explicit IfThenElse(Engine&, VarId output, VarId b, VarId x, VarId y);
 
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  void commit(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
 };

--- a/include/invariants/intDiv.hpp
+++ b/include/invariants/intDiv.hpp
@@ -21,13 +21,13 @@ class IntDiv : public Invariant {
   Int _zeroReplacement{1};
 
  public:
-  explicit IntDiv(VarId output, VarId x, VarId y);
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void close(Timestamp, Engine&) override;
-  void recompute(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  void commit(Timestamp, Engine&) override;
+  explicit IntDiv(Engine&, VarId output, VarId x, VarId y);
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void close(Timestamp) override;
+  void recompute(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
 };

--- a/include/invariants/linear.hpp
+++ b/include/invariants/linear.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <utility>
 #include <vector>
 
 #include "core/types.hpp"
@@ -20,16 +21,16 @@ class Linear : public Invariant {
   std::vector<CommittableInt> _localVarArray;
 
  public:
-  explicit Linear(VarId output, const std::vector<VarId>& varArray);
-  explicit Linear(VarId output, std::vector<Int> coeffs,
+  explicit Linear(Engine&, VarId output, const std::vector<VarId>& varArray);
+  explicit Linear(Engine&, VarId output, std::vector<Int> coeffs,
                   std::vector<VarId> varArray);
 
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void close(Timestamp, Engine&) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  void commit(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void close(Timestamp) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
 };

--- a/include/invariants/maxSparse.hpp
+++ b/include/invariants/maxSparse.hpp
@@ -21,13 +21,13 @@ class MaxSparse : public Invariant {
   PriorityList _localPriority;
 
  public:
-  explicit MaxSparse(VarId output, std::vector<VarId> varArray);
+  explicit MaxSparse(Engine&, VarId output, std::vector<VarId> varArray);
 
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  void commit(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
 };

--- a/include/invariants/minSparse.hpp
+++ b/include/invariants/minSparse.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <limits>
+#include <utility>
 #include <vector>
 
 #include "core/engine.hpp"
@@ -21,13 +22,13 @@ class MinSparse : public Invariant {
   PriorityList _localPriority;
 
  public:
-  explicit MinSparse(VarId output, std::vector<VarId> varArray);
+  explicit MinSparse(Engine&, VarId output, std::vector<VarId> varArray);
 
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  void commit(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
 };

--- a/include/invariants/mod.hpp
+++ b/include/invariants/mod.hpp
@@ -14,13 +14,13 @@ class Mod : public Invariant {
   Int _zeroReplacement{1};
 
  public:
-  explicit Mod(VarId output, VarId x, VarId y);
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void close(Timestamp, Engine&) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
-  void commit(Timestamp, Engine&) override;
+  explicit Mod(Engine&, VarId output, VarId x, VarId y);
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void close(Timestamp) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
+  void commit(Timestamp) override;
 };

--- a/include/invariants/plus.hpp
+++ b/include/invariants/plus.hpp
@@ -13,12 +13,12 @@ class Plus : public Invariant {
   const VarId _output, _x, _y;
 
  public:
-  explicit Plus(VarId output, VarId x, VarId y);
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void recompute(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
-  void commit(Timestamp, Engine&) override;
+  explicit Plus(Engine&, VarId output, VarId x, VarId y);
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
+  void commit(Timestamp) override;
 };

--- a/include/invariants/pow.hpp
+++ b/include/invariants/pow.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cmath>
 #include <vector>
 
 #include "core/types.hpp"
@@ -18,12 +19,12 @@ class Pow : public Invariant {
   Int _zeroReplacement{1};
 
  public:
-  explicit Pow(VarId output, VarId x, VarId y);
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void recompute(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  void commit(Timestamp, Engine&) override;
+  explicit Pow(Engine&, VarId output, VarId x, VarId y);
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void recompute(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
 };

--- a/include/invariants/times.hpp
+++ b/include/invariants/times.hpp
@@ -18,12 +18,12 @@ class Times : public Invariant {
   const VarId _output, _x, _y;
 
  public:
-  explicit Times(VarId output, VarId x, VarId y);
-  void registerVars(Engine&) override;
-  void updateBounds(Engine&, bool widenOnly = false) override;
-  void recompute(Timestamp, Engine&) override;
-  VarId nextInput(Timestamp, Engine&) override;
-  void notifyCurrentInputChanged(Timestamp, Engine&) override;
-  void notifyInputChanged(Timestamp, Engine&, LocalId) override;
-  void commit(Timestamp, Engine&) override;
+  explicit Times(Engine&, VarId output, VarId x, VarId y);
+  void registerVars() override;
+  void updateBounds(bool widenOnly = false) override;
+  void recompute(Timestamp) override;
+  VarId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  void commit(Timestamp) override;
 };

--- a/include/search/objective.hpp
+++ b/include/search/objective.hpp
@@ -45,7 +45,8 @@ class Objective {
     } else {
       _violation = _engine.makeIntVar(0, 0, std::numeric_limits<Int>::max());
       _engine.makeInvariant<Linear>(
-          *_violation, std::vector<VarId>{boundViolation, constraintViolation});
+          _engine, *_violation,
+          std::vector<VarId>{boundViolation, constraintViolation});
     }
     return *_violation;
   }

--- a/include/views/bool2IntView.hpp
+++ b/include/views/bool2IntView.hpp
@@ -22,7 +22,8 @@
  */
 class Bool2IntView : public IntView {
  public:
-  explicit Bool2IntView(const VarId parentId) : IntView(parentId) {}
+  explicit Bool2IntView(Engine& engine, const VarId parentId)
+      : IntView(engine, parentId) {}
 
   [[nodiscard]] Int value(Timestamp) override;
   [[nodiscard]] Int committedValue() override;

--- a/include/views/elementConst.hpp
+++ b/include/views/elementConst.hpp
@@ -29,7 +29,8 @@ class ElementConst : public IntView {
   }
 
  public:
-  explicit ElementConst(VarId parentId, std::vector<Int> array, Int offset = 1);
+  explicit ElementConst(Engine& engine, VarId parentId, std::vector<Int> array,
+                        Int offset = 1);
   [[nodiscard]] Int value(Timestamp) override;
   [[nodiscard]] Int committedValue() override;
   [[nodiscard]] Int lowerBound() const override;

--- a/include/views/equalConst.hpp
+++ b/include/views/equalConst.hpp
@@ -11,7 +11,8 @@ class EqualConst : public IntView {
   const Int _val;
 
  public:
-  explicit EqualConst(VarId parentId, Int val) : IntView(parentId), _val(val) {}
+  explicit EqualConst(Engine& engine, VarId parentId, Int val)
+      : IntView(engine, parentId), _val(val) {}
 
   [[nodiscard]] Int value(Timestamp) override;
   [[nodiscard]] Int committedValue() override;

--- a/include/views/greaterEqualConst.hpp
+++ b/include/views/greaterEqualConst.hpp
@@ -11,8 +11,8 @@ class GreaterEqualConst : public IntView {
   const Int _val;
 
  public:
-  explicit GreaterEqualConst(VarId parentId, Int val)
-      : IntView(parentId), _val(val) {}
+  explicit GreaterEqualConst(Engine& engine, VarId parentId, Int val)
+      : IntView(engine, parentId), _val(val) {}
 
   [[nodiscard]] Int value(Timestamp) override;
   [[nodiscard]] Int committedValue() override;

--- a/include/views/inDomain.hpp
+++ b/include/views/inDomain.hpp
@@ -18,7 +18,8 @@ class InDomain : public IntView {
   Int compute(const Int val) const;
 
  public:
-  explicit InDomain(VarId parentId, std::vector<DomainEntry>&& domain);
+  explicit InDomain(Engine& engine, VarId parentId,
+                    std::vector<DomainEntry>&& domain);
 
   [[nodiscard]] Int value(Timestamp) override;
   [[nodiscard]] Int committedValue() override;

--- a/include/views/inSparseDomain.hpp
+++ b/include/views/inSparseDomain.hpp
@@ -14,7 +14,7 @@ class InSparseDomain : public IntView {
   std::vector<int> _valueViolation;
 
  public:
-  explicit InSparseDomain(VarId parentId,
+  explicit InSparseDomain(Engine& engine, VarId parentId,
                           const std::vector<DomainEntry>& domain);
 
   [[nodiscard]] Int value(Timestamp) override;

--- a/include/views/intAbsView.hpp
+++ b/include/views/intAbsView.hpp
@@ -7,7 +7,8 @@
 
 class IntAbsView : public IntView {
  public:
-  IntAbsView(const VarId parentId) : IntView(parentId) {}
+  IntAbsView(Engine& engine, const VarId parentId)
+      : IntView(engine, parentId) {}
 
   [[nodiscard]] Int value(Timestamp) override;
   [[nodiscard]] Int committedValue() override;

--- a/include/views/intMaxView.hpp
+++ b/include/views/intMaxView.hpp
@@ -10,7 +10,8 @@ class IntMaxView : public IntView {
   Int _max;
 
  public:
-  explicit IntMaxView(VarId parentId, Int max) : IntView(parentId), _max(max) {}
+  explicit IntMaxView(Engine& engine, VarId parentId, Int max)
+      : IntView(engine, parentId), _max(max) {}
 
   [[nodiscard]] Int value(Timestamp) override;
   [[nodiscard]] Int committedValue() override;

--- a/include/views/intOffsetView.hpp
+++ b/include/views/intOffsetView.hpp
@@ -10,8 +10,8 @@ class IntOffsetView : public IntView {
   const Int _offset;
 
  public:
-  explicit IntOffsetView(VarId parentId, Int offset)
-      : IntView(parentId), _offset(offset) {}
+  explicit IntOffsetView(Engine& engine, VarId parentId, Int offset)
+      : IntView(engine, parentId), _offset(offset) {}
 
   [[nodiscard]] Int value(Timestamp) override;
   [[nodiscard]] Int committedValue() override;

--- a/include/views/intView.hpp
+++ b/include/views/intView.hpp
@@ -10,15 +10,11 @@ class IntView : public View {
   friend class Engine;
   // A raw pointer might be the best option here as views lifetime depend
   // on engine and not vice-versa:
-  Engine* _engine;
 
  public:
-  explicit IntView(VarId parentId) : View(parentId), _engine(nullptr) {}
+  explicit IntView(Engine& engine, VarId parentId) : View(engine, parentId) {}
 
-  void init(VarId id, Engine& engine) {
-    _id = id;
-    _engine = &engine;
-  }
+  void init(VarId id) { _id = id; }
 
   [[nodiscard]] virtual Int value(Timestamp) = 0;
   [[nodiscard]] virtual Int committedValue() = 0;

--- a/include/views/lessEqualConst.hpp
+++ b/include/views/lessEqualConst.hpp
@@ -11,8 +11,8 @@ class LessEqualConst : public IntView {
   const Int _val;
 
  public:
-  explicit LessEqualConst(VarId parentId, Int val)
-      : IntView(parentId), _val(val) {}
+  explicit LessEqualConst(Engine& engine, VarId parentId, Int val)
+      : IntView(engine, parentId), _val(val) {}
 
   [[nodiscard]] Int value(Timestamp) override;
   [[nodiscard]] Int committedValue() override;

--- a/include/views/notEqualConst.hpp
+++ b/include/views/notEqualConst.hpp
@@ -11,8 +11,8 @@ class NotEqualConst : public IntView {
   const Int _val;
 
  public:
-  explicit NotEqualConst(VarId parentId, Int val)
-      : IntView(parentId), _val(val) {}
+  explicit NotEqualConst(Engine& engine, VarId parentId, Int val)
+      : IntView(engine, parentId), _val(val) {}
 
   [[nodiscard]] Int value(Timestamp) override;
   [[nodiscard]] Int committedValue() override;

--- a/include/views/scalarView.hpp
+++ b/include/views/scalarView.hpp
@@ -7,8 +7,8 @@ class ScalarView : public IntView {
   const Int _scalar;
 
  public:
-  explicit ScalarView(VarId parentId, Int scalar)
-      : IntView(parentId), _scalar(scalar) {}
+  explicit ScalarView(Engine& engine, VarId parentId, Int scalar)
+      : IntView(engine, parentId), _scalar(scalar) {}
 
   [[nodiscard]] Int value(Timestamp) override;
   [[nodiscard]] Int committedValue() override;

--- a/include/views/view.hpp
+++ b/include/views/view.hpp
@@ -2,12 +2,16 @@
 #include "core/types.hpp"
 #include "variables/var.hpp"
 
+class Engine;
+
 class View : public Var {
  protected:
+  Engine& _engine;
   const VarId _parentId;
 
  public:
-  explicit View(VarId parentId) : Var(NULL_ID), _parentId(parentId) {
+  explicit View(Engine& engine, VarId parentId)
+      : Var(NULL_ID), _engine(engine), _parentId(parentId) {
     _id.idType = VarIdType::view;
   }
   virtual ~View() = default;

--- a/include/views/violation2BoolView.hpp
+++ b/include/views/violation2BoolView.hpp
@@ -7,7 +7,8 @@
 
 class Violation2BoolView : public IntView {
  public:
-  explicit Violation2BoolView(const VarId parentId) : IntView(parentId) {}
+  explicit Violation2BoolView(Engine& engine, const VarId parentId)
+      : IntView(engine, parentId) {}
 
   [[nodiscard]] Int value(Timestamp) override;
   [[nodiscard]] Int committedValue() override;

--- a/src/constraints/allDifferentExcept.cpp
+++ b/src/constraints/allDifferentExcept.cpp
@@ -1,14 +1,13 @@
 #include "constraints/allDifferentExcept.hpp"
 
 #include "core/engine.hpp"
-#include "variables/committableInt.hpp"
 /**
  * @param violationId id for the violationCount
  */
-AllDifferentExcept::AllDifferentExcept(VarId violationId,
+AllDifferentExcept::AllDifferentExcept(Engine& engine, VarId violationId,
                                        std::vector<VarId> variables,
                                        const std::vector<Int>& ignored)
-    : AllDifferent(violationId, variables) {
+    : AllDifferent(engine, violationId, variables) {
   _modifiedVars.reserve(_variables.size());
   const auto [lb, ub] =
       std::minmax_element(std::begin(ignored), std::end(ignored));
@@ -20,33 +19,32 @@ AllDifferentExcept::AllDifferentExcept(VarId violationId,
   }
 }
 
-void AllDifferentExcept::recompute(Timestamp ts, Engine& engine) {
+void AllDifferentExcept::recompute(Timestamp ts) {
   for (CommittableInt& c : _counts) {
     c.setValue(ts, 0);
   }
 
   Int violInc = 0;
   for (size_t i = 0; i < _variables.size(); ++i) {
-    const Int val = engine.value(ts, _variables[i]);
+    const Int val = _engine.value(ts, _variables[i]);
     if (!isIgnored(val)) {
       violInc += increaseCount(ts, val);
     }
     _localValues[i].setValue(ts, val);
   }
-  updateValue(ts, engine, _violationId, violInc);
+  updateValue(ts, _violationId, violInc);
 }
 
-void AllDifferentExcept::notifyInputChanged(Timestamp ts, Engine& engine,
-                                            LocalId id) {
+void AllDifferentExcept::notifyInputChanged(Timestamp ts, LocalId id) {
   assert(id < _localValues.size());
   const Int oldValue = _localValues[id].value(ts);
-  const Int newValue = engine.value(ts, _variables[id]);
+  const Int newValue = _engine.value(ts, _variables[id]);
   if (newValue == oldValue) {
     return;
   }
   _localValues[id].setValue(ts, newValue);
 
-  incValue(ts, engine, _violationId,
+  incValue(ts, _violationId,
            static_cast<Int>(
                (isIgnored(oldValue) ? 0 : decreaseCount(ts, oldValue)) +
                (isIgnored(newValue) ? 0 : increaseCount(ts, newValue))));

--- a/src/constraints/boolEqual.cpp
+++ b/src/constraints/boolEqual.cpp
@@ -8,33 +8,31 @@
  * @param x variable of lhs
  * @param y variable of rhs
  */
-BoolEqual::BoolEqual(VarId violationId, VarId x, VarId y)
-    : Constraint(violationId), _x(x), _y(y) {
+BoolEqual::BoolEqual(Engine& engine, VarId violationId, VarId x, VarId y)
+    : Constraint(engine, violationId), _x(x), _y(y) {
   _modifiedVars.reserve(1);
 }
 
-void BoolEqual::registerVars(Engine& engine) {
+void BoolEqual::registerVars() {
   assert(_id != NULL_ID);
-  engine.registerInvariantInput(_id, _x, LocalId(0));
-  engine.registerInvariantInput(_id, _y, LocalId(0));
-  registerDefinedVariable(engine, _violationId);
+  _engine.registerInvariantInput(_id, _x, LocalId(0));
+  _engine.registerInvariantInput(_id, _y, LocalId(0));
+  registerDefinedVariable(_violationId);
 }
 
-void BoolEqual::updateBounds(Engine& engine, bool widenOnly) {
-  engine.updateBounds(_violationId, 0, 1, widenOnly);
+void BoolEqual::updateBounds(bool widenOnly) {
+  _engine.updateBounds(_violationId, 0, 1, widenOnly);
 }
 
-void BoolEqual::recompute(Timestamp ts, Engine& engine) {
-  updateValue(ts, engine, _violationId,
-              static_cast<Int>((engine.value(ts, _x) != 0) !=
-                               (engine.value(ts, _y) != 0)));
+void BoolEqual::recompute(Timestamp ts) {
+  updateValue(ts, _violationId,
+              static_cast<Int>((_engine.value(ts, _x) != 0) !=
+                               (_engine.value(ts, _y) != 0)));
 }
 
-void BoolEqual::notifyInputChanged(Timestamp ts, Engine& engine, LocalId) {
-  recompute(ts, engine);
-}
+void BoolEqual::notifyInputChanged(Timestamp ts, LocalId) { recompute(ts); }
 
-VarId BoolEqual::nextInput(Timestamp ts, Engine&) {
+VarId BoolEqual::nextInput(Timestamp ts) {
   switch (_state.incValue(ts, 1)) {
     case 0:
       return _x;
@@ -45,10 +43,6 @@ VarId BoolEqual::nextInput(Timestamp ts, Engine&) {
   }
 }
 
-void BoolEqual::notifyCurrentInputChanged(Timestamp ts, Engine& engine) {
-  recompute(ts, engine);
-}
+void BoolEqual::notifyCurrentInputChanged(Timestamp ts) { recompute(ts); }
 
-void BoolEqual::commit(Timestamp ts, Engine& engine) {
-  Invariant::commit(ts, engine);
-}
+void BoolEqual::commit(Timestamp ts) { Invariant::commit(ts); }

--- a/src/constraints/boolLessEqual.cpp
+++ b/src/constraints/boolLessEqual.cpp
@@ -8,33 +8,32 @@
  * @param x variable of lhs
  * @param y variable of rhs
  */
-BoolLessEqual::BoolLessEqual(VarId violationId, VarId x, VarId y)
-    : Constraint(violationId), _x(x), _y(y) {
+BoolLessEqual::BoolLessEqual(Engine& engine, VarId violationId, VarId x,
+                             VarId y)
+    : Constraint(engine, violationId), _x(x), _y(y) {
   _modifiedVars.reserve(1);
 }
 
-void BoolLessEqual::registerVars(Engine& engine) {
+void BoolLessEqual::registerVars() {
   assert(_id != NULL_ID);
-  engine.registerInvariantInput(_id, _x, LocalId(0));
-  engine.registerInvariantInput(_id, _y, LocalId(0));
-  registerDefinedVariable(engine, _violationId);
+  _engine.registerInvariantInput(_id, _x, LocalId(0));
+  _engine.registerInvariantInput(_id, _y, LocalId(0));
+  registerDefinedVariable(_violationId);
 }
 
-void BoolLessEqual::updateBounds(Engine& engine, bool widenOnly) {
-  engine.updateBounds(_violationId, 0, 1, widenOnly);
+void BoolLessEqual::updateBounds(bool widenOnly) {
+  _engine.updateBounds(_violationId, 0, 1, widenOnly);
 }
 
-void BoolLessEqual::recompute(Timestamp ts, Engine& engine) {
-  updateValue(ts, engine, _violationId,
-              static_cast<Int>((engine.value(ts, _x) == 0) &&
-                               (engine.value(ts, _y) != 0)));
+void BoolLessEqual::recompute(Timestamp ts) {
+  updateValue(ts, _violationId,
+              static_cast<Int>((_engine.value(ts, _x) == 0) &&
+                               (_engine.value(ts, _y) != 0)));
 }
 
-void BoolLessEqual::notifyInputChanged(Timestamp ts, Engine& engine, LocalId) {
-  recompute(ts, engine);
-}
+void BoolLessEqual::notifyInputChanged(Timestamp ts, LocalId) { recompute(ts); }
 
-VarId BoolLessEqual::nextInput(Timestamp ts, Engine&) {
+VarId BoolLessEqual::nextInput(Timestamp ts) {
   switch (_state.incValue(ts, 1)) {
     case 0:
       return _x;
@@ -45,10 +44,6 @@ VarId BoolLessEqual::nextInput(Timestamp ts, Engine&) {
   }
 }
 
-void BoolLessEqual::notifyCurrentInputChanged(Timestamp ts, Engine& engine) {
-  recompute(ts, engine);
-}
+void BoolLessEqual::notifyCurrentInputChanged(Timestamp ts) { recompute(ts); }
 
-void BoolLessEqual::commit(Timestamp ts, Engine& engine) {
-  Invariant::commit(ts, engine);
-}
+void BoolLessEqual::commit(Timestamp ts) { Invariant::commit(ts); }

--- a/src/constraints/boolLessThan.cpp
+++ b/src/constraints/boolLessThan.cpp
@@ -8,33 +8,31 @@
  * @param x variable of lhs
  * @param y variable of rhs
  */
-BoolLessThan::BoolLessThan(VarId violationId, VarId x, VarId y)
-    : Constraint(violationId), _x(x), _y(y) {
+BoolLessThan::BoolLessThan(Engine& engine, VarId violationId, VarId x, VarId y)
+    : Constraint(engine, violationId), _x(x), _y(y) {
   _modifiedVars.reserve(1);
 }
 
-void BoolLessThan::registerVars(Engine& engine) {
+void BoolLessThan::registerVars() {
   assert(_id != NULL_ID);
-  engine.registerInvariantInput(_id, _x, LocalId(0));
-  engine.registerInvariantInput(_id, _y, LocalId(0));
-  registerDefinedVariable(engine, _violationId);
+  _engine.registerInvariantInput(_id, _x, LocalId(0));
+  _engine.registerInvariantInput(_id, _y, LocalId(0));
+  registerDefinedVariable(_violationId);
 }
 
-void BoolLessThan::updateBounds(Engine& engine, bool widenOnly) {
-  engine.updateBounds(_violationId, 0, 1, widenOnly);
+void BoolLessThan::updateBounds(bool widenOnly) {
+  _engine.updateBounds(_violationId, 0, 1, widenOnly);
 }
 
-void BoolLessThan::recompute(Timestamp ts, Engine& engine) {
+void BoolLessThan::recompute(Timestamp ts) {
   updateValue(
-      ts, engine, _violationId,
-      static_cast<Int>(engine.value(ts, _x) == 0) + engine.value(ts, _y));
+      ts, _violationId,
+      static_cast<Int>(_engine.value(ts, _x) == 0) + _engine.value(ts, _y));
 }
 
-void BoolLessThan::notifyInputChanged(Timestamp ts, Engine& engine, LocalId) {
-  recompute(ts, engine);
-}
+void BoolLessThan::notifyInputChanged(Timestamp ts, LocalId) { recompute(ts); }
 
-VarId BoolLessThan::nextInput(Timestamp ts, Engine&) {
+VarId BoolLessThan::nextInput(Timestamp ts) {
   switch (_state.incValue(ts, 1)) {
     case 0:
       return _x;
@@ -45,10 +43,6 @@ VarId BoolLessThan::nextInput(Timestamp ts, Engine&) {
   }
 }
 
-void BoolLessThan::notifyCurrentInputChanged(Timestamp ts, Engine& engine) {
-  recompute(ts, engine);
-}
+void BoolLessThan::notifyCurrentInputChanged(Timestamp ts) { recompute(ts); }
 
-void BoolLessThan::commit(Timestamp ts, Engine& engine) {
-  Invariant::commit(ts, engine);
-}
+void BoolLessThan::commit(Timestamp ts) { Invariant::commit(ts); }

--- a/src/constraints/constraint.cpp
+++ b/src/constraints/constraint.cpp
@@ -4,6 +4,6 @@
 
 inline VarId Constraint::violationId() const { return _violationId; }
 
-inline Int Constraint::violationCount(Engine& engine, Timestamp& ts) const {
-  return engine.value(ts, _violationId);
+inline Int Constraint::violationCount(Timestamp& ts) const {
+  return _engine.value(ts, _violationId);
 }

--- a/src/constraints/equal.cpp
+++ b/src/constraints/equal.cpp
@@ -8,23 +8,23 @@
  * @param x variable of lhs
  * @param y variable of rhs
  */
-Equal::Equal(VarId violationId, VarId x, VarId y)
-    : Constraint(violationId), _x(x), _y(y) {
+Equal::Equal(Engine& engine, VarId violationId, VarId x, VarId y)
+    : Constraint(engine, violationId), _x(x), _y(y) {
   _modifiedVars.reserve(1);
 }
 
-void Equal::registerVars(Engine& engine) {
+void Equal::registerVars() {
   assert(_id != NULL_ID);
-  engine.registerInvariantInput(_id, _x, LocalId(0));
-  engine.registerInvariantInput(_id, _y, LocalId(0));
-  registerDefinedVariable(engine, _violationId);
+  _engine.registerInvariantInput(_id, _x, LocalId(0));
+  _engine.registerInvariantInput(_id, _y, LocalId(0));
+  registerDefinedVariable(_violationId);
 }
 
-void Equal::updateBounds(Engine& engine, bool widenOnly) {
-  const Int xLb = engine.lowerBound(_x);
-  const Int xUb = engine.upperBound(_x);
-  const Int yLb = engine.lowerBound(_y);
-  const Int yUb = engine.upperBound(_y);
+void Equal::updateBounds(bool widenOnly) {
+  const Int xLb = _engine.lowerBound(_x);
+  const Int xUb = _engine.upperBound(_x);
+  const Int yLb = _engine.lowerBound(_y);
+  const Int yUb = _engine.upperBound(_y);
 
   const Int lb = xLb <= yUb && yLb <= xUb
                      ? 0
@@ -33,19 +33,17 @@ void Equal::updateBounds(Engine& engine, bool widenOnly) {
   const Int ub = std::max(std::max(std::abs(xLb - yLb), std::abs(xLb - yUb)),
                           std::max(std::abs(xUb - yLb), std::abs(xUb - yUb)));
 
-  engine.updateBounds(_violationId, lb, ub, widenOnly);
+  _engine.updateBounds(_violationId, lb, ub, widenOnly);
 }
 
-void Equal::recompute(Timestamp ts, Engine& engine) {
-  updateValue(ts, engine, _violationId,
-              std::abs(engine.value(ts, _x) - engine.value(ts, _y)));
+void Equal::recompute(Timestamp ts) {
+  updateValue(ts, _violationId,
+              std::abs(_engine.value(ts, _x) - _engine.value(ts, _y)));
 }
 
-void Equal::notifyInputChanged(Timestamp ts, Engine& engine, LocalId) {
-  recompute(ts, engine);
-}
+void Equal::notifyInputChanged(Timestamp ts, LocalId) { recompute(ts); }
 
-VarId Equal::nextInput(Timestamp ts, Engine&) {
+VarId Equal::nextInput(Timestamp ts) {
   switch (_state.incValue(ts, 1)) {
     case 0:
       return _x;
@@ -56,10 +54,6 @@ VarId Equal::nextInput(Timestamp ts, Engine&) {
   }
 }
 
-void Equal::notifyCurrentInputChanged(Timestamp ts, Engine& engine) {
-  recompute(ts, engine);
-}
+void Equal::notifyCurrentInputChanged(Timestamp ts) { recompute(ts); }
 
-void Equal::commit(Timestamp ts, Engine& engine) {
-  Invariant::commit(ts, engine);
-}
+void Equal::commit(Timestamp ts) { Invariant::commit(ts); }

--- a/src/constraints/globalCardinalityClosed.cpp
+++ b/src/constraints/globalCardinalityClosed.cpp
@@ -1,7 +1,6 @@
 #include "constraints/globalCardinalityClosed.hpp"
 
 #include "core/engine.hpp"
-#include "variables/committableInt.hpp"
 
 inline bool all_in_range(Int start, Int stop,
                          std::function<bool(Int)> predicate) {
@@ -15,11 +14,12 @@ inline bool all_in_range(Int start, Int stop,
 /**
  * @param violationId id for the violationCount
  */
-GlobalCardinalityClosed::GlobalCardinalityClosed(VarId violationId,
+GlobalCardinalityClosed::GlobalCardinalityClosed(Engine& engine,
+                                                 VarId violationId,
                                                  std::vector<VarId> outputs,
                                                  std::vector<VarId> inputs,
                                                  std::vector<Int> cover)
-    : Constraint(violationId),
+    : Constraint(engine, violationId),
       _outputs(std::move(outputs)),
       _inputs(std::move(inputs)),
       _cover(std::move(cover)),
@@ -36,25 +36,25 @@ GlobalCardinalityClosed::GlobalCardinalityClosed(VarId violationId,
   }));
 }
 
-void GlobalCardinalityClosed::registerVars(Engine& engine) {
+void GlobalCardinalityClosed::registerVars() {
   assert(!_id.equals(NULL_ID));
   for (size_t i = 0; i < _inputs.size(); ++i) {
-    engine.registerInvariantInput(_id, _inputs[i], LocalId(i));
+    _engine.registerInvariantInput(_id, _inputs[i], LocalId(i));
   }
-  registerDefinedVariable(engine, _violationId);
+  registerDefinedVariable(_violationId);
   for (const VarId output : _outputs) {
-    registerDefinedVariable(engine, output);
+    registerDefinedVariable(output);
   }
 }
 
-void GlobalCardinalityClosed::updateBounds(Engine& engine, bool widenOnly) {
-  engine.updateBounds(_violationId, 0, _inputs.size(), widenOnly);
+void GlobalCardinalityClosed::updateBounds(bool widenOnly) {
+  _engine.updateBounds(_violationId, 0, _inputs.size(), widenOnly);
   for (const VarId output : _outputs) {
-    engine.updateBounds(output, 0, _inputs.size(), widenOnly);
+    _engine.updateBounds(output, 0, _inputs.size(), widenOnly);
   }
 }
 
-void GlobalCardinalityClosed::close(Timestamp timestamp, Engine& engine) {
+void GlobalCardinalityClosed::close(Timestamp timestamp) {
   const auto [lb, ub] = std::minmax_element(_cover.begin(), _cover.end());
   _offset = *lb;
   _coverVarIndex.resize(*ub - *lb + 1, -1);
@@ -66,47 +66,46 @@ void GlobalCardinalityClosed::close(Timestamp timestamp, Engine& engine) {
   _counts.resize(_outputs.size(), CommittableInt(timestamp, 0));
   _localValues.clear();
   for (const VarId input : _inputs) {
-    _localValues.emplace_back(timestamp, engine.committedValue(input));
+    _localValues.emplace_back(timestamp, _engine.committedValue(input));
   }
 }
 
-void GlobalCardinalityClosed::recompute(Timestamp timestamp, Engine& engine) {
+void GlobalCardinalityClosed::recompute(Timestamp timestamp) {
   for (CommittableInt& c : _counts) {
     c.setValue(timestamp, 0);
   }
 
   Int excess = 0;
   for (size_t i = 0; i < _inputs.size(); ++i) {
-    excess += increaseCount(timestamp, engine.value(timestamp, _inputs[i]));
-    _localValues[i].setValue(timestamp, engine.value(timestamp, _inputs[i]));
+    excess += increaseCount(timestamp, _engine.value(timestamp, _inputs[i]));
+    _localValues[i].setValue(timestamp, _engine.value(timestamp, _inputs[i]));
   }
 
-  updateValue(timestamp, engine, _violationId, excess);
+  updateValue(timestamp, _violationId, excess);
   for (size_t i = 0; i < _outputs.size(); ++i) {
     assert(0 <= _cover[i] - _offset &&
            _cover[i] - _offset < static_cast<Int>(_coverVarIndex.size()));
-    updateValue(timestamp, engine, _outputs[i], _counts[i].value(timestamp));
+    updateValue(timestamp, _outputs[i], _counts[i].value(timestamp));
   }
 }
 
 void GlobalCardinalityClosed::notifyInputChanged(Timestamp timestamp,
-                                                 Engine& engine,
                                                  LocalId localId) {
   assert(localId < _localValues.size());
   const Int oldValue = _localValues[localId].value(timestamp);
-  const Int newValue = engine.value(timestamp, _inputs[localId]);
+  const Int newValue = _engine.value(timestamp, _inputs[localId]);
   if (newValue == oldValue) {
     return;
   }
   const Int dec = decreaseCount(timestamp, oldValue);
   const Int inc = increaseCount(timestamp, newValue);
   _localValues[localId].setValue(timestamp, newValue);
-  incValue(timestamp, engine, _violationId, inc - dec);
-  updateOutput(timestamp, engine, oldValue);
-  updateOutput(timestamp, engine, newValue);
+  incValue(timestamp, _violationId, inc - dec);
+  updateOutput(timestamp, oldValue);
+  updateOutput(timestamp, newValue);
 }
 
-VarId GlobalCardinalityClosed::nextInput(Timestamp timestamp, Engine&) {
+VarId GlobalCardinalityClosed::nextInput(Timestamp timestamp) {
   const auto index = static_cast<size_t>(_state.incValue(timestamp, 1));
   assert(0 <= _state.value(timestamp));
   if (index < _inputs.size()) {
@@ -115,14 +114,13 @@ VarId GlobalCardinalityClosed::nextInput(Timestamp timestamp, Engine&) {
   return NULL_ID;
 }
 
-void GlobalCardinalityClosed::notifyCurrentInputChanged(Timestamp timestamp,
-                                                        Engine& engine) {
+void GlobalCardinalityClosed::notifyCurrentInputChanged(Timestamp timestamp) {
   assert(static_cast<size_t>(_state.value(timestamp)) < _inputs.size());
-  notifyInputChanged(timestamp, engine, _state.value(timestamp));
+  notifyInputChanged(timestamp, _state.value(timestamp));
 }
 
-void GlobalCardinalityClosed::commit(Timestamp timestamp, Engine& engine) {
-  Invariant::commit(timestamp, engine);
+void GlobalCardinalityClosed::commit(Timestamp timestamp) {
+  Invariant::commit(timestamp);
 
   for (auto& localValue : _localValues) {
     localValue.commitIf(timestamp);

--- a/src/constraints/lessEqual.cpp
+++ b/src/constraints/lessEqual.cpp
@@ -8,36 +8,35 @@
  * @param x variable of lhs
  * @param y variable of rhs
  */
-LessEqual::LessEqual(VarId violationId, VarId x, VarId y)
-    : Constraint(violationId), _x(x), _y(y) {
+LessEqual::LessEqual(Engine& engine, VarId violationId, VarId x, VarId y)
+    : Constraint(engine, violationId), _x(x), _y(y) {
   _modifiedVars.reserve(1);
 }
 
-void LessEqual::registerVars(Engine& engine) {
+void LessEqual::registerVars() {
   assert(_id != NULL_ID);
-  engine.registerInvariantInput(_id, _x, LocalId(0));
-  engine.registerInvariantInput(_id, _y, LocalId(0));
-  registerDefinedVariable(engine, _violationId);
+  _engine.registerInvariantInput(_id, _x, LocalId(0));
+  _engine.registerInvariantInput(_id, _y, LocalId(0));
+  registerDefinedVariable(_violationId);
 }
 
-void LessEqual::updateBounds(Engine& engine, bool widenOnly) {
-  engine.updateBounds(
+void LessEqual::updateBounds(bool widenOnly) {
+  _engine.updateBounds(
       _violationId,
-      std::max(Int(0), engine.lowerBound(_x) - engine.upperBound(_y)),
-      std::max(Int(0), engine.upperBound(_x) - engine.lowerBound(_y)),
+      std::max(Int(0), _engine.lowerBound(_x) - _engine.upperBound(_y)),
+      std::max(Int(0), _engine.upperBound(_x) - _engine.lowerBound(_y)),
       widenOnly);
 }
 
-void LessEqual::recompute(Timestamp ts, Engine& engine) {
-  updateValue(ts, engine, _violationId,
-              std::max(Int(0), engine.value(ts, _x) - engine.value(ts, _y)));
+void LessEqual::recompute(Timestamp ts) {
+  updateValue(
+      ts, _violationId,
+      std::max(Int(0), _engine.value(ts, _x) - _engine.value(ts, _y)));
 }
 
-void LessEqual::notifyInputChanged(Timestamp ts, Engine& engine, LocalId) {
-  recompute(ts, engine);
-}
+void LessEqual::notifyInputChanged(Timestamp ts, LocalId) { recompute(ts); }
 
-VarId LessEqual::nextInput(Timestamp ts, Engine&) {
+VarId LessEqual::nextInput(Timestamp ts) {
   switch (_state.incValue(ts, 1)) {
     case 0:
       return _x;
@@ -48,10 +47,6 @@ VarId LessEqual::nextInput(Timestamp ts, Engine&) {
   }
 }
 
-void LessEqual::notifyCurrentInputChanged(Timestamp ts, Engine& engine) {
-  recompute(ts, engine);
-}
+void LessEqual::notifyCurrentInputChanged(Timestamp ts) { recompute(ts); }
 
-void LessEqual::commit(Timestamp ts, Engine& engine) {
-  Invariant::commit(ts, engine);
-}
+void LessEqual::commit(Timestamp ts) { Invariant::commit(ts); }

--- a/src/constraints/lessThan.cpp
+++ b/src/constraints/lessThan.cpp
@@ -8,37 +8,35 @@
  * @param x variable of lhs
  * @param y variable of rhs
  */
-LessThan::LessThan(VarId violationId, VarId x, VarId y)
-    : Constraint(violationId), _x(x), _y(y) {
+LessThan::LessThan(Engine& engine, VarId violationId, VarId x, VarId y)
+    : Constraint(engine, violationId), _x(x), _y(y) {
   _modifiedVars.reserve(1);
 }
 
-void LessThan::registerVars(Engine& engine) {
+void LessThan::registerVars() {
   assert(_id != NULL_ID);
-  engine.registerInvariantInput(_id, _x, LocalId(0));
-  engine.registerInvariantInput(_id, _y, LocalId(0));
-  registerDefinedVariable(engine, _violationId);
+  _engine.registerInvariantInput(_id, _x, LocalId(0));
+  _engine.registerInvariantInput(_id, _y, LocalId(0));
+  registerDefinedVariable(_violationId);
 }
 
-void LessThan::updateBounds(Engine& engine, bool widenOnly) {
-  engine.updateBounds(
+void LessThan::updateBounds(bool widenOnly) {
+  _engine.updateBounds(
       _violationId,
-      std::max(Int(0), 1 + engine.lowerBound(_x) - engine.upperBound(_y)),
-      std::max(Int(0), 1 + engine.upperBound(_x) - engine.lowerBound(_y)),
+      std::max(Int(0), 1 + _engine.lowerBound(_x) - _engine.upperBound(_y)),
+      std::max(Int(0), 1 + _engine.upperBound(_x) - _engine.lowerBound(_y)),
       widenOnly);
 }
 
-void LessThan::recompute(Timestamp ts, Engine& engine) {
+void LessThan::recompute(Timestamp ts) {
   updateValue(
-      ts, engine, _violationId,
-      std::max(Int(0), engine.value(ts, _x) - engine.value(ts, _y) + 1));
+      ts, _violationId,
+      std::max(Int(0), _engine.value(ts, _x) - _engine.value(ts, _y) + 1));
 }
 
-void LessThan::notifyInputChanged(Timestamp ts, Engine& engine, LocalId) {
-  recompute(ts, engine);
-}
+void LessThan::notifyInputChanged(Timestamp ts, LocalId) { recompute(ts); }
 
-VarId LessThan::nextInput(Timestamp ts, Engine&) {
+VarId LessThan::nextInput(Timestamp ts) {
   switch (_state.incValue(ts, 1)) {
     case 0:
       return _x;
@@ -49,10 +47,6 @@ VarId LessThan::nextInput(Timestamp ts, Engine&) {
   }
 }
 
-void LessThan::notifyCurrentInputChanged(Timestamp ts, Engine& engine) {
-  recompute(ts, engine);
-}
+void LessThan::notifyCurrentInputChanged(Timestamp ts) { recompute(ts); }
 
-void LessThan::commit(Timestamp ts, Engine& engine) {
-  Invariant::commit(ts, engine);
-}
+void LessThan::commit(Timestamp ts) { Invariant::commit(ts); }

--- a/src/constraints/powDomain.cpp
+++ b/src/constraints/powDomain.cpp
@@ -9,40 +9,38 @@
  * @param x variable of lhs
  * @param y parameter of rhs
  */
-PowDomain::PowDomain(VarId violationId, VarId x, VarId y)
-    : Constraint(violationId), _x(x), _y(y) {
+PowDomain::PowDomain(Engine& engine, VarId violationId, VarId x, VarId y)
+    : Constraint(engine, violationId), _x(x), _y(y) {
   _modifiedVars.reserve(1);
 }
 
-void PowDomain::registerVars(Engine& engine) {
+void PowDomain::registerVars() {
   assert(_id != NULL_ID);
-  engine.registerInvariantInput(_id, _x, LocalId(0));
-  engine.registerInvariantInput(_id, _y, LocalId(0));
-  registerDefinedVariable(engine, _violationId);
+  _engine.registerInvariantInput(_id, _x, LocalId(0));
+  _engine.registerInvariantInput(_id, _y, LocalId(0));
+  registerDefinedVariable(_violationId);
 }
 
-void PowDomain::updateBounds(Engine& engine, bool widenOnly) {
-  const Int xLb = engine.lowerBound(_x);
-  const Int xUb = engine.upperBound(_x);
-  const Int yLb = engine.lowerBound(_y);
-  const Int yUb = engine.upperBound(_y);
+void PowDomain::updateBounds(bool widenOnly) {
+  const Int xLb = _engine.lowerBound(_x);
+  const Int xUb = _engine.upperBound(_x);
+  const Int yLb = _engine.lowerBound(_y);
+  const Int yUb = _engine.upperBound(_y);
 
   const Int lb = xLb == 0 && xUb == 0 && yUb < 0 ? 1 : 0;
   const Int ub = xLb <= 0 && 0 <= xUb && yLb < 0 ? 1 : 0;
 
-  engine.updateBounds(_violationId, lb, ub, widenOnly);
+  _engine.updateBounds(_violationId, lb, ub, widenOnly);
 }
 
-void PowDomain::recompute(Timestamp ts, Engine& engine) {
-  updateValue(ts, engine, _violationId,
-              engine.value(ts, _x) == 0 && engine.value(ts, _y) < 0 ? 1 : 0);
+void PowDomain::recompute(Timestamp ts) {
+  updateValue(ts, _violationId,
+              _engine.value(ts, _x) == 0 && _engine.value(ts, _y) < 0 ? 1 : 0);
 }
 
-void PowDomain::notifyInputChanged(Timestamp ts, Engine& engine, LocalId) {
-  recompute(ts, engine);
-}
+void PowDomain::notifyInputChanged(Timestamp ts, LocalId) { recompute(ts); }
 
-VarId PowDomain::nextInput(Timestamp ts, Engine&) {
+VarId PowDomain::nextInput(Timestamp ts) {
   switch (_state.incValue(ts, 1)) {
     case 0:
       return _x;
@@ -53,13 +51,9 @@ VarId PowDomain::nextInput(Timestamp ts, Engine&) {
   }
 }
 
-void PowDomain::notifyCurrentInputChanged(Timestamp ts, Engine& engine) {
-  recompute(ts, engine);
-}
+void PowDomain::notifyCurrentInputChanged(Timestamp ts) { recompute(ts); }
 
-void PowDomain::commit(Timestamp ts, Engine& engine) {
-  Invariant::commit(ts, engine);
-}
+void PowDomain::commit(Timestamp ts) { Invariant::commit(ts); }
 
 [[nodiscard]] bool PowDomain::shouldPost(Engine& engine, VarId x, VarId y) {
   return engine.lowerBound(x) <= 0 && 0 <= engine.upperBound(x) &&

--- a/src/core/propagationEngine.cpp
+++ b/src/core/propagationEngine.cpp
@@ -160,7 +160,7 @@ void PropagationEngine::clearPropagationQueue() {
 void PropagationEngine::closeInvariants() {
   for (auto iter = _store.invariantBegin(); iter != _store.invariantEnd();
        ++iter) {
-    (*iter)->close(_currentTimestamp, *this);
+    (*iter)->close(_currentTimestamp);
   }
 }
 
@@ -176,7 +176,7 @@ void PropagationEngine::recomputeAndCommit() {
     for (auto iter = _store.invariantBegin(); iter != _store.invariantEnd();
          ++iter) {
       assert((*iter) != nullptr);
-      (*iter)->recompute(_currentTimestamp, *this);
+      (*iter)->recompute(_currentTimestamp);
     }
     for (auto iter = _store.intVarBegin(); iter != _store.intVarEnd(); ++iter) {
       if (iter->hasChanged(_currentTimestamp)) {
@@ -189,7 +189,7 @@ void PropagationEngine::recomputeAndCommit() {
   // Commiting an invariant will commit any internal datastructure.
   for (auto iter = _store.invariantBegin(); iter != _store.invariantEnd();
        ++iter) {
-    (*iter)->commit(_currentTimestamp, *this);
+    (*iter)->commit(_currentTimestamp);
   }
   clearPropagationQueue();
 }
@@ -326,7 +326,7 @@ void PropagationEngine::propagate() {
         Invariant& defInv = _store.invariant(definingInvariant);
         if (queuedVar == defInv.primaryDefinedVar()) {
           const Int oldValue = variable.value(_currentTimestamp);
-          defInv.compute(_currentTimestamp, *this);
+          defInv.compute(_currentTimestamp);
           for (const VarId inputId : defInv.nonPrimaryDefinedVars()) {
             if (hasChanged(_currentTimestamp, inputId)) {
               assert(!_isEnqueued.get(inputId));
@@ -335,7 +335,7 @@ void PropagationEngine::propagate() {
             }
           }
           if constexpr (DoCommit) {
-            defInv.commit(_currentTimestamp, *this);
+            defInv.commit(_currentTimestamp);
           }
           if (oldValue == variable.value(_currentTimestamp)) {
             continue;
@@ -352,6 +352,8 @@ void PropagationEngine::propagate() {
         invariant.notify(toNotify.localId);
         assert(invariant.primaryDefinedVar() != NULL_ID);
         assert(invariant.primaryDefinedVar().idType == VarIdType::var);
+        //        assert(_propGraph.position(queuedVar) <
+        //             _propGraph.position(invariant.primaryDefinedVar()));
         if constexpr (SingleLayer) {
           assert(_propGraph.layer(invariant.primaryDefinedVar()) == 0);
           enqueueComputedVar(invariant.primaryDefinedVar());
@@ -444,7 +446,7 @@ void PropagationEngine::computeBounds() {
                  (inputsToCompute[invariantId] == inputsToCompute[invId] &&
                   size_t(invariantId) <= size_t(invId));
         }));
-    _store.invariant(invariantId).updateBounds(*this, true);
+    _store.invariant(invariantId).updateBounds(true);
 
     for (const VarIdBase outputVarId :
          _propGraph.variablesDefinedBy(invariantId)) {

--- a/src/invariantgraph/constraints/allDifferentNode.cpp
+++ b/src/invariantgraph/constraints/allDifferentNode.cpp
@@ -42,7 +42,8 @@ void invariantgraph::AllDifferentNode::createDefinedVariables(Engine& engine) {
     } else {
       assert(!isReified());
       _intermediate = engine.makeIntVar(0, 0, 0);
-      setViolationVarId(engine.makeIntView<NotEqualConst>(_intermediate, 0));
+      setViolationVarId(
+          engine.makeIntView<NotEqualConst>(engine, _intermediate, 0));
     }
   }
 }
@@ -71,5 +72,6 @@ void invariantgraph::AllDifferentNode::registerWithEngine(Engine& engine) {
                  [&](const auto& var) { return var->varId(); });
 
   engine.makeConstraint<AllDifferent>(
-      !shouldHold() ? _intermediate : violationVarId(), engineVariables);
+      engine, !shouldHold() ? _intermediate : violationVarId(),
+      engineVariables);
 }

--- a/src/invariantgraph/constraints/allEqualNode.cpp
+++ b/src/invariantgraph/constraints/allEqualNode.cpp
@@ -30,11 +30,11 @@ void invariantgraph::AllEqualNode::createDefinedVariables(Engine& engine) {
     _allDifferentViolationVarId = engine.makeIntVar(0, 0, 0);
     if (shouldHold()) {
       setViolationVarId(engine.makeIntView<EqualConst>(
-          _allDifferentViolationVarId, staticInputs().size() - 1));
+          engine, _allDifferentViolationVarId, staticInputs().size() - 1));
     } else {
       assert(!isReified());
       setViolationVarId(engine.makeIntView<NotEqualConst>(
-          _allDifferentViolationVarId, staticInputs().size() - 1));
+          engine, _allDifferentViolationVarId, staticInputs().size() - 1));
     }
   }
 }
@@ -48,6 +48,6 @@ void invariantgraph::AllEqualNode::registerWithEngine(Engine& engine) {
                  std::back_inserter(engineVariables),
                  [&](const auto& var) { return var->varId(); });
 
-  engine.makeConstraint<AllDifferent>(_allDifferentViolationVarId,
+  engine.makeConstraint<AllDifferent>(engine, _allDifferentViolationVarId,
                                       engineVariables);
 }

--- a/src/invariantgraph/constraints/arrayBoolAndNode.cpp
+++ b/src/invariantgraph/constraints/arrayBoolAndNode.cpp
@@ -27,7 +27,8 @@ void invariantgraph::ArrayBoolAndNode::createDefinedVariables(Engine& engine) {
     } else {
       assert(!isReified());
       _intermediate = engine.makeIntVar(0, 0, 0);
-      setViolationVarId(engine.makeIntView<NotEqualConst>(_intermediate, 0));
+      setViolationVarId(
+          engine.makeIntView<NotEqualConst>(engine, _intermediate, 0));
     }
   }
 }
@@ -39,6 +40,6 @@ void invariantgraph::ArrayBoolAndNode::registerWithEngine(Engine& engine) {
                  std::back_inserter(inputs),
                  [&](const auto& node) { return node->varId(); });
 
-  engine.makeInvariant<ForAll>(!shouldHold() ? _intermediate : violationVarId(),
-                               inputs);
+  engine.makeInvariant<ForAll>(
+      engine, !shouldHold() ? _intermediate : violationVarId(), inputs);
 }

--- a/src/invariantgraph/constraints/arrayBoolOrNode.cpp
+++ b/src/invariantgraph/constraints/arrayBoolOrNode.cpp
@@ -27,7 +27,8 @@ void invariantgraph::ArrayBoolOrNode::createDefinedVariables(Engine& engine) {
     } else {
       assert(!isReified());
       _intermediate = engine.makeIntVar(0, 0, 0);
-      setViolationVarId(engine.makeIntView<NotEqualConst>(_intermediate, 0));
+      setViolationVarId(
+          engine.makeIntView<NotEqualConst>(engine, _intermediate, 0));
     }
   }
 }
@@ -39,6 +40,6 @@ void invariantgraph::ArrayBoolOrNode::registerWithEngine(Engine& engine) {
                  std::back_inserter(inputs),
                  [&](const auto& node) { return node->varId(); });
 
-  engine.makeInvariant<Exists>(!shouldHold() ? _intermediate : violationVarId(),
-                               inputs);
+  engine.makeInvariant<Exists>(
+      engine, !shouldHold() ? _intermediate : violationVarId(), inputs);
 }

--- a/src/invariantgraph/constraints/arrayBoolXorNode.cpp
+++ b/src/invariantgraph/constraints/arrayBoolXorNode.cpp
@@ -24,10 +24,12 @@ void invariantgraph::ArrayBoolXorNode::createDefinedVariables(Engine& engine) {
   if (violationVarId() == NULL_ID) {
     _intermediate = engine.makeIntVar(0, 0, 0);
     if (shouldHold()) {
-      setViolationVarId(engine.makeIntView<EqualConst>(_intermediate, 1));
+      setViolationVarId(
+          engine.makeIntView<EqualConst>(engine, _intermediate, 1));
     } else {
       assert(!isReified());
-      setViolationVarId(engine.makeIntView<NotEqualConst>(_intermediate, 1));
+      setViolationVarId(
+          engine.makeIntView<NotEqualConst>(engine, _intermediate, 1));
     }
   }
 }
@@ -39,5 +41,5 @@ void invariantgraph::ArrayBoolXorNode::registerWithEngine(Engine& engine) {
                  std::back_inserter(inputs),
                  [&](const auto& node) { return node->varId(); });
 
-  engine.makeInvariant<BoolLinear>(_intermediate, inputs);
+  engine.makeInvariant<BoolLinear>(engine, _intermediate, inputs);
 }

--- a/src/invariantgraph/constraints/boolAndNode.cpp
+++ b/src/invariantgraph/constraints/boolAndNode.cpp
@@ -30,7 +30,8 @@ void invariantgraph::BoolAndNode::createDefinedVariables(Engine& engine) {
     } else {
       assert(!isReified());
       _intermediate = engine.makeIntVar(0, 0, 0);
-      setViolationVarId(engine.makeIntView<NotEqualConst>(_intermediate, 0));
+      setViolationVarId(
+          engine.makeIntView<NotEqualConst>(engine, _intermediate, 0));
     }
   }
 }
@@ -40,5 +41,6 @@ void invariantgraph::BoolAndNode::registerWithEngine(Engine& engine) {
   assert(a()->varId() != NULL_ID);
   assert(b()->varId() != NULL_ID);
 
-  engine.makeInvariant<BoolAnd>(violationVarId(), a()->varId(), b()->varId());
+  engine.makeInvariant<BoolAnd>(engine, violationVarId(), a()->varId(),
+                                b()->varId());
 }

--- a/src/invariantgraph/constraints/boolClauseNode.cpp
+++ b/src/invariantgraph/constraints/boolClauseNode.cpp
@@ -31,12 +31,12 @@ void invariantgraph::BoolClauseNode::createDefinedVariables(Engine& engine) {
     _sumVarId = engine.makeIntVar(0, 0, 0);
     if (shouldHold()) {
       setViolationVarId(engine.makeIntView<EqualConst>(
-          _sumVarId,
+          engine, _sumVarId,
           static_cast<Int>(_as.size()) + static_cast<Int>(_bs.size())));
     } else {
       assert(!isReified());
       setViolationVarId(engine.makeIntView<NotEqualConst>(
-          _sumVarId,
+          engine, _sumVarId,
           static_cast<Int>(_as.size()) + static_cast<Int>(_bs.size())));
     }
   }
@@ -50,10 +50,11 @@ void invariantgraph::BoolClauseNode::registerWithEngine(Engine& engine) {
 
   std::transform(_bs.begin(), _bs.end(), std::back_inserter(engineVariables),
                  [&](const auto& var) {
-                   return engine.makeIntView<NotEqualConst>(var->varId(), 0);
+                   return engine.makeIntView<NotEqualConst>(engine,
+                                                            var->varId(), 0);
                  });
 
   assert(_sumVarId != NULL_ID);
   assert(violationVarId() != NULL_ID);
-  engine.makeInvariant<BoolLinear>(_sumVarId, engineVariables);
+  engine.makeInvariant<BoolLinear>(engine, _sumVarId, engineVariables);
 }

--- a/src/invariantgraph/constraints/boolEqNode.cpp
+++ b/src/invariantgraph/constraints/boolEqNode.cpp
@@ -33,9 +33,10 @@ void invariantgraph::BoolEqNode::registerWithEngine(Engine& engine) {
   assert(b()->varId() != NULL_ID);
 
   if (shouldHold()) {
-    engine.makeConstraint<BoolEqual>(violationVarId(), a()->varId(),
+    engine.makeConstraint<BoolEqual>(engine, violationVarId(), a()->varId(),
                                      b()->varId());
   } else {
-    engine.makeInvariant<BoolXor>(violationVarId(), a()->varId(), b()->varId());
+    engine.makeInvariant<BoolXor>(engine, violationVarId(), a()->varId(),
+                                  b()->varId());
   }
 }

--- a/src/invariantgraph/constraints/boolLeNode.cpp
+++ b/src/invariantgraph/constraints/boolLeNode.cpp
@@ -33,11 +33,11 @@ void invariantgraph::BoolLeNode::registerWithEngine(Engine& engine) {
   assert(b()->varId() != NULL_ID);
 
   if (shouldHold()) {
-    engine.makeConstraint<BoolLessEqual>(violationVarId(), a()->varId(),
+    engine.makeConstraint<BoolLessEqual>(engine, violationVarId(), a()->varId(),
                                          b()->varId());
   } else {
     assert(!isReified());
-    engine.makeConstraint<BoolLessThan>(violationVarId(), b()->varId(),
+    engine.makeConstraint<BoolLessThan>(engine, violationVarId(), b()->varId(),
                                         a()->varId());
   }
 }

--- a/src/invariantgraph/constraints/boolLinEqNode.cpp
+++ b/src/invariantgraph/constraints/boolLinEqNode.cpp
@@ -30,9 +30,10 @@ void invariantgraph::BoolLinEqNode::createDefinedVariables(Engine& engine) {
   if (violationVarId() == NULL_ID) {
     _sumVarId = engine.makeIntVar(0, 0, 0);
     if (shouldHold()) {
-      setViolationVarId(engine.makeIntView<EqualConst>(_sumVarId, _c));
+      setViolationVarId(engine.makeIntView<EqualConst>(engine, _sumVarId, _c));
     } else {
-      setViolationVarId(engine.makeIntView<NotEqualConst>(_sumVarId, _c));
+      setViolationVarId(
+          engine.makeIntView<NotEqualConst>(engine, _sumVarId, _c));
     }
   }
 }
@@ -46,5 +47,5 @@ void invariantgraph::BoolLinEqNode::registerWithEngine(Engine& engine) {
   assert(_sumVarId != NULL_ID);
   assert(violationVarId() != NULL_ID);
 
-  engine.makeInvariant<BoolLinear>(_sumVarId, _coeffs, variables);
+  engine.makeInvariant<BoolLinear>(engine, _sumVarId, _coeffs, variables);
 }

--- a/src/invariantgraph/constraints/boolLinLeNode.cpp
+++ b/src/invariantgraph/constraints/boolLinLeNode.cpp
@@ -30,11 +30,12 @@ void invariantgraph::BoolLinLeNode::createDefinedVariables(Engine& engine) {
   if (violationVarId() == NULL_ID) {
     _sumVarId = engine.makeIntVar(0, 0, 0);
     if (shouldHold()) {
-      setViolationVarId(engine.makeIntView<LessEqualConst>(_sumVarId, _bound));
+      setViolationVarId(
+          engine.makeIntView<LessEqualConst>(engine, _sumVarId, _bound));
     } else {
       assert(!isReified());
       setViolationVarId(
-          engine.makeIntView<GreaterEqualConst>(_sumVarId, _bound + 1));
+          engine.makeIntView<GreaterEqualConst>(engine, _sumVarId, _bound + 1));
     }
   }
 }
@@ -48,5 +49,5 @@ void invariantgraph::BoolLinLeNode::registerWithEngine(Engine& engine) {
   assert(_sumVarId != NULL_ID);
   assert(violationVarId() != NULL_ID);
 
-  engine.makeInvariant<BoolLinear>(_sumVarId, _coeffs, variables);
+  engine.makeInvariant<BoolLinear>(engine, _sumVarId, _coeffs, variables);
 }

--- a/src/invariantgraph/constraints/boolLtNode.cpp
+++ b/src/invariantgraph/constraints/boolLtNode.cpp
@@ -33,11 +33,11 @@ void invariantgraph::BoolLtNode::registerWithEngine(Engine& engine) {
   assert(b()->varId() != NULL_ID);
 
   if (shouldHold()) {
-    engine.makeConstraint<BoolLessThan>(violationVarId(), a()->varId(),
+    engine.makeConstraint<BoolLessThan>(engine, violationVarId(), a()->varId(),
                                         b()->varId());
   } else {
     assert(!isReified());
-    engine.makeConstraint<BoolLessEqual>(violationVarId(), b()->varId(),
+    engine.makeConstraint<BoolLessEqual>(engine, violationVarId(), b()->varId(),
                                          a()->varId());
   }
 }

--- a/src/invariantgraph/constraints/boolOrNode.cpp
+++ b/src/invariantgraph/constraints/boolOrNode.cpp
@@ -30,7 +30,8 @@ void invariantgraph::BoolOrNode::createDefinedVariables(Engine& engine) {
     } else {
       assert(!isReified());
       _intermediate = engine.makeIntVar(0, 0, 0);
-      setViolationVarId(engine.makeIntView<NotEqualConst>(_intermediate, 0));
+      setViolationVarId(
+          engine.makeIntView<NotEqualConst>(engine, _intermediate, 0));
     }
   }
 }
@@ -38,5 +39,6 @@ void invariantgraph::BoolOrNode::createDefinedVariables(Engine& engine) {
 void invariantgraph::BoolOrNode::registerWithEngine(Engine& engine) {
   assert(violationVarId() != NULL_ID);
 
-  engine.makeInvariant<BoolOr>(violationVarId(), a()->varId(), b()->varId());
+  engine.makeInvariant<BoolOr>(engine, violationVarId(), a()->varId(),
+                               b()->varId());
 }

--- a/src/invariantgraph/constraints/boolXorNode.cpp
+++ b/src/invariantgraph/constraints/boolXorNode.cpp
@@ -31,10 +31,11 @@ void invariantgraph::BoolXorNode::registerWithEngine(Engine& engine) {
   assert(violationVarId() != NULL_ID);
 
   if (shouldHold()) {
-    engine.makeInvariant<BoolXor>(violationVarId(), a()->varId(), b()->varId());
+    engine.makeInvariant<BoolXor>(engine, violationVarId(), a()->varId(),
+                                  b()->varId());
   } else {
     assert(!isReified());
-    engine.makeConstraint<BoolEqual>(violationVarId(), a()->varId(),
+    engine.makeConstraint<BoolEqual>(engine, violationVarId(), a()->varId(),
                                      b()->varId());
   }
 }

--- a/src/invariantgraph/constraints/countEqNode.cpp
+++ b/src/invariantgraph/constraints/countEqNode.cpp
@@ -82,11 +82,11 @@ void invariantgraph::CountEqNode::createDefinedVariables(Engine& engine) {
     _intermediate = engine.makeIntVar(0, 0, 0);
     if (shouldHold()) {
       setViolationVarId(
-          engine.makeIntView<EqualConst>(_intermediate, _cParameter));
+          engine.makeIntView<EqualConst>(engine, _intermediate, _cParameter));
     } else {
       assert(!isReified());
-      setViolationVarId(
-          engine.makeIntView<NotEqualConst>(_intermediate, _cParameter));
+      setViolationVarId(engine.makeIntView<NotEqualConst>(engine, _intermediate,
+                                                          _cParameter));
     }
   }
 }
@@ -110,7 +110,7 @@ void invariantgraph::CountEqNode::registerWithEngine(Engine& engine) {
     assert(_cIsParameter == (_intermediate != NULL_ID));
     assert(_cIsParameter == (violationVarId() != NULL_ID));
     engine.makeInvariant<Count>(
-        _cIsParameter ? _intermediate : cVarNode()->varId(),
+        engine, _cIsParameter ? _intermediate : cVarNode()->varId(),
         yVarNode()->varId(), engineInputs);
     return;
   }
@@ -121,7 +121,7 @@ void invariantgraph::CountEqNode::registerWithEngine(Engine& engine) {
     assert(!isReified());
     assert(cVarNode() != nullptr);
     assert(cVarNode()->varId() != NULL_ID);
-    engine.makeInvariant<CountConst>(cVarNode()->varId(), _yParameter,
+    engine.makeInvariant<CountConst>(engine, cVarNode()->varId(), _yParameter,
                                      engineInputs);
     return;
   }
@@ -129,5 +129,6 @@ void invariantgraph::CountEqNode::registerWithEngine(Engine& engine) {
   assert(violationVarId() != NULL_ID);
   assert(_intermediate != NULL_ID);
   assert(cVarNode() == nullptr);
-  engine.makeInvariant<CountConst>(_intermediate, _yParameter, engineInputs);
+  engine.makeInvariant<CountConst>(engine, _intermediate, _yParameter,
+                                   engineInputs);
 }

--- a/src/invariantgraph/constraints/countGeqNode.cpp
+++ b/src/invariantgraph/constraints/countGeqNode.cpp
@@ -71,12 +71,12 @@ void invariantgraph::CountGeqNode::createDefinedVariables(Engine& engine) {
       registerViolation(engine);
     } else {
       if (shouldHold()) {
-        setViolationVarId(
-            engine.makeIntView<GreaterEqualConst>(_intermediate, _cParameter));
+        setViolationVarId(engine.makeIntView<GreaterEqualConst>(
+            engine, _intermediate, _cParameter));
       } else {
         assert(!isReified());
-        setViolationVarId(
-            engine.makeIntView<LessEqualConst>(_intermediate, _cParameter + 1));
+        setViolationVarId(engine.makeIntView<LessEqualConst>(
+            engine, _intermediate, _cParameter + 1));
       }
     }
   }
@@ -102,22 +102,23 @@ void invariantgraph::CountGeqNode::registerWithEngine(Engine& engine) {
   if (!_yIsParameter) {
     assert(yVarNode() != nullptr);
     assert(yVarNode()->varId() != NULL_ID);
-    engine.makeInvariant<Count>(_intermediate, yVarNode()->varId(),
+    engine.makeInvariant<Count>(engine, _intermediate, yVarNode()->varId(),
                                 engineInputs);
   } else {
     assert(yVarNode() == nullptr);
-    engine.makeInvariant<CountConst>(_intermediate, _yParameter, engineInputs);
+    engine.makeInvariant<CountConst>(engine, _intermediate, _yParameter,
+                                     engineInputs);
   }
   if (!_cIsParameter) {
     assert(cVarNode() != nullptr);
     assert(cVarNode()->varId() != NULL_ID);
     if (shouldHold()) {
       // c >= count(inputs, y) -> count(inputs, y) <= c
-      engine.makeInvariant<LessEqual>(violationVarId(), _intermediate,
+      engine.makeInvariant<LessEqual>(engine, violationVarId(), _intermediate,
                                       cVarNode()->varId());
     } else {
-      engine.makeInvariant<LessThan>(violationVarId(), cVarNode()->varId(),
-                                     _intermediate);
+      engine.makeInvariant<LessThan>(engine, violationVarId(),
+                                     cVarNode()->varId(), _intermediate);
     }
   }
 }

--- a/src/invariantgraph/constraints/countGtNode.cpp
+++ b/src/invariantgraph/constraints/countGtNode.cpp
@@ -68,11 +68,11 @@ void invariantgraph::CountGtNode::createDefinedVariables(Engine& engine) {
     } else {
       if (shouldHold()) {
         setViolationVarId(engine.makeIntView<GreaterEqualConst>(
-            _intermediate, _cParameter + 1));
+            engine, _intermediate, _cParameter + 1));
       } else {
         assert(!isReified());
-        setViolationVarId(
-            engine.makeIntView<LessEqualConst>(_intermediate, _cParameter));
+        setViolationVarId(engine.makeIntView<LessEqualConst>(
+            engine, _intermediate, _cParameter));
       }
     }
   }
@@ -98,22 +98,23 @@ void invariantgraph::CountGtNode::registerWithEngine(Engine& engine) {
   if (!_yIsParameter) {
     assert(yVarNode() != nullptr);
     assert(yVarNode()->varId() != NULL_ID);
-    engine.makeInvariant<Count>(_intermediate, yVarNode()->varId(),
+    engine.makeInvariant<Count>(engine, _intermediate, yVarNode()->varId(),
                                 engineInputs);
   } else {
     assert(yVarNode() == nullptr);
-    engine.makeInvariant<CountConst>(_intermediate, _yParameter, engineInputs);
+    engine.makeInvariant<CountConst>(engine, _intermediate, _yParameter,
+                                     engineInputs);
   }
   if (!_cIsParameter) {
     assert(cVarNode() != nullptr);
     assert(cVarNode()->varId() != NULL_ID);
     if (shouldHold()) {
       // c > count(x, y) -> count(x, y) < c
-      engine.makeInvariant<LessThan>(violationVarId(), _intermediate,
+      engine.makeInvariant<LessThan>(engine, violationVarId(), _intermediate,
                                      cVarNode()->varId());
     } else {
-      engine.makeInvariant<LessEqual>(violationVarId(), cVarNode()->varId(),
-                                      _intermediate);
+      engine.makeInvariant<LessEqual>(engine, violationVarId(),
+                                      cVarNode()->varId(), _intermediate);
     }
   }
 }

--- a/src/invariantgraph/constraints/countLeqNode.cpp
+++ b/src/invariantgraph/constraints/countLeqNode.cpp
@@ -67,12 +67,12 @@ void invariantgraph::CountLeqNode::createDefinedVariables(Engine& engine) {
       registerViolation(engine);
     } else {
       if (shouldHold()) {
-        setViolationVarId(
-            engine.makeIntView<LessEqualConst>(_intermediate, _cParameter));
+        setViolationVarId(engine.makeIntView<LessEqualConst>(
+            engine, _intermediate, _cParameter));
       } else {
         assert(!isReified());
         setViolationVarId(engine.makeIntView<GreaterEqualConst>(
-            _intermediate, _cParameter + 1));
+            engine, _intermediate, _cParameter + 1));
       }
     }
   }
@@ -98,21 +98,22 @@ void invariantgraph::CountLeqNode::registerWithEngine(Engine& engine) {
   if (!_yIsParameter) {
     assert(yVarNode() != nullptr);
     assert(yVarNode()->varId() != NULL_ID);
-    engine.makeInvariant<Count>(_intermediate, yVarNode()->varId(),
+    engine.makeInvariant<Count>(engine, _intermediate, yVarNode()->varId(),
                                 engineInputs);
   } else {
     assert(yVarNode() == nullptr);
-    engine.makeInvariant<CountConst>(_intermediate, _yParameter, engineInputs);
+    engine.makeInvariant<CountConst>(engine, _intermediate, _yParameter,
+                                     engineInputs);
   }
   if (!_cIsParameter) {
     assert(cVarNode() != nullptr);
     assert(cVarNode()->varId() != NULL_ID);
     if (shouldHold()) {
-      engine.makeInvariant<LessEqual>(violationVarId(), cVarNode()->varId(),
-                                      _intermediate);
+      engine.makeInvariant<LessEqual>(engine, violationVarId(),
+                                      cVarNode()->varId(), _intermediate);
     } else {
       // c > count(x, y) -> count(x, y) < c
-      engine.makeInvariant<LessThan>(violationVarId(), _intermediate,
+      engine.makeInvariant<LessThan>(engine, violationVarId(), _intermediate,
                                      cVarNode()->varId());
     }
   }

--- a/src/invariantgraph/constraints/countLtNode.cpp
+++ b/src/invariantgraph/constraints/countLtNode.cpp
@@ -67,12 +67,12 @@ void invariantgraph::CountLtNode::createDefinedVariables(Engine& engine) {
       registerViolation(engine);
     } else {
       if (shouldHold()) {
-        setViolationVarId(
-            engine.makeIntView<LessEqualConst>(_intermediate, _cParameter - 1));
+        setViolationVarId(engine.makeIntView<LessEqualConst>(
+            engine, _intermediate, _cParameter - 1));
       } else {
         assert(!isReified());
-        setViolationVarId(
-            engine.makeIntView<GreaterEqualConst>(_intermediate, _cParameter));
+        setViolationVarId(engine.makeIntView<GreaterEqualConst>(
+            engine, _intermediate, _cParameter));
       }
     }
   }
@@ -98,21 +98,22 @@ void invariantgraph::CountLtNode::registerWithEngine(Engine& engine) {
   if (!_yIsParameter) {
     assert(yVarNode() != nullptr);
     assert(yVarNode()->varId() != NULL_ID);
-    engine.makeInvariant<Count>(_intermediate, yVarNode()->varId(),
+    engine.makeInvariant<Count>(engine, _intermediate, yVarNode()->varId(),
                                 engineInputs);
   } else {
     assert(yVarNode() == nullptr);
-    engine.makeInvariant<CountConst>(_intermediate, _yParameter, engineInputs);
+    engine.makeInvariant<CountConst>(engine, _intermediate, _yParameter,
+                                     engineInputs);
   }
   if (!_cIsParameter) {
     assert(cVarNode() != nullptr);
     assert(cVarNode()->varId() != NULL_ID);
     if (shouldHold()) {
-      engine.makeInvariant<LessThan>(violationVarId(), cVarNode()->varId(),
-                                     _intermediate);
+      engine.makeInvariant<LessThan>(engine, violationVarId(),
+                                     cVarNode()->varId(), _intermediate);
     } else {
       // c >= count(x, y) -> count(x, y) <= c
-      engine.makeInvariant<LessEqual>(violationVarId(), _intermediate,
+      engine.makeInvariant<LessEqual>(engine, violationVarId(), _intermediate,
                                       cVarNode()->varId());
     }
   }

--- a/src/invariantgraph/constraints/countNeqNode.cpp
+++ b/src/invariantgraph/constraints/countNeqNode.cpp
@@ -67,12 +67,12 @@ void invariantgraph::CountNeqNode::createDefinedVariables(Engine& engine) {
       registerViolation(engine);
     } else {
       if (shouldHold()) {
-        setViolationVarId(
-            engine.makeIntView<NotEqualConst>(_intermediate, _cParameter - 1));
+        setViolationVarId(engine.makeIntView<NotEqualConst>(
+            engine, _intermediate, _cParameter - 1));
       } else {
         assert(!isReified());
-        setViolationVarId(
-            engine.makeIntView<EqualConst>(_intermediate, _cParameter + 1));
+        setViolationVarId(engine.makeIntView<EqualConst>(engine, _intermediate,
+                                                         _cParameter + 1));
       }
     }
   }
@@ -98,21 +98,22 @@ void invariantgraph::CountNeqNode::registerWithEngine(Engine& engine) {
   if (!_yIsParameter) {
     assert(yVarNode() != nullptr);
     assert(yVarNode()->varId() != NULL_ID);
-    engine.makeInvariant<Count>(_intermediate, yVarNode()->varId(),
+    engine.makeInvariant<Count>(engine, _intermediate, yVarNode()->varId(),
                                 engineInputs);
   } else {
     assert(yVarNode() == nullptr);
-    engine.makeInvariant<CountConst>(_intermediate, _yParameter, engineInputs);
+    engine.makeInvariant<CountConst>(engine, _intermediate, _yParameter,
+                                     engineInputs);
   }
   if (!_cIsParameter) {
     assert(cVarNode() != nullptr);
     assert(cVarNode()->varId() != NULL_ID);
     if (shouldHold()) {
-      engine.makeInvariant<NotEqual>(violationVarId(), cVarNode()->varId(),
-                                     _intermediate);
+      engine.makeInvariant<NotEqual>(engine, violationVarId(),
+                                     cVarNode()->varId(), _intermediate);
     } else {
       // c >= count(x, y) -> count(x, y) <= c
-      engine.makeInvariant<Equal>(violationVarId(), _intermediate,
+      engine.makeInvariant<Equal>(engine, violationVarId(), _intermediate,
                                   cVarNode()->varId());
     }
   }

--- a/src/invariantgraph/constraints/globalCardinalityLowUpClosedNode.cpp
+++ b/src/invariantgraph/constraints/globalCardinalityLowUpClosedNode.cpp
@@ -44,7 +44,8 @@ void invariantgraph::GlobalCardinalityLowUpClosedNode::createDefinedVariables(
   if (violationVarId() == NULL_ID) {
     if (!shouldHold()) {
       _intermediate = engine.makeIntVar(0, 0, staticInputs().size());
-      setViolationVarId(engine.makeIntView<NotEqualConst>(_intermediate, 0));
+      setViolationVarId(
+          engine.makeIntView<NotEqualConst>(engine, _intermediate, 0));
     } else {
       registerViolation(engine);
     }
@@ -59,10 +60,10 @@ void invariantgraph::GlobalCardinalityLowUpClosedNode::registerWithEngine(
                  [&](auto node) { return node->varId(); });
 
   if (shouldHold()) {
-    engine.makeInvariant<GlobalCardinalityConst<true>>(violationVarId(), inputs,
-                                                       _cover, _low, _up);
+    engine.makeInvariant<GlobalCardinalityConst<true>>(
+        engine, violationVarId(), inputs, _cover, _low, _up);
   } else {
-    engine.makeInvariant<GlobalCardinalityConst<true>>(_intermediate, inputs,
-                                                       _cover, _low, _up);
+    engine.makeInvariant<GlobalCardinalityConst<true>>(
+        engine, _intermediate, inputs, _cover, _low, _up);
   }
 }

--- a/src/invariantgraph/constraints/globalCardinalityLowUpNode.cpp
+++ b/src/invariantgraph/constraints/globalCardinalityLowUpNode.cpp
@@ -43,7 +43,8 @@ void invariantgraph::GlobalCardinalityLowUpNode::createDefinedVariables(
   if (violationVarId() == NULL_ID) {
     if (!shouldHold()) {
       _intermediate = engine.makeIntVar(0, 0, staticInputs().size());
-      setViolationVarId(engine.makeIntView<NotEqualConst>(_intermediate, 0));
+      setViolationVarId(
+          engine.makeIntView<NotEqualConst>(engine, _intermediate, 0));
     } else {
       registerViolation(engine);
     }
@@ -59,9 +60,9 @@ void invariantgraph::GlobalCardinalityLowUpNode::registerWithEngine(
 
   if (shouldHold()) {
     engine.makeInvariant<GlobalCardinalityConst<false>>(
-        violationVarId(), inputs, _cover, _low, _up);
+        engine, violationVarId(), inputs, _cover, _low, _up);
   } else {
-    engine.makeInvariant<GlobalCardinalityConst<false>>(_intermediate, inputs,
-                                                        _cover, _low, _up);
+    engine.makeInvariant<GlobalCardinalityConst<false>>(
+        engine, _intermediate, inputs, _cover, _low, _up);
   }
 }

--- a/src/invariantgraph/constraints/globalCardinalityNode.cpp
+++ b/src/invariantgraph/constraints/globalCardinalityNode.cpp
@@ -72,29 +72,33 @@ void invariantgraph::GlobalCardinalityNode::registerWithEngine(Engine& engine) {
                    std::back_inserter(countOutputs),
                    [&](auto node) { return node->varId(); });
 
-    engine.makeInvariant<GlobalCardinalityOpen>(countOutputs, inputs, _cover);
+    engine.makeInvariant<GlobalCardinalityOpen>(engine, countOutputs, inputs,
+                                                _cover);
   } else {
     assert(violationVarId() != NULL_ID);
     assert(_intermediate.size() == _counts.size());
     assert(_violations.size() == _counts.size());
-    engine.makeInvariant<GlobalCardinalityOpen>(_intermediate, inputs, _cover);
+    engine.makeInvariant<GlobalCardinalityOpen>(engine, _intermediate, inputs,
+                                                _cover);
     for (size_t i = 0; i < _counts.size(); ++i) {
       if (shouldHold()) {
-        engine.makeConstraint<Equal>(_violations.at(i), _intermediate.at(i),
+        engine.makeConstraint<Equal>(engine, _violations.at(i),
+                                     _intermediate.at(i),
                                      _counts.at(i)->varId());
       } else {
-        engine.makeConstraint<NotEqual>(_violations.at(i), _intermediate.at(i),
+        engine.makeConstraint<NotEqual>(engine, _violations.at(i),
+                                        _intermediate.at(i),
                                         _counts.at(i)->varId());
       }
     }
     if (_counts.size() > 1) {
       if (shouldHold()) {
         // To hold, each count must be equal to its corresponding intermediate:
-        engine.makeInvariant<Linear>(violationVarId(), _violations);
+        engine.makeInvariant<Linear>(engine, violationVarId(), _violations);
       } else {
         // To hold, only one count must not be equal to its corresponding
         // intermediate:
-        engine.makeInvariant<Exists>(violationVarId(), _violations);
+        engine.makeInvariant<Exists>(engine, violationVarId(), _violations);
       }
     }
   }

--- a/src/invariantgraph/constraints/intEqNode.cpp
+++ b/src/invariantgraph/constraints/intEqNode.cpp
@@ -33,10 +33,11 @@ void invariantgraph::IntEqNode::registerWithEngine(Engine& engine) {
   assert(b()->varId() != NULL_ID);
 
   if (shouldHold()) {
-    engine.makeConstraint<Equal>(violationVarId(), a()->varId(), b()->varId());
+    engine.makeConstraint<Equal>(engine, violationVarId(), a()->varId(),
+                                 b()->varId());
   } else {
     assert(!isReified());
-    engine.makeConstraint<NotEqual>(violationVarId(), a()->varId(),
+    engine.makeConstraint<NotEqual>(engine, violationVarId(), a()->varId(),
                                     b()->varId());
   }
 }

--- a/src/invariantgraph/constraints/intLeNode.cpp
+++ b/src/invariantgraph/constraints/intLeNode.cpp
@@ -31,11 +31,11 @@ void invariantgraph::IntLeNode::registerWithEngine(Engine& engine) {
   assert(violationVarId() != NULL_ID);
 
   if (shouldHold()) {
-    engine.makeConstraint<LessEqual>(violationVarId(), a()->varId(),
+    engine.makeConstraint<LessEqual>(engine, violationVarId(), a()->varId(),
                                      b()->varId());
   } else {
     assert(!isReified());
-    engine.makeConstraint<LessThan>(violationVarId(), b()->varId(),
+    engine.makeConstraint<LessThan>(engine, violationVarId(), b()->varId(),
                                     a()->varId());
   }
 }

--- a/src/invariantgraph/constraints/intLinEqNode.cpp
+++ b/src/invariantgraph/constraints/intLinEqNode.cpp
@@ -30,10 +30,11 @@ void invariantgraph::IntLinEqNode::createDefinedVariables(Engine& engine) {
   if (violationVarId() == NULL_ID) {
     _sumVarId = engine.makeIntVar(0, 0, 0);
     if (shouldHold()) {
-      setViolationVarId(engine.makeIntView<EqualConst>(_sumVarId, _c));
+      setViolationVarId(engine.makeIntView<EqualConst>(engine, _sumVarId, _c));
     } else {
       assert(!isReified());
-      setViolationVarId(engine.makeIntView<NotEqualConst>(_sumVarId, _c));
+      setViolationVarId(
+          engine.makeIntView<NotEqualConst>(engine, _sumVarId, _c));
     }
   }
 }
@@ -47,5 +48,5 @@ void invariantgraph::IntLinEqNode::registerWithEngine(Engine& engine) {
   assert(_sumVarId != NULL_ID);
   assert(violationVarId() != NULL_ID);
 
-  engine.makeInvariant<Linear>(_sumVarId, _coeffs, variables);
+  engine.makeInvariant<Linear>(engine, _sumVarId, _coeffs, variables);
 }

--- a/src/invariantgraph/constraints/intLinLeNode.cpp
+++ b/src/invariantgraph/constraints/intLinLeNode.cpp
@@ -30,11 +30,12 @@ void invariantgraph::IntLinLeNode::createDefinedVariables(Engine& engine) {
   if (violationVarId() == NULL_ID) {
     _sumVarId = engine.makeIntVar(0, 0, 0);
     if (shouldHold()) {
-      setViolationVarId(engine.makeIntView<LessEqualConst>(_sumVarId, _bound));
+      setViolationVarId(
+          engine.makeIntView<LessEqualConst>(engine, _sumVarId, _bound));
     } else {
       assert(!isReified());
       setViolationVarId(
-          engine.makeIntView<GreaterEqualConst>(_sumVarId, _bound + 1));
+          engine.makeIntView<GreaterEqualConst>(engine, _sumVarId, _bound + 1));
     }
   }
 }
@@ -48,5 +49,5 @@ void invariantgraph::IntLinLeNode::registerWithEngine(Engine& engine) {
   assert(_sumVarId != NULL_ID);
   assert(violationVarId() != NULL_ID);
 
-  engine.makeInvariant<Linear>(_sumVarId, _coeffs, variables);
+  engine.makeInvariant<Linear>(engine, _sumVarId, _coeffs, variables);
 }

--- a/src/invariantgraph/constraints/intLinNeNode.cpp
+++ b/src/invariantgraph/constraints/intLinNeNode.cpp
@@ -29,10 +29,11 @@ void invariantgraph::IntLinNeNode::createDefinedVariables(Engine& engine) {
   if (_sumVarId == NULL_ID) {
     _sumVarId = engine.makeIntVar(0, 0, 0);
     if (shouldHold()) {
-      setViolationVarId(engine.makeIntView<NotEqualConst>(_sumVarId, _c));
+      setViolationVarId(
+          engine.makeIntView<NotEqualConst>(engine, _sumVarId, _c));
     } else {
       assert(!isReified());
-      setViolationVarId(engine.makeIntView<EqualConst>(_sumVarId, _c));
+      setViolationVarId(engine.makeIntView<EqualConst>(engine, _sumVarId, _c));
     }
   }
 }
@@ -46,5 +47,5 @@ void invariantgraph::IntLinNeNode::registerWithEngine(Engine& engine) {
   assert(_sumVarId != NULL_ID);
   assert(violationVarId() != NULL_ID);
 
-  engine.makeInvariant<Linear>(_sumVarId, _coeffs, variables);
+  engine.makeInvariant<Linear>(engine, _sumVarId, _coeffs, variables);
 }

--- a/src/invariantgraph/constraints/intLtNode.cpp
+++ b/src/invariantgraph/constraints/intLtNode.cpp
@@ -31,11 +31,11 @@ void invariantgraph::IntLtNode::registerWithEngine(Engine& engine) {
   assert(violationVarId() != NULL_ID);
 
   if (shouldHold()) {
-    engine.makeConstraint<LessThan>(violationVarId(), a()->varId(),
+    engine.makeConstraint<LessThan>(engine, violationVarId(), a()->varId(),
                                     b()->varId());
   } else {
     assert(!isReified());
-    engine.makeConstraint<LessEqual>(violationVarId(), b()->varId(),
+    engine.makeConstraint<LessEqual>(engine, violationVarId(), b()->varId(),
                                      a()->varId());
   }
 }

--- a/src/invariantgraph/constraints/intNeNode.cpp
+++ b/src/invariantgraph/constraints/intNeNode.cpp
@@ -31,10 +31,11 @@ void invariantgraph::IntNeNode::registerWithEngine(Engine& engine) {
   assert(violationVarId() != NULL_ID);
 
   if (shouldHold()) {
-    engine.makeConstraint<NotEqual>(violationVarId(), a()->varId(),
+    engine.makeConstraint<NotEqual>(engine, violationVarId(), a()->varId(),
                                     b()->varId());
   } else {
     assert(!isReified());
-    engine.makeConstraint<Equal>(violationVarId(), a()->varId(), b()->varId());
+    engine.makeConstraint<Equal>(engine, violationVarId(), a()->varId(),
+                                 b()->varId());
   }
 }

--- a/src/invariantgraph/constraints/setInNode.cpp
+++ b/src/invariantgraph/constraints/setInNode.cpp
@@ -50,11 +50,12 @@ void invariantgraph::SetInNode::createDefinedVariables(Engine& engine) {
     if (!shouldHold()) {
       assert(!isReified());
       _intermediate =
-          engine.makeIntView<InDomain>(input, std::move(domainEntries));
-      setViolationVarId(engine.makeIntView<NotEqualConst>(_intermediate, 0));
-    } else {
+          engine.makeIntView<InDomain>(engine, input, std::move(domainEntries));
       setViolationVarId(
-          engine.makeIntView<InDomain>(input, std::move(domainEntries)));
+          engine.makeIntView<NotEqualConst>(engine, _intermediate, 0));
+    } else {
+      setViolationVarId(engine.makeIntView<InDomain>(engine, input,
+                                                     std::move(domainEntries)));
     }
   }
 }

--- a/src/invariantgraph/invariantGraph.cpp
+++ b/src/invariantgraph/invariantGraph.cpp
@@ -360,7 +360,7 @@ VarId invariantgraph::InvariantGraph::createViolations(Engine& engine) {
     return violations.front();
   }
   const VarId totalViolation = engine.makeIntVar(0, 0, 0);
-  engine.makeInvariant<Linear>(totalViolation, violations);
+  engine.makeInvariant<Linear>(engine, totalViolation, violations);
   return totalViolation;
 }
 

--- a/src/invariantgraph/invariants/arrayIntElement2dNode.cpp
+++ b/src/invariantgraph/invariants/arrayIntElement2dNode.cpp
@@ -40,7 +40,7 @@ void invariantgraph::ArrayIntElement2dNode::createDefinedVariables(
 
 void invariantgraph::ArrayIntElement2dNode::registerWithEngine(Engine& engine) {
   assert(definedVariables().front()->varId() != NULL_ID);
-  engine.makeInvariant<Element2dConst>(definedVariables().front()->varId(),
-                                       idx1()->varId(), idx2()->varId(),
-                                       _parMatrix, _offset1, _offset2);
+  engine.makeInvariant<Element2dConst>(
+      engine, definedVariables().front()->varId(), idx1()->varId(),
+      idx2()->varId(), _parMatrix, _offset1, _offset2);
 }

--- a/src/invariantgraph/invariants/arrayIntElementNode.cpp
+++ b/src/invariantgraph/invariants/arrayIntElementNode.cpp
@@ -24,7 +24,7 @@ void invariantgraph::ArrayIntElementNode::createDefinedVariables(
   if (definedVariables().front()->varId() == NULL_ID) {
     assert(b()->varId() != NULL_ID);
     definedVariables().front()->setVarId(
-        engine.makeIntView<ElementConst>(b()->varId(), _as, _offset));
+        engine.makeIntView<ElementConst>(engine, b()->varId(), _as, _offset));
   }
 }
 

--- a/src/invariantgraph/invariants/arrayIntMaximumNode.cpp
+++ b/src/invariantgraph/invariants/arrayIntMaximumNode.cpp
@@ -30,6 +30,6 @@ void invariantgraph::ArrayIntMaximumNode::registerWithEngine(Engine& engine) {
                  [&](const auto& node) { return node->varId(); });
 
   assert(definedVariables().front()->varId() != NULL_ID);
-  engine.makeInvariant<MaxSparse>(definedVariables().front()->varId(),
+  engine.makeInvariant<MaxSparse>(engine, definedVariables().front()->varId(),
                                   variables);
 }

--- a/src/invariantgraph/invariants/arrayIntMinimumNode.cpp
+++ b/src/invariantgraph/invariants/arrayIntMinimumNode.cpp
@@ -30,6 +30,6 @@ void invariantgraph::ArrayIntMinimumNode::registerWithEngine(Engine& engine) {
                  [&](const auto& node) { return node->varId(); });
 
   assert(definedVariables().front()->varId() != NULL_ID);
-  engine.makeInvariant<MinSparse>(definedVariables().front()->varId(),
+  engine.makeInvariant<MinSparse>(engine, definedVariables().front()->varId(),
                                   variables);
 }

--- a/src/invariantgraph/invariants/arrayVarBoolElement2dNode.cpp
+++ b/src/invariantgraph/invariants/arrayVarBoolElement2dNode.cpp
@@ -41,7 +41,7 @@ void invariantgraph::ArrayVarBoolElement2dNode::registerWithEngine(
   }
 
   assert(definedVariables().front()->varId() != NULL_ID);
-  engine.makeInvariant<Element2dVar>(definedVariables().front()->varId(),
-                                     idx1()->varId(), idx2()->varId(),
-                                     varMatrix, _offset1, _offset2);
+  engine.makeInvariant<Element2dVar>(
+      engine, definedVariables().front()->varId(), idx1()->varId(),
+      idx2()->varId(), varMatrix, _offset1, _offset2);
 }

--- a/src/invariantgraph/invariants/arrayVarBoolElementNode.cpp
+++ b/src/invariantgraph/invariants/arrayVarBoolElementNode.cpp
@@ -37,6 +37,6 @@ void invariantgraph::ArrayVarBoolElementNode::registerWithEngine(
                  [&](auto node) { return node->varId(); });
 
   assert(definedVariables().front()->varId() != NULL_ID);
-  engine.makeInvariant<ElementVar>(definedVariables().front()->varId(),
+  engine.makeInvariant<ElementVar>(engine, definedVariables().front()->varId(),
                                    b()->varId(), as);
 }

--- a/src/invariantgraph/invariants/arrayVarIntElement2dNode.cpp
+++ b/src/invariantgraph/invariants/arrayVarIntElement2dNode.cpp
@@ -41,7 +41,7 @@ void invariantgraph::ArrayVarIntElement2dNode::registerWithEngine(
   }
 
   assert(definedVariables().front()->varId() != NULL_ID);
-  engine.makeInvariant<Element2dVar>(definedVariables().front()->varId(),
-                                     idx1()->varId(), idx2()->varId(),
-                                     varMatrix, _offset1, _offset2);
+  engine.makeInvariant<Element2dVar>(
+      engine, definedVariables().front()->varId(), idx1()->varId(),
+      idx2()->varId(), varMatrix, _offset1, _offset2);
 }

--- a/src/invariantgraph/invariants/arrayVarIntElementNode.cpp
+++ b/src/invariantgraph/invariants/arrayVarIntElementNode.cpp
@@ -35,6 +35,6 @@ void invariantgraph::ArrayVarIntElementNode::registerWithEngine(
 
   assert(definedVariables().front()->varId() != NULL_ID);
 
-  engine.makeInvariant<ElementVar>(definedVariables().front()->varId(),
+  engine.makeInvariant<ElementVar>(engine, definedVariables().front()->varId(),
                                    b()->varId(), as, _offset);
 }

--- a/src/invariantgraph/invariants/boolLinearNode.cpp
+++ b/src/invariantgraph/invariants/boolLinearNode.cpp
@@ -65,15 +65,15 @@ void invariantgraph::BoolLinearNode::createDefinedVariables(Engine& engine) {
 
     if (_definingCoefficient == -1) {
       auto scalar = engine.makeIntView<ScalarView>(
-          staticInputs().front()->varId(), _coeffs.front());
+          engine, staticInputs().front()->varId(), _coeffs.front());
       definedVariables().front()->setVarId(
-          engine.makeIntView<IntOffsetView>(scalar, -_sum));
+          engine.makeIntView<IntOffsetView>(engine, scalar, -_sum));
     } else {
       assert(_definingCoefficient == 1);
       auto scalar = engine.makeIntView<ScalarView>(
-          staticInputs().front()->varId(), -_coeffs.front());
+          engine, staticInputs().front()->varId(), -_coeffs.front());
       definedVariables().front()->setVarId(
-          engine.makeIntView<IntOffsetView>(scalar, _sum));
+          engine.makeIntView<IntOffsetView>(engine, scalar, _sum));
     }
 
     return;
@@ -86,13 +86,13 @@ void invariantgraph::BoolLinearNode::createDefinedVariables(Engine& engine) {
     auto offsetIntermediate = _intermediateVarId;
     if (_sum != 0) {
       offsetIntermediate =
-          engine.makeIntView<IntOffsetView>(_intermediateVarId, -_sum);
+          engine.makeIntView<IntOffsetView>(engine, _intermediateVarId, -_sum);
     }
 
     auto invertedIntermediate = offsetIntermediate;
     if (_definingCoefficient == 1) {
       invertedIntermediate =
-          engine.makeIntView<ScalarView>(offsetIntermediate, -1);
+          engine.makeIntView<ScalarView>(engine, offsetIntermediate, -1);
     }
 
     definedVariables().front()->setVarId(invertedIntermediate);
@@ -111,5 +111,6 @@ void invariantgraph::BoolLinearNode::registerWithEngine(Engine& engine) {
     return;
   }
 
-  engine.makeInvariant<BoolLinear>(_intermediateVarId, _coeffs, variables);
+  engine.makeInvariant<BoolLinear>(engine, _intermediateVarId, _coeffs,
+                                   variables);
 }

--- a/src/invariantgraph/invariants/intDivNode.cpp
+++ b/src/invariantgraph/invariants/intDivNode.cpp
@@ -21,6 +21,6 @@ void invariantgraph::IntDivNode::createDefinedVariables(Engine& engine) {
 
 void invariantgraph::IntDivNode::registerWithEngine(Engine& engine) {
   assert(definedVariables().front()->varId() != NULL_ID);
-  engine.makeInvariant<IntDiv>(definedVariables().front()->varId(),
+  engine.makeInvariant<IntDiv>(engine, definedVariables().front()->varId(),
                                a()->varId(), b()->varId());
 }

--- a/src/invariantgraph/invariants/intLinearNode.cpp
+++ b/src/invariantgraph/invariants/intLinearNode.cpp
@@ -65,15 +65,15 @@ void invariantgraph::IntLinearNode::createDefinedVariables(Engine& engine) {
 
     if (_definingCoefficient == -1) {
       auto scalar = engine.makeIntView<ScalarView>(
-          staticInputs().front()->varId(), _coeffs.front());
+          engine, staticInputs().front()->varId(), _coeffs.front());
       definedVariables().front()->setVarId(
-          engine.makeIntView<IntOffsetView>(scalar, -_sum));
+          engine.makeIntView<IntOffsetView>(engine, scalar, -_sum));
     } else {
       assert(_definingCoefficient == 1);
       auto scalar = engine.makeIntView<ScalarView>(
-          staticInputs().front()->varId(), -_coeffs.front());
+          engine, staticInputs().front()->varId(), -_coeffs.front());
       definedVariables().front()->setVarId(
-          engine.makeIntView<IntOffsetView>(scalar, _sum));
+          engine.makeIntView<IntOffsetView>(engine, scalar, _sum));
     }
 
     return;
@@ -86,13 +86,13 @@ void invariantgraph::IntLinearNode::createDefinedVariables(Engine& engine) {
     auto offsetIntermediate = _intermediateVarId;
     if (_sum != 0) {
       offsetIntermediate =
-          engine.makeIntView<IntOffsetView>(_intermediateVarId, -_sum);
+          engine.makeIntView<IntOffsetView>(engine, _intermediateVarId, -_sum);
     }
 
     auto invertedIntermediate = offsetIntermediate;
     if (_definingCoefficient == 1) {
       invertedIntermediate =
-          engine.makeIntView<ScalarView>(offsetIntermediate, -1);
+          engine.makeIntView<ScalarView>(engine, offsetIntermediate, -1);
     }
 
     definedVariables().front()->setVarId(invertedIntermediate);
@@ -111,5 +111,5 @@ void invariantgraph::IntLinearNode::registerWithEngine(Engine& engine) {
     return;
   }
 
-  engine.makeInvariant<Linear>(_intermediateVarId, _coeffs, variables);
+  engine.makeInvariant<Linear>(engine, _intermediateVarId, _coeffs, variables);
 }

--- a/src/invariantgraph/invariants/intMaxNode.cpp
+++ b/src/invariantgraph/invariants/intMaxNode.cpp
@@ -21,6 +21,6 @@ void invariantgraph::IntMaxNode::createDefinedVariables(Engine& engine) {
 
 void invariantgraph::IntMaxNode::registerWithEngine(Engine& engine) {
   assert(definedVariables().front()->varId() != NULL_ID);
-  engine.makeInvariant<BinaryMax>(definedVariables().front()->varId(),
+  engine.makeInvariant<BinaryMax>(engine, definedVariables().front()->varId(),
                                   a()->varId(), b()->varId());
 }

--- a/src/invariantgraph/invariants/intMinNode.cpp
+++ b/src/invariantgraph/invariants/intMinNode.cpp
@@ -21,6 +21,6 @@ void invariantgraph::IntMinNode::createDefinedVariables(Engine& engine) {
 
 void invariantgraph::IntMinNode::registerWithEngine(Engine& engine) {
   assert(definedVariables().front()->varId() != NULL_ID);
-  engine.makeInvariant<BinaryMin>(definedVariables().front()->varId(),
+  engine.makeInvariant<BinaryMin>(engine, definedVariables().front()->varId(),
                                   a()->varId(), b()->varId());
 }

--- a/src/invariantgraph/invariants/intModNode.cpp
+++ b/src/invariantgraph/invariants/intModNode.cpp
@@ -21,6 +21,6 @@ void invariantgraph::IntModNode::createDefinedVariables(Engine& engine) {
 
 void invariantgraph::IntModNode::registerWithEngine(Engine& engine) {
   assert(definedVariables().front()->varId() != NULL_ID);
-  engine.makeInvariant<Mod>(definedVariables().front()->varId(), a()->varId(),
-                            b()->varId());
+  engine.makeInvariant<Mod>(engine, definedVariables().front()->varId(),
+                            a()->varId(), b()->varId());
 }

--- a/src/invariantgraph/invariants/intPlusNode.cpp
+++ b/src/invariantgraph/invariants/intPlusNode.cpp
@@ -21,6 +21,6 @@ void invariantgraph::IntPlusNode::createDefinedVariables(Engine& engine) {
 
 void invariantgraph::IntPlusNode::registerWithEngine(Engine& engine) {
   assert(definedVariables().front()->varId() != NULL_ID);
-  engine.makeInvariant<Plus>(definedVariables().front()->varId(), a()->varId(),
-                             b()->varId());
+  engine.makeInvariant<Plus>(engine, definedVariables().front()->varId(),
+                             a()->varId(), b()->varId());
 }

--- a/src/invariantgraph/invariants/intPowNode.cpp
+++ b/src/invariantgraph/invariants/intPowNode.cpp
@@ -21,6 +21,6 @@ void invariantgraph::IntPowNode::createDefinedVariables(Engine& engine) {
 
 void invariantgraph::IntPowNode::registerWithEngine(Engine& engine) {
   assert(definedVariables().front()->varId() != NULL_ID);
-  engine.makeInvariant<Pow>(definedVariables().front()->varId(), a()->varId(),
-                            b()->varId());
+  engine.makeInvariant<Pow>(engine, definedVariables().front()->varId(),
+                            a()->varId(), b()->varId());
 }

--- a/src/invariantgraph/invariants/intTimesNode.cpp
+++ b/src/invariantgraph/invariants/intTimesNode.cpp
@@ -21,6 +21,6 @@ void invariantgraph::IntTimesNode::createDefinedVariables(Engine& engine) {
 
 void invariantgraph::IntTimesNode::registerWithEngine(Engine& engine) {
   assert(definedVariables().front()->varId() != NULL_ID);
-  engine.makeInvariant<Times>(definedVariables().front()->varId(), a()->varId(),
-                              b()->varId());
+  engine.makeInvariant<Times>(engine, definedVariables().front()->varId(),
+                              a()->varId(), b()->varId());
 }

--- a/src/invariantgraph/variableNode.cpp
+++ b/src/invariantgraph/variableNode.cpp
@@ -76,11 +76,11 @@ VarId invariantgraph::VariableNode::postDomainConstraint(
   // domain.size() - 1 = number of "holes" in the domain:
   const float denseness = 1.0 - ((float)(domain.size() - 1) / (float)interval);
   if (SPARSE_MIN_DENSENESS <= denseness) {
-    _domainViolationId =
-        engine.makeIntView<InSparseDomain>(this->varId(), std::move(domain));
+    _domainViolationId = engine.makeIntView<InSparseDomain>(
+        engine, this->varId(), std::move(domain));
   } else {
     _domainViolationId =
-        engine.makeIntView<InDomain>(this->varId(), std::move(domain));
+        engine.makeIntView<InDomain>(engine, this->varId(), std::move(domain));
   }
   return _domainViolationId;
 }

--- a/src/invariantgraph/views/bool2IntNode.cpp
+++ b/src/invariantgraph/views/bool2IntNode.cpp
@@ -16,7 +16,7 @@ invariantgraph::Bool2IntNode::fromModelConstraint(
 void invariantgraph::Bool2IntNode::createDefinedVariables(Engine& engine) {
   if (definedVariables().front()->varId() == NULL_ID) {
     definedVariables().front()->setVarId(
-        engine.makeIntView<Bool2IntView>(input()->varId()));
+        engine.makeIntView<Bool2IntView>(engine, input()->varId()));
   }
 }
 

--- a/src/invariantgraph/views/boolNotNode.cpp
+++ b/src/invariantgraph/views/boolNotNode.cpp
@@ -15,7 +15,7 @@ invariantgraph::BoolNotNode::fromModelConstraint(
 void invariantgraph::BoolNotNode::createDefinedVariables(Engine& engine) {
   if (definedVariables().front()->varId() == NULL_ID) {
     definedVariables().front()->setVarId(
-        engine.makeIntView<Bool2IntView>(input()->varId()));
+        engine.makeIntView<Bool2IntView>(engine, input()->varId()));
   }
 }
 

--- a/src/invariantgraph/views/intAbsNode.cpp
+++ b/src/invariantgraph/views/intAbsNode.cpp
@@ -16,7 +16,7 @@ invariantgraph::IntAbsNode::fromModelConstraint(
 void invariantgraph::IntAbsNode::createDefinedVariables(Engine& engine) {
   if (definedVariables().front()->varId() == NULL_ID) {
     definedVariables().front()->setVarId(
-        engine.makeIntView<IntAbsView>(input()->varId()));
+        engine.makeIntView<IntAbsView>(engine, input()->varId()));
   }
 }
 

--- a/src/invariants/absDiff.cpp
+++ b/src/invariants/absDiff.cpp
@@ -2,24 +2,24 @@
 
 #include "core/engine.hpp"
 
-AbsDiff::AbsDiff(VarId output, VarId x, VarId y)
-    : Invariant(), _output(output), _x(x), _y(y) {
+AbsDiff::AbsDiff(Engine& engine, VarId output, VarId x, VarId y)
+    : Invariant(engine), _output(output), _x(x), _y(y) {
   _modifiedVars.reserve(1);
 }
 
-void AbsDiff::registerVars(Engine& engine) {
+void AbsDiff::registerVars() {
   assert(!_id.equals(NULL_ID));
 
-  registerDefinedVariable(engine, _output);
-  engine.registerInvariantInput(_id, _x, 0);
-  engine.registerInvariantInput(_id, _y, 0);
+  registerDefinedVariable(_output);
+  _engine.registerInvariantInput(_id, _x, 0);
+  _engine.registerInvariantInput(_id, _y, 0);
 }
 
-void AbsDiff::updateBounds(Engine& engine, bool widenOnly) {
-  const Int xLb = engine.lowerBound(_x);
-  const Int xUb = engine.upperBound(_x);
-  const Int yLb = engine.lowerBound(_y);
-  const Int yUb = engine.upperBound(_y);
+void AbsDiff::updateBounds(bool widenOnly) {
+  const Int xLb = _engine.lowerBound(_x);
+  const Int xUb = _engine.upperBound(_x);
+  const Int yLb = _engine.lowerBound(_y);
+  const Int yUb = _engine.upperBound(_y);
 
   const Int lb = xLb <= yUb && yLb <= xUb
                      ? 0
@@ -28,19 +28,17 @@ void AbsDiff::updateBounds(Engine& engine, bool widenOnly) {
   const Int ub = std::max(std::max(std::abs(xLb - yLb), std::abs(xLb - yUb)),
                           std::max(std::abs(xUb - yLb), std::abs(xUb - yUb)));
 
-  engine.updateBounds(_output, lb, ub, widenOnly);
+  _engine.updateBounds(_output, lb, ub, widenOnly);
 }
 
-void AbsDiff::recompute(Timestamp ts, Engine& engine) {
-  updateValue(ts, engine, _output,
-              std::abs(engine.value(ts, _x) - engine.value(ts, _y)));
+void AbsDiff::recompute(Timestamp ts) {
+  updateValue(ts, _output,
+              std::abs(_engine.value(ts, _x) - _engine.value(ts, _y)));
 }
 
-void AbsDiff::notifyInputChanged(Timestamp ts, Engine& engine, LocalId) {
-  recompute(ts, engine);
-}
+void AbsDiff::notifyInputChanged(Timestamp ts, LocalId) { recompute(ts); }
 
-VarId AbsDiff::nextInput(Timestamp ts, Engine&) {
+VarId AbsDiff::nextInput(Timestamp ts) {
   switch (_state.incValue(ts, 1)) {
     case 0:
       return _x;
@@ -51,10 +49,6 @@ VarId AbsDiff::nextInput(Timestamp ts, Engine&) {
   }
 }
 
-void AbsDiff::notifyCurrentInputChanged(Timestamp ts, Engine& engine) {
-  recompute(ts, engine);
-}
+void AbsDiff::notifyCurrentInputChanged(Timestamp ts) { recompute(ts); }
 
-void AbsDiff::commit(Timestamp ts, Engine& engine) {
-  Invariant::commit(ts, engine);
-}
+void AbsDiff::commit(Timestamp ts) { Invariant::commit(ts); }

--- a/src/invariants/binaryMax.cpp
+++ b/src/invariants/binaryMax.cpp
@@ -2,30 +2,30 @@
 
 #include "core/engine.hpp"
 
-BinaryMax::BinaryMax(VarId output, VarId x, VarId y)
-    : Invariant(), _output(output), _x(x), _y(y) {
+BinaryMax::BinaryMax(Engine& engine, VarId output, VarId x, VarId y)
+    : Invariant(engine), _output(output), _x(x), _y(y) {
   _modifiedVars.reserve(1);
 }
 
-void BinaryMax::registerVars(Engine& engine) {
+void BinaryMax::registerVars() {
   assert(!_id.equals(NULL_ID));
-  engine.registerInvariantInput(_id, _x, 0);
-  engine.registerInvariantInput(_id, _y, 0);
-  registerDefinedVariable(engine, _output);
+  _engine.registerInvariantInput(_id, _x, 0);
+  _engine.registerInvariantInput(_id, _y, 0);
+  registerDefinedVariable(_output);
 }
 
-void BinaryMax::updateBounds(Engine& engine, bool widenOnly) {
-  engine.updateBounds(
-      _output, std::max(engine.lowerBound(_x), engine.lowerBound(_y)),
-      std::max(engine.upperBound(_x), engine.upperBound(_y)), widenOnly);
+void BinaryMax::updateBounds(bool widenOnly) {
+  _engine.updateBounds(
+      _output, std::max(_engine.lowerBound(_x), _engine.lowerBound(_y)),
+      std::max(_engine.upperBound(_x), _engine.upperBound(_y)), widenOnly);
 }
 
-void BinaryMax::recompute(Timestamp ts, Engine& engine) {
-  updateValue(ts, engine, _output,
-              std::max(engine.value(ts, _x), engine.value(ts, _y)));
+void BinaryMax::recompute(Timestamp ts) {
+  updateValue(ts, _output,
+              std::max(_engine.value(ts, _x), _engine.value(ts, _y)));
 }
 
-VarId BinaryMax::nextInput(Timestamp ts, Engine&) {
+VarId BinaryMax::nextInput(Timestamp ts) {
   switch (_state.incValue(ts, 1)) {
     case 0:
       return _x;
@@ -36,14 +36,8 @@ VarId BinaryMax::nextInput(Timestamp ts, Engine&) {
   }
 }
 
-void BinaryMax::notifyCurrentInputChanged(Timestamp ts, Engine& engine) {
-  recompute(ts, engine);
-}
+void BinaryMax::notifyCurrentInputChanged(Timestamp ts) { recompute(ts); }
 
-void BinaryMax::notifyInputChanged(Timestamp ts, Engine& engine, LocalId) {
-  recompute(ts, engine);
-}
+void BinaryMax::notifyInputChanged(Timestamp ts, LocalId) { recompute(ts); }
 
-void BinaryMax::commit(Timestamp ts, Engine& engine) {
-  Invariant::commit(ts, engine);
-}
+void BinaryMax::commit(Timestamp ts) { Invariant::commit(ts); }

--- a/src/invariants/binaryMin.cpp
+++ b/src/invariants/binaryMin.cpp
@@ -2,30 +2,30 @@
 
 #include "core/engine.hpp"
 
-BinaryMin::BinaryMin(VarId output, VarId x, VarId y)
-    : Invariant(), _output(output), _x(x), _y(y) {
+BinaryMin::BinaryMin(Engine& engine, VarId output, VarId x, VarId y)
+    : Invariant(engine), _output(output), _x(x), _y(y) {
   _modifiedVars.reserve(1);
 }
 
-void BinaryMin::registerVars(Engine& engine) {
+void BinaryMin::registerVars() {
   assert(!_id.equals(NULL_ID));
-  engine.registerInvariantInput(_id, _x, 0);
-  engine.registerInvariantInput(_id, _y, 0);
-  registerDefinedVariable(engine, _output);
+  _engine.registerInvariantInput(_id, _x, 0);
+  _engine.registerInvariantInput(_id, _y, 0);
+  registerDefinedVariable(_output);
 }
 
-void BinaryMin::updateBounds(Engine& engine, bool widenOnly) {
-  engine.updateBounds(
-      _output, std::min(engine.lowerBound(_x), engine.lowerBound(_y)),
-      std::min(engine.upperBound(_x), engine.upperBound(_y)), widenOnly);
+void BinaryMin::updateBounds(bool widenOnly) {
+  _engine.updateBounds(
+      _output, std::min(_engine.lowerBound(_x), _engine.lowerBound(_y)),
+      std::min(_engine.upperBound(_x), _engine.upperBound(_y)), widenOnly);
 }
 
-void BinaryMin::recompute(Timestamp ts, Engine& engine) {
-  updateValue(ts, engine, _output,
-              std::min(engine.value(ts, _x), engine.value(ts, _y)));
+void BinaryMin::recompute(Timestamp ts) {
+  updateValue(ts, _output,
+              std::min(_engine.value(ts, _x), _engine.value(ts, _y)));
 }
 
-VarId BinaryMin::nextInput(Timestamp ts, Engine&) {
+VarId BinaryMin::nextInput(Timestamp ts) {
   switch (_state.incValue(ts, 1)) {
     case 0:
       return _x;
@@ -36,14 +36,8 @@ VarId BinaryMin::nextInput(Timestamp ts, Engine&) {
   }
 }
 
-void BinaryMin::notifyCurrentInputChanged(Timestamp ts, Engine& engine) {
-  recompute(ts, engine);
-}
+void BinaryMin::notifyCurrentInputChanged(Timestamp ts) { recompute(ts); }
 
-void BinaryMin::notifyInputChanged(Timestamp ts, Engine& engine, LocalId) {
-  recompute(ts, engine);
-}
+void BinaryMin::notifyInputChanged(Timestamp ts, LocalId) { recompute(ts); }
 
-void BinaryMin::commit(Timestamp ts, Engine& engine) {
-  Invariant::commit(ts, engine);
-}
+void BinaryMin::commit(Timestamp ts) { Invariant::commit(ts); }

--- a/src/invariants/boolAnd.cpp
+++ b/src/invariants/boolAnd.cpp
@@ -10,34 +10,32 @@
  * @param y second violation variable
  * @param output the result
  */
-BoolAnd::BoolAnd(VarId output, VarId x, VarId y)
-    : Invariant(), _output(output), _x(x), _y(y) {
+BoolAnd::BoolAnd(Engine& engine, VarId output, VarId x, VarId y)
+    : Invariant(engine), _output(output), _x(x), _y(y) {
   _modifiedVars.reserve(1);
 }
 
-void BoolAnd::registerVars(Engine& engine) {
+void BoolAnd::registerVars() {
   assert(_id != NULL_ID);
-  engine.registerInvariantInput(_id, _x, LocalId(0));
-  engine.registerInvariantInput(_id, _y, LocalId(0));
-  registerDefinedVariable(engine, _output);
+  _engine.registerInvariantInput(_id, _x, LocalId(0));
+  _engine.registerInvariantInput(_id, _y, LocalId(0));
+  registerDefinedVariable(_output);
 }
 
-void BoolAnd::updateBounds(Engine& engine, bool widenOnly) {
-  engine.updateBounds(
-      _output, std::max(engine.lowerBound(_x), engine.lowerBound(_y)),
-      std::max(engine.upperBound(_x), engine.upperBound(_y)), widenOnly);
+void BoolAnd::updateBounds(bool widenOnly) {
+  _engine.updateBounds(
+      _output, std::max(_engine.lowerBound(_x), _engine.lowerBound(_y)),
+      std::max(_engine.upperBound(_x), _engine.upperBound(_y)), widenOnly);
 }
 
-void BoolAnd::recompute(Timestamp ts, Engine& engine) {
-  updateValue(ts, engine, _output,
-              std::max(engine.value(ts, _x), engine.value(ts, _y)));
+void BoolAnd::recompute(Timestamp ts) {
+  updateValue(ts, _output,
+              std::max(_engine.value(ts, _x), _engine.value(ts, _y)));
 }
 
-void BoolAnd::notifyInputChanged(Timestamp ts, Engine& engine, LocalId) {
-  recompute(ts, engine);
-}
+void BoolAnd::notifyInputChanged(Timestamp ts, LocalId) { recompute(ts); }
 
-VarId BoolAnd::nextInput(Timestamp ts, Engine&) {
+VarId BoolAnd::nextInput(Timestamp ts) {
   switch (_state.incValue(ts, 1)) {
     case 0:
       return _x;
@@ -48,10 +46,6 @@ VarId BoolAnd::nextInput(Timestamp ts, Engine&) {
   }
 }
 
-void BoolAnd::notifyCurrentInputChanged(Timestamp ts, Engine& engine) {
-  recompute(ts, engine);
-}
+void BoolAnd::notifyCurrentInputChanged(Timestamp ts) { recompute(ts); }
 
-void BoolAnd::commit(Timestamp ts, Engine& engine) {
-  Invariant::commit(ts, engine);
-}
+void BoolAnd::commit(Timestamp ts) { Invariant::commit(ts); }

--- a/src/invariants/boolLinear.cpp
+++ b/src/invariants/boolLinear.cpp
@@ -1,15 +1,15 @@
 #include "invariants/boolLinear.hpp"
 
-#include <utility>
-
 #include "core/engine.hpp"
 
-BoolLinear::BoolLinear(VarId output, const std::vector<VarId>& violArray)
-    : BoolLinear(output, std::vector<Int>(violArray.size(), 1), violArray) {}
+BoolLinear::BoolLinear(Engine& engine, VarId output,
+                       const std::vector<VarId>& violArray)
+    : BoolLinear(engine, output, std::vector<Int>(violArray.size(), 1),
+                 violArray) {}
 
-BoolLinear::BoolLinear(VarId output, std::vector<Int> coeffs,
+BoolLinear::BoolLinear(Engine& engine, VarId output, std::vector<Int> coeffs,
                        std::vector<VarId> violArray)
-    : Invariant(),
+    : Invariant(engine),
       _output(output),
       _coeffs(std::move(coeffs)),
       _violArray(std::move(violArray)),
@@ -18,25 +18,25 @@ BoolLinear::BoolLinear(VarId output, std::vector<Int> coeffs,
   _modifiedVars.reserve(_violArray.size());
 }
 
-void BoolLinear::registerVars(Engine& engine) {
+void BoolLinear::registerVars() {
   // precondition: this invariant must be registered with the engine before it
   // is initialised.
   assert(_id != NULL_ID);
 
   for (size_t i = 0; i < _violArray.size(); ++i) {
-    engine.registerInvariantInput(_id, _violArray[i], i);
+    _engine.registerInvariantInput(_id, _violArray[i], i);
   }
-  registerDefinedVariable(engine, _output);
+  registerDefinedVariable(_output);
 }
 
-void BoolLinear::updateBounds(Engine& engine, bool widenOnly) {
+void BoolLinear::updateBounds(bool widenOnly) {
   // precondition: this invariant must be registered with the engine before it
   // is initialised.
   Int lb = 0;
   Int ub = 0;
   for (size_t i = 0; i < _violArray.size(); ++i) {
-    const Int violLb = engine.lowerBound(_violArray[i]);
-    const Int violUb = engine.upperBound(_violArray[i]);
+    const Int violLb = _engine.lowerBound(_violArray[i]);
+    const Int violUb = _engine.upperBound(_violArray[i]);
     // violation != 0 <=> false
     const Int boolLb = static_cast<Int>(violLb == 0 && violUb == 0);
     // violation == 0 <=> true
@@ -48,38 +48,37 @@ void BoolLinear::updateBounds(Engine& engine, bool widenOnly) {
     lb += _coeffs[i] * (_coeffs[i] < 0 ? boolUb : boolLb);
     ub += _coeffs[i] * (_coeffs[i] < 0 ? boolLb : boolUb);
   }
-  engine.updateBounds(_output, lb, ub, widenOnly);
+  _engine.updateBounds(_output, lb, ub, widenOnly);
 }
 
-void BoolLinear::close(Timestamp ts, Engine& engine) {
+void BoolLinear::close(Timestamp ts) {
   _isSatisfied.clear();
   for (const VarId input : _violArray) {
-    _isSatisfied.emplace_back(ts, engine.committedValue(input));
+    _isSatisfied.emplace_back(ts, _engine.committedValue(input));
   }
 }
 
-void BoolLinear::recompute(Timestamp ts, Engine& engine) {
+void BoolLinear::recompute(Timestamp ts) {
   Int sum = 0;
   for (size_t i = 0; i < _violArray.size(); ++i) {
-    sum += _coeffs[i] * static_cast<Int>(engine.value(ts, _violArray[i]) == 0);
-    _isSatisfied[i].commitValue(engine.committedValue(_violArray[i]) == 0);
-    _isSatisfied[i].setValue(ts, engine.value(ts, _violArray[i]) == 0);
+    sum += _coeffs[i] * static_cast<Int>(_engine.value(ts, _violArray[i]) == 0);
+    _isSatisfied[i].commitValue(_engine.committedValue(_violArray[i]) == 0);
+    _isSatisfied[i].setValue(ts, _engine.value(ts, _violArray[i]) == 0);
   }
-  updateValue(ts, engine, _output, sum);
+  updateValue(ts, _output, sum);
 }
 
-void BoolLinear::notifyInputChanged(Timestamp ts, Engine& engine, LocalId id) {
+void BoolLinear::notifyInputChanged(Timestamp ts, LocalId id) {
   assert(id < _isSatisfied.size());
-  const Int newValue = static_cast<Int>(engine.value(ts, _violArray[id]) == 0);
+  const Int newValue = static_cast<Int>(_engine.value(ts, _violArray[id]) == 0);
   if (newValue == _isSatisfied[id].value(ts)) {
     return;
   }
-  incValue(ts, engine, _output,
-           (newValue - _isSatisfied[id].value(ts)) * _coeffs[id]);
+  incValue(ts, _output, (newValue - _isSatisfied[id].value(ts)) * _coeffs[id]);
   _isSatisfied[id].setValue(ts, newValue);
 }
 
-VarId BoolLinear::nextInput(Timestamp ts, Engine&) {
+VarId BoolLinear::nextInput(Timestamp ts) {
   const auto index = static_cast<size_t>(_state.incValue(ts, 1));
   assert(0 <= _state.value(ts));
   if (index < _violArray.size()) {
@@ -88,16 +87,16 @@ VarId BoolLinear::nextInput(Timestamp ts, Engine&) {
   return NULL_ID;  // Done
 }
 
-void BoolLinear::notifyCurrentInputChanged(Timestamp ts, Engine& engine) {
+void BoolLinear::notifyCurrentInputChanged(Timestamp ts) {
   assert(_state.value(ts) != -1);
-  notifyInputChanged(ts, engine, _state.value(ts));
+  notifyInputChanged(ts, _state.value(ts));
 }
 
-void BoolLinear::commit(Timestamp ts, Engine& engine) {
-  Invariant::commit(ts, engine);
+void BoolLinear::commit(Timestamp ts) {
+  Invariant::commit(ts);
   for (size_t i = 0; i < _isSatisfied.size(); ++i) {
     _isSatisfied[i].commitIf(ts);
-    assert(static_cast<Int>(engine.committedValue(_violArray[i]) == 0) ==
+    assert(static_cast<Int>(_engine.committedValue(_violArray[i]) == 0) ==
            _isSatisfied[i].committedValue());
   }
 }

--- a/src/invariants/boolOr.cpp
+++ b/src/invariants/boolOr.cpp
@@ -10,34 +10,32 @@
  * @param y second violation variable
  * @param output result
  */
-BoolOr::BoolOr(VarId output, VarId x, VarId y)
-    : Invariant(), _output(output), _x(x), _y(y) {
+BoolOr::BoolOr(Engine& engine, VarId output, VarId x, VarId y)
+    : Invariant(engine), _output(output), _x(x), _y(y) {
   _modifiedVars.reserve(1);
 }
 
-void BoolOr::registerVars(Engine& engine) {
+void BoolOr::registerVars() {
   assert(_id != NULL_ID);
-  engine.registerInvariantInput(_id, _x, LocalId(0));
-  engine.registerInvariantInput(_id, _y, LocalId(0));
-  registerDefinedVariable(engine, _output);
+  _engine.registerInvariantInput(_id, _x, LocalId(0));
+  _engine.registerInvariantInput(_id, _y, LocalId(0));
+  registerDefinedVariable(_output);
 }
 
-void BoolOr::updateBounds(Engine& engine, bool widenOnly) {
-  engine.updateBounds(
-      _output, std::min(engine.lowerBound(_x), engine.lowerBound(_y)),
-      std::min(engine.upperBound(_x), engine.upperBound(_y)), widenOnly);
+void BoolOr::updateBounds(bool widenOnly) {
+  _engine.updateBounds(
+      _output, std::min(_engine.lowerBound(_x), _engine.lowerBound(_y)),
+      std::min(_engine.upperBound(_x), _engine.upperBound(_y)), widenOnly);
 }
 
-void BoolOr::recompute(Timestamp ts, Engine& engine) {
-  updateValue(ts, engine, _output,
-              std::min(engine.value(ts, _x), engine.value(ts, _y)));
+void BoolOr::recompute(Timestamp ts) {
+  updateValue(ts, _output,
+              std::min(_engine.value(ts, _x), _engine.value(ts, _y)));
 }
 
-void BoolOr::notifyInputChanged(Timestamp ts, Engine& engine, LocalId) {
-  recompute(ts, engine);
-}
+void BoolOr::notifyInputChanged(Timestamp ts, LocalId) { recompute(ts); }
 
-VarId BoolOr::nextInput(Timestamp ts, Engine&) {
+VarId BoolOr::nextInput(Timestamp ts) {
   switch (_state.incValue(ts, 1)) {
     case 0:
       return _x;
@@ -48,10 +46,6 @@ VarId BoolOr::nextInput(Timestamp ts, Engine&) {
   }
 }
 
-void BoolOr::notifyCurrentInputChanged(Timestamp ts, Engine& engine) {
-  recompute(ts, engine);
-}
+void BoolOr::notifyCurrentInputChanged(Timestamp ts) { recompute(ts); }
 
-void BoolOr::commit(Timestamp ts, Engine& engine) {
-  Invariant::commit(ts, engine);
-}
+void BoolOr::commit(Timestamp ts) { Invariant::commit(ts); }

--- a/src/invariants/boolXor.cpp
+++ b/src/invariants/boolXor.cpp
@@ -10,33 +10,31 @@
  * @param y second violation variable
  * @param output result
  */
-BoolXor::BoolXor(VarId output, VarId x, VarId y)
-    : Invariant(), _output(output), _x(x), _y(y) {
+BoolXor::BoolXor(Engine& engine, VarId output, VarId x, VarId y)
+    : Invariant(engine), _output(output), _x(x), _y(y) {
   _modifiedVars.reserve(1);
 }
 
-void BoolXor::registerVars(Engine& engine) {
+void BoolXor::registerVars() {
   assert(_id != NULL_ID);
-  engine.registerInvariantInput(_id, _x, LocalId(0));
-  engine.registerInvariantInput(_id, _y, LocalId(0));
-  registerDefinedVariable(engine, _output);
+  _engine.registerInvariantInput(_id, _x, LocalId(0));
+  _engine.registerInvariantInput(_id, _y, LocalId(0));
+  registerDefinedVariable(_output);
 }
 
-void BoolXor::updateBounds(Engine& engine, bool widenOnly) {
-  engine.updateBounds(_output, 0, 1, widenOnly);
+void BoolXor::updateBounds(bool widenOnly) {
+  _engine.updateBounds(_output, 0, 1, widenOnly);
 }
 
-void BoolXor::recompute(Timestamp ts, Engine& engine) {
-  updateValue(ts, engine, _output,
-              static_cast<Int>((engine.value(ts, _x) != 0) ==
-                               (engine.value(ts, _y) != 0)));
+void BoolXor::recompute(Timestamp ts) {
+  updateValue(ts, _output,
+              static_cast<Int>((_engine.value(ts, _x) != 0) ==
+                               (_engine.value(ts, _y) != 0)));
 }
 
-void BoolXor::notifyInputChanged(Timestamp ts, Engine& engine, LocalId) {
-  recompute(ts, engine);
-}
+void BoolXor::notifyInputChanged(Timestamp ts, LocalId) { recompute(ts); }
 
-VarId BoolXor::nextInput(Timestamp ts, Engine&) {
+VarId BoolXor::nextInput(Timestamp ts) {
   switch (_state.incValue(ts, 1)) {
     case 0:
       return _x;
@@ -47,10 +45,6 @@ VarId BoolXor::nextInput(Timestamp ts, Engine&) {
   }
 }
 
-void BoolXor::notifyCurrentInputChanged(Timestamp ts, Engine& engine) {
-  recompute(ts, engine);
-}
+void BoolXor::notifyCurrentInputChanged(Timestamp ts) { recompute(ts); }
 
-void BoolXor::commit(Timestamp ts, Engine& engine) {
-  Invariant::commit(ts, engine);
-}
+void BoolXor::commit(Timestamp ts) { Invariant::commit(ts); }

--- a/src/invariants/count.cpp
+++ b/src/invariants/count.cpp
@@ -1,11 +1,9 @@
 #include "invariants/count.hpp"
 
-#include <utility>
-
 #include "core/engine.hpp"
 
-Count::Count(VarId output, VarId y, std::vector<VarId> varArray)
-    : Invariant(),
+Count::Count(Engine& engine, VarId output, VarId y, std::vector<VarId> varArray)
+    : Invariant(engine),
       _output(output),
       _y(y),
       _variables(std::move(varArray)),
@@ -16,69 +14,69 @@ Count::Count(VarId output, VarId y, std::vector<VarId> varArray)
   _modifiedVars.reserve(_variables.size() + 1);
 }
 
-void Count::registerVars(Engine& engine) {
+void Count::registerVars() {
   assert(!_id.equals(NULL_ID));
   for (size_t i = 0; i < _variables.size(); ++i) {
-    engine.registerInvariantInput(_id, _variables[i], i);
+    _engine.registerInvariantInput(_id, _variables[i], i);
   }
-  engine.registerInvariantInput(_id, _y, _variables.size());
-  registerDefinedVariable(engine, _output);
+  _engine.registerInvariantInput(_id, _y, _variables.size());
+  registerDefinedVariable(_output);
 }
 
-void Count::updateBounds(Engine& engine, bool widenOnly) {
-  engine.updateBounds(_output, 0, _variables.size(), widenOnly);
+void Count::updateBounds(bool widenOnly) {
+  _engine.updateBounds(_output, 0, _variables.size(), widenOnly);
 }
 
-void Count::close(Timestamp ts, Engine& engine) {
+void Count::close(Timestamp ts) {
   Int lb = std::numeric_limits<Int>::max();
   Int ub = std::numeric_limits<Int>::min();
 
   for (size_t i = 0; i < _variables.size(); ++i) {
-    lb = std::min(lb, engine.lowerBound(_variables[i]));
-    ub = std::max(ub, engine.upperBound(_variables[i]));
-    _localValues.emplace_back(ts, engine.committedValue(_variables[i]));
+    lb = std::min(lb, _engine.lowerBound(_variables[i]));
+    ub = std::max(ub, _engine.upperBound(_variables[i]));
+    _localValues.emplace_back(ts, _engine.committedValue(_variables[i]));
   }
   assert(ub >= lb);
-  lb = std::max(lb, engine.lowerBound(_y));
-  ub = std::max(ub, engine.lowerBound(_y));
+  lb = std::max(lb, _engine.lowerBound(_y));
+  ub = std::max(ub, _engine.lowerBound(_y));
 
   _counts.resize(static_cast<unsigned long>(ub - lb + 1),
                  CommittableInt(ts, 0));
   _offset = lb;
 }
 
-void Count::recompute(Timestamp ts, Engine& engine) {
+void Count::recompute(Timestamp ts) {
   for (CommittableInt& c : _counts) {
     c.setValue(ts, 0);
   }
 
-  updateValue(ts, engine, _output, 0);
+  updateValue(ts, _output, 0);
 
   for (size_t i = 0; i < _variables.size(); ++i) {
-    _localValues[i].setValue(ts, engine.value(ts, _variables[i]));
-    increaseCount(ts, engine.value(ts, _variables[i]));
+    _localValues[i].setValue(ts, _engine.value(ts, _variables[i]));
+    increaseCount(ts, _engine.value(ts, _variables[i]));
   }
-  updateValue(ts, engine, _output, count(ts, engine.value(ts, _y)));
+  updateValue(ts, _output, count(ts, _engine.value(ts, _y)));
 }
 
-void Count::notifyInputChanged(Timestamp ts, Engine& engine, LocalId id) {
+void Count::notifyInputChanged(Timestamp ts, LocalId id) {
   if (id == _localValues.size()) {
-    updateValue(ts, engine, _output, count(ts, engine.value(ts, _y)));
+    updateValue(ts, _output, count(ts, _engine.value(ts, _y)));
     return;
   }
   assert(id < _localValues.size());
   const Int oldValue = _localValues[id].value(ts);
-  const Int newValue = engine.value(ts, _variables[id]);
+  const Int newValue = _engine.value(ts, _variables[id]);
   if (newValue == oldValue) {
     return;
   }
   decreaseCount(ts, oldValue);
   increaseCount(ts, newValue);
   _localValues[id].setValue(ts, newValue);
-  updateValue(ts, engine, _output, count(ts, engine.value(ts, _y)));
+  updateValue(ts, _output, count(ts, _engine.value(ts, _y)));
 }
 
-VarId Count::nextInput(Timestamp ts, Engine&) {
+VarId Count::nextInput(Timestamp ts) {
   const auto index = static_cast<size_t>(_state.incValue(ts, 1));
   if (index < _variables.size()) {
     return _variables[index];
@@ -88,13 +86,13 @@ VarId Count::nextInput(Timestamp ts, Engine&) {
   return NULL_ID;
 }
 
-void Count::notifyCurrentInputChanged(Timestamp ts, Engine& engine) {
+void Count::notifyCurrentInputChanged(Timestamp ts) {
   assert(static_cast<size_t>(_state.value(ts)) <= _variables.size());
-  notifyInputChanged(ts, engine, static_cast<size_t>(_state.value(ts)));
+  notifyInputChanged(ts, static_cast<size_t>(_state.value(ts)));
 }
 
-void Count::commit(Timestamp ts, Engine& engine) {
-  Invariant::commit(ts, engine);
+void Count::commit(Timestamp ts) {
+  Invariant::commit(ts);
 
   for (CommittableInt& localValue : _localValues) {
     localValue.commitIf(ts);

--- a/src/invariants/countConst.cpp
+++ b/src/invariants/countConst.cpp
@@ -1,62 +1,65 @@
 #include "invariants/countConst.hpp"
 
-#include <utility>
-
 #include "core/engine.hpp"
 
-CountConst::CountConst(VarId output, Int y, std::vector<VarId> variables)
-    : Invariant(), _output(output), _y(y), _variables(std::move(variables)) {
+CountConst::CountConst(Engine& engine, VarId output, Int y,
+                       std::vector<VarId> variables)
+    : Invariant(engine),
+      _output(output),
+      _y(y),
+      _variables(std::move(variables)) {
   _hasCountValue.reserve(_variables.size());
   _modifiedVars.reserve(_variables.size());
 }
 
-void CountConst::registerVars(Engine& engine) {
+void CountConst::registerVars() {
   // precondition: this invariant must be registered with the engine before it
   // is initialised.
   assert(_id != NULL_ID);
 
   for (size_t i = 0; i < _variables.size(); ++i) {
-    engine.registerInvariantInput(_id, _variables[i], i);
+    _engine.registerInvariantInput(_id, _variables[i], i);
   }
-  registerDefinedVariable(engine, _output);
+  registerDefinedVariable(_output);
 }
 
-void CountConst::updateBounds(Engine& engine, bool widenOnly) {
-  engine.updateBounds(_output, 0, _variables.size(), widenOnly);
+void CountConst::updateBounds(bool widenOnly) {
+  _engine.updateBounds(_output, 0, _variables.size(), widenOnly);
 }
 
-void CountConst::close(Timestamp ts, Engine& engine) {
+void CountConst::close(Timestamp ts) {
   _hasCountValue.clear();
   for (const VarId input : _variables) {
     _hasCountValue.emplace_back(
-        ts, static_cast<Int>(engine.committedValue(input) == _y));
+        ts, static_cast<Int>(_engine.committedValue(input) == _y));
   }
 }
 
-void CountConst::recompute(Timestamp ts, Engine& engine) {
+void CountConst::recompute(Timestamp ts) {
   Int count = 0;
   for (size_t i = 0; i < _variables.size(); ++i) {
     _hasCountValue[i].commitValue(
-        static_cast<Int>(engine.committedValue(_variables[i])) == _y);
-    count += static_cast<Int>(engine.value(ts, _variables[i]) == _y);
+        static_cast<Int>(_engine.committedValue(_variables[i])) == _y);
+    count += static_cast<Int>(_engine.value(ts, _variables[i]) == _y);
     _hasCountValue[i].setValue(
-        ts, static_cast<Int>(engine.value(ts, _variables[i])) == _y);
+        ts, static_cast<Int>(_engine.value(ts, _variables[i])) == _y);
   }
-  updateValue(ts, engine, _output, count);
+  updateValue(ts, _output, count);
 }
 
-void CountConst::notifyInputChanged(Timestamp ts, Engine& engine, LocalId id) {
+void CountConst::notifyInputChanged(Timestamp ts, LocalId id) {
   assert(id < _hasCountValue.size());
   const Int oldValue = _hasCountValue[id].value(ts);
-  const Int newValue = static_cast<Int>(engine.value(ts, _variables[id]) == _y);
+  const Int newValue =
+      static_cast<Int>(_engine.value(ts, _variables[id]) == _y);
   if (oldValue == newValue) {
     return;
   }
   _hasCountValue[id].setValue(ts, newValue);
-  incValue(ts, engine, _output, newValue - oldValue);
+  incValue(ts, _output, newValue - oldValue);
 }
 
-VarId CountConst::nextInput(Timestamp ts, Engine&) {
+VarId CountConst::nextInput(Timestamp ts) {
   const auto index = static_cast<size_t>(_state.incValue(ts, 1));
   assert(0 <= _state.value(ts));
   if (index < _variables.size()) {
@@ -65,16 +68,16 @@ VarId CountConst::nextInput(Timestamp ts, Engine&) {
   return NULL_ID;  // Done
 }
 
-void CountConst::notifyCurrentInputChanged(Timestamp ts, Engine& engine) {
+void CountConst::notifyCurrentInputChanged(Timestamp ts) {
   assert(_state.value(ts) != -1);
-  notifyInputChanged(ts, engine, _state.value(ts));
+  notifyInputChanged(ts, _state.value(ts));
 }
 
-void CountConst::commit(Timestamp ts, Engine& engine) {
-  Invariant::commit(ts, engine);
+void CountConst::commit(Timestamp ts) {
+  Invariant::commit(ts);
   for (size_t i = 0; i < _hasCountValue.size(); ++i) {
     _hasCountValue[i].commitIf(ts);
     assert(_hasCountValue[i].committedValue() ==
-           static_cast<Int>(engine.committedValue(_variables[i]) == _y));
+           static_cast<Int>(_engine.committedValue(_variables[i]) == _y));
   }
 }

--- a/src/invariants/element2dVar.cpp
+++ b/src/invariants/element2dVar.cpp
@@ -1,5 +1,7 @@
 #include "invariants/element2dVar.hpp"
 
+#include "core/engine.hpp"
+
 static inline Int numCols(const std::vector<std::vector<VarId>>& varMatrix) {
   assert(std::all_of(varMatrix.begin(), varMatrix.end(), [&](const auto& col) {
     return col.size() == varMatrix.front().size();
@@ -7,10 +9,11 @@ static inline Int numCols(const std::vector<std::vector<VarId>>& varMatrix) {
   return varMatrix.empty() ? 0 : varMatrix.front().size();
 }
 
-Element2dVar::Element2dVar(VarId output, VarId index1, VarId index2,
+Element2dVar::Element2dVar(Engine& engine, VarId output, VarId index1,
+                           VarId index2,
                            std::vector<std::vector<VarId>> varMatrix,
                            Int offset1, Int offset2)
-    : Invariant(),
+    : Invariant(engine),
       _varMatrix(varMatrix),
       _indices{index1, index2},
       _dimensions{static_cast<Int>(_varMatrix.size()), numCols(_varMatrix)},
@@ -19,28 +22,28 @@ Element2dVar::Element2dVar(VarId output, VarId index1, VarId index2,
   _modifiedVars.reserve(1);
 }
 
-void Element2dVar::registerVars(Engine& engine) {
+void Element2dVar::registerVars() {
   assert(_id != NULL_ID);
-  engine.registerInvariantInput(_id, _indices[0], LocalId(0));
-  engine.registerInvariantInput(_id, _indices[1], LocalId(0));
+  _engine.registerInvariantInput(_id, _indices[0], LocalId(0));
+  _engine.registerInvariantInput(_id, _indices[1], LocalId(0));
   for (const auto& varRow : _varMatrix) {
     for (const VarId input : varRow) {
-      engine.registerInvariantInput(_id, input, LocalId(0));
+      _engine.registerInvariantInput(_id, input, LocalId(0), true);
     }
   }
-  registerDefinedVariable(engine, _output);
+  registerDefinedVariable(_output);
 }
 
-void Element2dVar::updateBounds(Engine& engine, bool widenOnly) {
+void Element2dVar::updateBounds(bool widenOnly) {
   Int lb = std::numeric_limits<Int>::max();
   Int ub = std::numeric_limits<Int>::min();
 
   std::array<Int, 2> iLb;
   std::array<Int, 2> iUb;
   for (size_t i = 0; i < 2; ++i) {
-    iLb[i] = std::max<Int>(_offsets[i], engine.lowerBound(_indices[i]));
+    iLb[i] = std::max<Int>(_offsets[i], _engine.lowerBound(_indices[i]));
     iUb[i] = std::min<Int>(_dimensions[i] - 1 + _offsets[i],
-                           engine.upperBound(_indices[i]));
+                           _engine.upperBound(_indices[i]));
     if (iLb > iUb) {
       iLb[i] = _offsets[i];
       iUb[i] = _dimensions[i] - 1 + _offsets[i];
@@ -54,52 +57,46 @@ void Element2dVar::updateBounds(Engine& engine, bool widenOnly) {
       assert(_offsets[1] <= i2);
       assert(i2 - _offsets[1] < _dimensions[1]);
       lb = std::min(
-          lb, engine.lowerBound(_varMatrix[safeIndex1(i1)][safeIndex2(i2)]));
+          lb, _engine.lowerBound(_varMatrix[safeIndex1(i1)][safeIndex2(i2)]));
       ub = std::max(
-          ub, engine.upperBound(_varMatrix[safeIndex1(i1)][safeIndex2(i2)]));
+          ub, _engine.upperBound(_varMatrix[safeIndex1(i1)][safeIndex2(i2)]));
     }
   }
-  engine.updateBounds(_output, lb, ub, widenOnly);
+  _engine.updateBounds(_output, lb, ub, widenOnly);
 }
 
-void Element2dVar::recompute(Timestamp ts, Engine& engine) {
-  assert(safeIndex1(engine.value(ts, _indices[0])) <
+void Element2dVar::recompute(Timestamp ts) {
+  assert(safeIndex1(_engine.value(ts, _indices[0])) <
          static_cast<size_t>(_dimensions[0]));
-  assert(safeIndex2(engine.value(ts, _indices[1])) <
+  assert(safeIndex2(_engine.value(ts, _indices[1])) <
          static_cast<size_t>(_dimensions[1]));
-  updateValue(
-      ts, engine, _output,
-      engine.value(ts, _varMatrix[safeIndex1(engine.value(ts, _indices[0]))]
-                                 [safeIndex2(engine.value(ts, _indices[1]))]));
+  updateValue(ts, _output,
+              _engine.value(
+                  ts, _varMatrix[safeIndex1(_engine.value(ts, _indices[0]))]
+                                [safeIndex2(_engine.value(ts, _indices[1]))]));
 }
 
-void Element2dVar::notifyInputChanged(Timestamp ts, Engine& engine, LocalId) {
-  recompute(ts, engine);
-}
+void Element2dVar::notifyInputChanged(Timestamp ts, LocalId) { recompute(ts); }
 
-VarId Element2dVar::nextInput(Timestamp ts, Engine& engine) {
+VarId Element2dVar::nextInput(Timestamp ts) {
   switch (_state.incValue(ts, 1)) {
     case 0:
       return _indices[0];
     case 1:
       return _indices[1];
     case 2: {
-      assert(safeIndex1(engine.value(ts, _indices[0])) <
+      assert(safeIndex1(_engine.value(ts, _indices[0])) <
              static_cast<size_t>(_dimensions[0]));
-      assert(safeIndex2(engine.value(ts, _indices[1])) <
+      assert(safeIndex2(_engine.value(ts, _indices[1])) <
              static_cast<size_t>(_dimensions[1]));
-      return _varMatrix[safeIndex1(engine.value(ts, _indices[0]))]
-                       [safeIndex2(engine.value(ts, _indices[1]))];
+      return _varMatrix[safeIndex1(_engine.value(ts, _indices[0]))]
+                       [safeIndex2(_engine.value(ts, _indices[1]))];
     }
     default:
       return NULL_ID;  // Done
   }
 }
 
-void Element2dVar::notifyCurrentInputChanged(Timestamp ts, Engine& engine) {
-  recompute(ts, engine);
-}
+void Element2dVar::notifyCurrentInputChanged(Timestamp ts) { recompute(ts); }
 
-void Element2dVar::commit(Timestamp ts, Engine& engine) {
-  Invariant::commit(ts, engine);
-}
+void Element2dVar::commit(Timestamp ts) { Invariant::commit(ts); }

--- a/src/invariants/elementVar.cpp
+++ b/src/invariants/elementVar.cpp
@@ -1,8 +1,10 @@
 #include "invariants/elementVar.hpp"
 
-ElementVar::ElementVar(VarId output, VarId index, std::vector<VarId> varArray,
-                       Int offset)
-    : Invariant(),
+#include "core/engine.hpp"
+
+ElementVar::ElementVar(Engine& engine, VarId output, VarId index,
+                       std::vector<VarId> varArray, Int offset)
+    : Invariant(engine),
       _output(output),
       _index(index),
       _varArray(varArray),
@@ -10,21 +12,21 @@ ElementVar::ElementVar(VarId output, VarId index, std::vector<VarId> varArray,
   _modifiedVars.reserve(1);
 }
 
-void ElementVar::registerVars(Engine& engine) {
+void ElementVar::registerVars() {
   assert(_id != NULL_ID);
-  engine.registerInvariantInput(_id, _index, LocalId(0));
+  _engine.registerInvariantInput(_id, _index, LocalId(0));
   for (const VarId input : _varArray) {
-    engine.registerInvariantInput(_id, input, LocalId(0), true);
+    _engine.registerInvariantInput(_id, input, LocalId(0), true);
   }
-  registerDefinedVariable(engine, _output);
+  registerDefinedVariable(_output);
 }
 
-void ElementVar::updateBounds(Engine& engine, bool widenOnly) {
+void ElementVar::updateBounds(bool widenOnly) {
   Int lb = std::numeric_limits<Int>::max();
   Int ub = std::numeric_limits<Int>::min();
-  Int iLb = std::max<Int>(_offset, engine.lowerBound(_index));
+  Int iLb = std::max<Int>(_offset, _engine.lowerBound(_index));
   Int iUb = std::min<Int>(static_cast<Int>(_varArray.size()) - 1 + _offset,
-                          engine.upperBound(_index));
+                          _engine.upperBound(_index));
   if (iLb > iUb) {
     iLb = _offset;
     iUb = static_cast<Int>(_varArray.size()) - 1 + _offset;
@@ -32,42 +34,36 @@ void ElementVar::updateBounds(Engine& engine, bool widenOnly) {
   for (Int i = iLb; i <= iUb; ++i) {
     assert(_offset <= i);
     assert(i - _offset < static_cast<Int>(_varArray.size()));
-    lb = std::min(lb, engine.lowerBound(_varArray[safeIndex(i)]));
-    ub = std::max(ub, engine.upperBound(_varArray[safeIndex(i)]));
+    lb = std::min(lb, _engine.lowerBound(_varArray[safeIndex(i)]));
+    ub = std::max(ub, _engine.upperBound(_varArray[safeIndex(i)]));
   }
-  engine.updateBounds(_output, lb, ub, widenOnly);
+  _engine.updateBounds(_output, lb, ub, widenOnly);
 }
 
-void ElementVar::recompute(Timestamp ts, Engine& engine) {
-  assert(safeIndex(engine.value(ts, _index)) < _varArray.size());
-  updateValue(ts, engine, _output,
-              engine.value(
-                  ts, _dynamicInputVar.set(
-                          ts, _varArray[safeIndex(engine.value(ts, _index))])));
+void ElementVar::recompute(Timestamp ts) {
+  assert(safeIndex(_engine.value(ts, _index)) < _varArray.size());
+  updateValue(
+      ts, _output,
+      _engine.value(ts,
+                    _dynamicInputVar.set(
+                        ts, _varArray[safeIndex(_engine.value(ts, _index))])));
 }
 
-void ElementVar::notifyInputChanged(Timestamp ts, Engine& engine, LocalId) {
-  recompute(ts, engine);
-}
+void ElementVar::notifyInputChanged(Timestamp ts, LocalId) { recompute(ts); }
 
-VarId ElementVar::nextInput(Timestamp ts, Engine& engine) {
+VarId ElementVar::nextInput(Timestamp ts) {
   switch (_state.incValue(ts, 1)) {
     case 0:
       return _index;
     case 1: {
-      assert(safeIndex(engine.value(ts, _index)) < _varArray.size());
-      return _varArray[safeIndex(engine.value(ts, _index))];
+      assert(safeIndex(_engine.value(ts, _index)) < _varArray.size());
+      return _varArray[safeIndex(_engine.value(ts, _index))];
     }
     default:
       return NULL_ID;  // Done
   }
 }
 
-void ElementVar::notifyCurrentInputChanged(Timestamp ts, Engine& engine) {
-  recompute(ts, engine);
-}
+void ElementVar::notifyCurrentInputChanged(Timestamp ts) { recompute(ts); }
 
-void ElementVar::commit(Timestamp ts, Engine& engine) {
-  Invariant::commit(ts, engine);
-  _dynamicInputVar.commitIf(ts);
-}
+void ElementVar::commit(Timestamp ts) { Invariant::commit(ts); }

--- a/src/invariants/exists.cpp
+++ b/src/invariants/exists.cpp
@@ -1,48 +1,50 @@
 #include "invariants/exists.hpp"
 
-Exists::Exists(VarId output, std::vector<VarId> varArray)
-    : Invariant(),
+#include "core/engine.hpp"
+
+Exists::Exists(Engine& engine, VarId output, std::vector<VarId> varArray)
+    : Invariant(engine),
       _output(output),
       _varArray(std::move(varArray)),
       _localPriority(_varArray.size()) {
   _modifiedVars.reserve(_varArray.size());
 }
 
-void Exists::registerVars(Engine& engine) {
+void Exists::registerVars() {
   assert(!_id.equals(NULL_ID));
   for (size_t i = 0; i < _varArray.size(); ++i) {
-    engine.registerInvariantInput(_id, _varArray[i], i);
+    _engine.registerInvariantInput(_id, _varArray[i], i);
   }
-  registerDefinedVariable(engine, _output);
+  registerDefinedVariable(_output);
 }
 
-void Exists::updateBounds(Engine& engine, bool widenOnly) {
+void Exists::updateBounds(bool widenOnly) {
   Int lb = std::numeric_limits<Int>::max();
   Int ub = std::numeric_limits<Int>::max();
   for (const VarId input : _varArray) {
-    lb = std::min(lb, engine.lowerBound(input));
-    ub = std::min(ub, engine.upperBound(input));
+    lb = std::min(lb, _engine.lowerBound(input));
+    ub = std::min(ub, _engine.upperBound(input));
   }
-  engine.updateBounds(_output, std::max(Int(0), lb), ub, widenOnly);
+  _engine.updateBounds(_output, std::max(Int(0), lb), ub, widenOnly);
 }
 
-void Exists::recompute(Timestamp ts, Engine& engine) {
+void Exists::recompute(Timestamp ts) {
   for (size_t i = 0; i < _varArray.size(); ++i) {
     _localPriority.updatePriority(
-        ts, i, std::max(Int(0), engine.value(ts, _varArray[i])));
+        ts, i, std::max(Int(0), _engine.value(ts, _varArray[i])));
   }
   assert(_localPriority.minPriority(ts) >= 0);
-  updateValue(ts, engine, _output, _localPriority.minPriority(ts));
+  updateValue(ts, _output, _localPriority.minPriority(ts));
 }
 
-void Exists::notifyInputChanged(Timestamp ts, Engine& engine, LocalId id) {
+void Exists::notifyInputChanged(Timestamp ts, LocalId id) {
   _localPriority.updatePriority(
-      ts, id, std::max(Int(0), engine.value(ts, _varArray[id])));
+      ts, id, std::max(Int(0), _engine.value(ts, _varArray[id])));
   assert(_localPriority.minPriority(ts) >= 0);
-  updateValue(ts, engine, _output, _localPriority.minPriority(ts));
+  updateValue(ts, _output, _localPriority.minPriority(ts));
 }
 
-VarId Exists::nextInput(Timestamp ts, Engine&) {
+VarId Exists::nextInput(Timestamp ts) {
   const auto index = static_cast<size_t>(_state.incValue(ts, 1));
   assert(0 <= _state.value(ts));
   if (index < _varArray.size()) {
@@ -52,11 +54,11 @@ VarId Exists::nextInput(Timestamp ts, Engine&) {
   }
 }
 
-void Exists::notifyCurrentInputChanged(Timestamp ts, Engine& engine) {
-  notifyInputChanged(ts, engine, _state.value(ts));
+void Exists::notifyCurrentInputChanged(Timestamp ts) {
+  notifyInputChanged(ts, _state.value(ts));
 }
 
-void Exists::commit(Timestamp ts, Engine& engine) {
-  Invariant::commit(ts, engine);
+void Exists::commit(Timestamp ts) {
+  Invariant::commit(ts);
   _localPriority.commitIf(ts);
 }

--- a/src/invariants/ifThenElse.cpp
+++ b/src/invariants/ifThenElse.cpp
@@ -1,53 +1,48 @@
 #include "invariants/ifThenElse.hpp"
 
-IfThenElse::IfThenElse(VarId output, VarId b, VarId x, VarId y)
-    : Invariant(), _output(output), _b(b), _xy({x, y}) {
+#include "core/engine.hpp"
+
+IfThenElse::IfThenElse(Engine& engine, VarId output, VarId b, VarId x, VarId y)
+    : Invariant(engine), _output(output), _b(b), _xy({x, y}) {
   _modifiedVars.reserve(1);
 }
 
-void IfThenElse::registerVars(Engine& engine) {
+void IfThenElse::registerVars() {
   assert(!_id.equals(NULL_ID));
-  engine.registerInvariantInput(_id, _b, 0);
-  engine.registerInvariantInput(_id, _xy[0], 0, true);
-  engine.registerInvariantInput(_id, _xy[1], 0, true);
-  registerDefinedVariable(engine, _output);
+  _engine.registerInvariantInput(_id, _b, 0);
+  _engine.registerInvariantInput(_id, _xy[0], 0, true);
+  _engine.registerInvariantInput(_id, _xy[1], 0, true);
+  registerDefinedVariable(_output);
 }
 
-void IfThenElse::updateBounds(Engine& engine, bool widenOnly) {
-  engine.updateBounds(
-      _output, std::min(engine.lowerBound(_xy[0]), engine.lowerBound(_xy[1])),
-      std::max(engine.upperBound(_xy[0]), engine.upperBound(_xy[1])),
+void IfThenElse::updateBounds(bool widenOnly) {
+  _engine.updateBounds(
+      _output, std::min(_engine.lowerBound(_xy[0]), _engine.lowerBound(_xy[1])),
+      std::max(_engine.upperBound(_xy[0]), _engine.upperBound(_xy[1])),
       widenOnly);
 }
 
-void IfThenElse::recompute(Timestamp ts, Engine& engine) {
+void IfThenElse::recompute(Timestamp ts) {
   updateValue(
-      ts, engine, _output,
-      engine.value(
+      ts, _output,
+      _engine.value(
           ts, _dynamicInputVar.set(
-                  ts, _xy[static_cast<size_t>(engine.value(ts, _b) != 0)])));
+                  ts, _xy[static_cast<size_t>(_engine.value(ts, _b) != 0)])));
 }
 
-void IfThenElse::notifyInputChanged(Timestamp ts, Engine& engine, LocalId) {
-  recompute(ts, engine);
-}
+void IfThenElse::notifyInputChanged(Timestamp ts, LocalId) { recompute(ts); }
 
-VarId IfThenElse::nextInput(Timestamp ts, Engine& engine) {
+VarId IfThenElse::nextInput(Timestamp ts) {
   switch (_state.incValue(ts, 1)) {
     case 0:
       return _b;
     case 1:
-      return _xy[1 - (engine.value(ts, _b) == 0)];
+      return _xy[1 - (_engine.value(ts, _b) == 0)];
     default:
       return NULL_ID;  // Done
   }
 }
 
-void IfThenElse::notifyCurrentInputChanged(Timestamp ts, Engine& engine) {
-  recompute(ts, engine);
-}
+void IfThenElse::notifyCurrentInputChanged(Timestamp ts) { recompute(ts); }
 
-void IfThenElse::commit(Timestamp ts, Engine& engine) {
-  Invariant::commit(ts, engine);
-  _dynamicInputVar.commitIf(ts);
-}
+void IfThenElse::commit(Timestamp ts) { Invariant::commit(ts); }

--- a/src/invariants/invariant.cpp
+++ b/src/invariants/invariant.cpp
@@ -4,29 +4,29 @@
 
 void Invariant::notify(LocalId id) { _modifiedVars.push(id); }
 
-void Invariant::compute(Timestamp ts, Engine& engine) {
+void Invariant::compute(Timestamp ts) {
   assert(_modifiedVars.size() > 0);
   assert(_primaryDefinedVar != NULL_ID);
 
   while (_modifiedVars.hasNext()) {
     // don't turn this into a for loop...
-    this->notifyInputChanged(ts, engine, _modifiedVars.pop());
+    this->notifyInputChanged(ts, _modifiedVars.pop());
   }
 }
 
-void Invariant::registerDefinedVariable(Engine& engine, VarId id) {
+void Invariant::registerDefinedVariable(VarId id) {
   if (_primaryDefinedVar == NULL_ID) {
     _primaryDefinedVar = id;
   } else {
     _definedVars.push_back(id);
   }
-  engine.registerDefinedVariable(id, _id);
+  _engine.registerDefinedVariable(id, _id);
 }
 
-void Invariant::updateValue(Timestamp ts, Engine& engine, VarId id, Int val) {
-  engine.updateValue(ts, id, val);
+void Invariant::updateValue(Timestamp ts, VarId id, Int val) {
+  _engine.updateValue(ts, id, val);
 }
 
-void Invariant::incValue(Timestamp ts, Engine& engine, VarId id, Int val) {
-  engine.incValue(ts, id, val);
+void Invariant::incValue(Timestamp ts, VarId id, Int val) {
+  _engine.incValue(ts, id, val);
 }

--- a/src/invariants/linear.cpp
+++ b/src/invariants/linear.cpp
@@ -1,15 +1,13 @@
 #include "invariants/linear.hpp"
 
-#include <utility>
-
 #include "core/engine.hpp"
 
-Linear::Linear(VarId output, const std::vector<VarId>& varArray)
-    : Linear(output, std::vector<Int>(varArray.size(), 1), varArray) {}
+Linear::Linear(Engine& engine, VarId output, const std::vector<VarId>& varArray)
+    : Linear(engine, output, std::vector<Int>(varArray.size(), 1), varArray) {}
 
-Linear::Linear(VarId output, std::vector<Int> coeffs,
+Linear::Linear(Engine& engine, VarId output, std::vector<Int> coeffs,
                std::vector<VarId> varArray)
-    : Invariant(),
+    : Invariant(engine),
       _output(output),
       _coeffs(std::move(coeffs)),
       _varArray(std::move(varArray)),
@@ -18,57 +16,57 @@ Linear::Linear(VarId output, std::vector<Int> coeffs,
   _modifiedVars.reserve(_varArray.size());
 }
 
-void Linear::registerVars(Engine& engine) {
+void Linear::registerVars() {
   // precondition: this invariant must be registered with the engine before it
   // is initialised.
   assert(_id != NULL_ID);
 
   for (size_t i = 0; i < _varArray.size(); ++i) {
-    engine.registerInvariantInput(_id, _varArray[i], i);
+    _engine.registerInvariantInput(_id, _varArray[i], i);
   }
-  registerDefinedVariable(engine, _output);
+  registerDefinedVariable(_output);
 }
 
-void Linear::updateBounds(Engine& engine, bool widenOnly) {
+void Linear::updateBounds(bool widenOnly) {
   // precondition: this invariant must be registered with the engine before it
   // is initialised.
   Int lb = 0;
   Int ub = 0;
   for (size_t i = 0; i < _varArray.size(); ++i) {
-    lb += _coeffs[i] * (_coeffs[i] < 0 ? engine.upperBound(_varArray[i])
-                                       : engine.lowerBound(_varArray[i]));
-    ub += _coeffs[i] * (_coeffs[i] < 0 ? engine.lowerBound(_varArray[i])
-                                       : engine.upperBound(_varArray[i]));
+    lb += _coeffs[i] * (_coeffs[i] < 0 ? _engine.upperBound(_varArray[i])
+                                       : _engine.lowerBound(_varArray[i]));
+    ub += _coeffs[i] * (_coeffs[i] < 0 ? _engine.lowerBound(_varArray[i])
+                                       : _engine.upperBound(_varArray[i]));
   }
-  engine.updateBounds(_output, lb, ub, widenOnly);
+  _engine.updateBounds(_output, lb, ub, widenOnly);
 }
 
-void Linear::close(Timestamp ts, Engine& engine) {
+void Linear::close(Timestamp ts) {
   _localVarArray.clear();
   for (const VarId input : _varArray) {
-    _localVarArray.emplace_back(ts, engine.committedValue(input));
+    _localVarArray.emplace_back(ts, _engine.committedValue(input));
   }
 }
 
-void Linear::recompute(Timestamp ts, Engine& engine) {
+void Linear::recompute(Timestamp ts) {
   Int sum = 0;
   for (size_t i = 0; i < _varArray.size(); ++i) {
-    sum += _coeffs[i] * engine.value(ts, _varArray[i]);
-    _localVarArray[i].commitValue(engine.committedValue(_varArray[i]));
-    _localVarArray[i].setValue(ts, engine.value(ts, _varArray[i]));
+    sum += _coeffs[i] * _engine.value(ts, _varArray[i]);
+    _localVarArray[i].commitValue(_engine.committedValue(_varArray[i]));
+    _localVarArray[i].setValue(ts, _engine.value(ts, _varArray[i]));
   }
-  updateValue(ts, engine, _output, sum);
+  updateValue(ts, _output, sum);
 }
 
-void Linear::notifyInputChanged(Timestamp ts, Engine& engine, LocalId id) {
+void Linear::notifyInputChanged(Timestamp ts, LocalId id) {
   assert(id < _localVarArray.size());
-  const Int newValue = engine.value(ts, _varArray[id]);
-  incValue(ts, engine, _output,
+  const Int newValue = _engine.value(ts, _varArray[id]);
+  incValue(ts, _output,
            (newValue - _localVarArray[id].value(ts)) * _coeffs[id]);
   _localVarArray[id].setValue(ts, newValue);
 }
 
-VarId Linear::nextInput(Timestamp ts, Engine&) {
+VarId Linear::nextInput(Timestamp ts) {
   const auto index = static_cast<size_t>(_state.incValue(ts, 1));
   assert(0 <= _state.value(ts));
   if (index < _varArray.size()) {
@@ -77,16 +75,16 @@ VarId Linear::nextInput(Timestamp ts, Engine&) {
   return NULL_ID;  // Done
 }
 
-void Linear::notifyCurrentInputChanged(Timestamp ts, Engine& engine) {
+void Linear::notifyCurrentInputChanged(Timestamp ts) {
   assert(_state.value(ts) != -1);
-  notifyInputChanged(ts, engine, _state.value(ts));
+  notifyInputChanged(ts, _state.value(ts));
 }
 
-void Linear::commit(Timestamp ts, Engine& engine) {
-  Invariant::commit(ts, engine);
+void Linear::commit(Timestamp ts) {
+  Invariant::commit(ts);
   for (size_t i = 0; i < _localVarArray.size(); ++i) {
     _localVarArray[i].commitIf(ts);
-    assert(engine.committedValue(_varArray[i]) ==
+    assert(_engine.committedValue(_varArray[i]) ==
            _localVarArray[i].committedValue());
   }
 }

--- a/src/invariants/mod.cpp
+++ b/src/invariants/mod.cpp
@@ -4,43 +4,41 @@
 
 static inline Int mod(Int xVal, Int yVal) { return xVal % std::abs(yVal); }
 
-Mod::Mod(VarId output, VarId x, VarId y)
-    : Invariant(), _output(output), _x(x), _y(y) {
+Mod::Mod(Engine& engine, VarId output, VarId x, VarId y)
+    : Invariant(engine), _output(output), _x(x), _y(y) {
   _modifiedVars.reserve(1);
 }
 
-void Mod::registerVars(Engine& engine) {
+void Mod::registerVars() {
   assert(!_id.equals(NULL_ID));
-  engine.registerInvariantInput(_id, _x, 0);
-  engine.registerInvariantInput(_id, _y, 0);
-  registerDefinedVariable(engine, _output);
+  _engine.registerInvariantInput(_id, _x, 0);
+  _engine.registerInvariantInput(_id, _y, 0);
+  registerDefinedVariable(_output);
 }
 
-void Mod::updateBounds(Engine& engine, bool widenOnly) {
-  engine.updateBounds(_output, std::min(Int(0), engine.lowerBound(_x)),
-                      std::max(Int(0), engine.upperBound(_x)), widenOnly);
+void Mod::updateBounds(bool widenOnly) {
+  _engine.updateBounds(_output, std::min(Int(0), _engine.lowerBound(_x)),
+                       std::max(Int(0), _engine.upperBound(_x)), widenOnly);
 }
 
-void Mod::close(Timestamp, Engine& engine) {
-  assert(engine.lowerBound(_y) != 0 || engine.upperBound(_y) != 0);
-  if (engine.lowerBound(_y) <= 0 && 0 <= engine.upperBound(_y)) {
-    _zeroReplacement = engine.upperBound(_y) >= 1 ? 1 : -1;
+void Mod::close(Timestamp) {
+  assert(_engine.lowerBound(_y) != 0 || _engine.upperBound(_y) != 0);
+  if (_engine.lowerBound(_y) <= 0 && 0 <= _engine.upperBound(_y)) {
+    _zeroReplacement = _engine.upperBound(_y) >= 1 ? 1 : -1;
   }
 }
 
-void Mod::recompute(Timestamp ts, Engine& engine) {
+void Mod::recompute(Timestamp ts) {
   assert(_zeroReplacement != 0);
-  const Int denominator = engine.value(ts, _y);
-  updateValue(ts, engine, _output,
-              engine.value(ts, _x) %
+  const Int denominator = _engine.value(ts, _y);
+  updateValue(ts, _output,
+              _engine.value(ts, _x) %
                   std::abs(denominator != 0 ? denominator : _zeroReplacement));
 }
 
-void Mod::notifyInputChanged(Timestamp ts, Engine& engine, LocalId) {
-  recompute(ts, engine);
-}
+void Mod::notifyInputChanged(Timestamp ts, LocalId) { recompute(ts); }
 
-VarId Mod::nextInput(Timestamp ts, Engine&) {
+VarId Mod::nextInput(Timestamp ts) {
   switch (_state.incValue(ts, 1)) {
     case 0:
       return _x;
@@ -51,10 +49,6 @@ VarId Mod::nextInput(Timestamp ts, Engine&) {
   }
 }
 
-void Mod::notifyCurrentInputChanged(Timestamp ts, Engine& engine) {
-  recompute(ts, engine);
-}
+void Mod::notifyCurrentInputChanged(Timestamp ts) { recompute(ts); }
 
-void Mod::commit(Timestamp ts, Engine& engine) {
-  Invariant::commit(ts, engine);
-}
+void Mod::commit(Timestamp ts) { Invariant::commit(ts); }

--- a/src/invariants/plus.cpp
+++ b/src/invariants/plus.cpp
@@ -2,28 +2,29 @@
 
 #include "core/engine.hpp"
 
-Plus::Plus(VarId output, VarId x, VarId y)
-    : Invariant(), _output(output), _x(x), _y(y) {
+Plus::Plus(Engine& engine, VarId output, VarId x, VarId y)
+    : Invariant(engine), _output(output), _x(x), _y(y) {
   _modifiedVars.reserve(1);
 }
 
-void Plus::registerVars(Engine& engine) {
+void Plus::registerVars() {
   assert(!_id.equals(NULL_ID));
-  engine.registerInvariantInput(_id, _x, 0);
-  engine.registerInvariantInput(_id, _y, 0);
-  registerDefinedVariable(engine, _output);
+  _engine.registerInvariantInput(_id, _x, 0);
+  _engine.registerInvariantInput(_id, _y, 0);
+  registerDefinedVariable(_output);
 }
 
-void Plus::updateBounds(Engine& engine, bool widenOnly) {
-  engine.updateBounds(_output, engine.lowerBound(_x) + engine.lowerBound(_y),
-                      engine.upperBound(_x) + engine.upperBound(_y), widenOnly);
+void Plus::updateBounds(bool widenOnly) {
+  _engine.updateBounds(_output, _engine.lowerBound(_x) + _engine.lowerBound(_y),
+                       _engine.upperBound(_x) + _engine.upperBound(_y),
+                       widenOnly);
 }
 
-void Plus::recompute(Timestamp ts, Engine& engine) {
-  updateValue(ts, engine, _output, engine.value(ts, _x) + engine.value(ts, _y));
+void Plus::recompute(Timestamp ts) {
+  updateValue(ts, _output, _engine.value(ts, _x) + _engine.value(ts, _y));
 }
 
-VarId Plus::nextInput(Timestamp ts, Engine&) {
+VarId Plus::nextInput(Timestamp ts) {
   switch (_state.incValue(ts, 1)) {
     case 0:
       return _x;
@@ -34,14 +35,8 @@ VarId Plus::nextInput(Timestamp ts, Engine&) {
   }
 }
 
-void Plus::notifyCurrentInputChanged(Timestamp ts, Engine& engine) {
-  recompute(ts, engine);
-}
+void Plus::notifyCurrentInputChanged(Timestamp ts) { recompute(ts); }
 
-void Plus::notifyInputChanged(Timestamp ts, Engine& engine, LocalId) {
-  recompute(ts, engine);
-}
+void Plus::notifyInputChanged(Timestamp ts, LocalId) { recompute(ts); }
 
-void Plus::commit(Timestamp ts, Engine& engine) {
-  Invariant::commit(ts, engine);
-}
+void Plus::commit(Timestamp ts) { Invariant::commit(ts); }

--- a/src/invariants/times.cpp
+++ b/src/invariants/times.cpp
@@ -2,34 +2,34 @@
 
 #include "core/engine.hpp"
 
-Times::Times(VarId output, VarId x, VarId y)
-    : Invariant(), _output(output), _x(x), _y(y) {
+Times::Times(Engine& engine, VarId output, VarId x, VarId y)
+    : Invariant(engine), _output(output), _x(x), _y(y) {
   _modifiedVars.reserve(1);
 }
 
-void Times::registerVars(Engine& engine) {
+void Times::registerVars() {
   assert(!_id.equals(NULL_ID));
-  engine.registerInvariantInput(_id, _x, 0);
-  engine.registerInvariantInput(_id, _y, 0);
-  registerDefinedVariable(engine, _output);
+  _engine.registerInvariantInput(_id, _x, 0);
+  _engine.registerInvariantInput(_id, _y, 0);
+  registerDefinedVariable(_output);
 }
 
-void Times::updateBounds(Engine& engine, bool widenOnly) {
-  const Int xLb = engine.lowerBound(_x);
-  const Int xUb = engine.upperBound(_x);
-  const Int yLb = engine.lowerBound(_y);
-  const Int yUb = engine.upperBound(_y);
+void Times::updateBounds(bool widenOnly) {
+  const Int xLb = _engine.lowerBound(_x);
+  const Int xUb = _engine.upperBound(_x);
+  const Int yLb = _engine.lowerBound(_y);
+  const Int yUb = _engine.upperBound(_y);
   const std::array<const Int, 4> vals{xLb * yLb, xLb * yUb, xUb * yLb,
                                       xUb * yUb};
   const auto [lb, ub] = std::minmax_element(vals.begin(), vals.end());
-  engine.updateBounds(_output, *lb, *ub, widenOnly);
+  _engine.updateBounds(_output, *lb, *ub, widenOnly);
 }
 
-void Times::recompute(Timestamp ts, Engine& engine) {
-  updateValue(ts, engine, _output, engine.value(ts, _x) * engine.value(ts, _y));
+void Times::recompute(Timestamp ts) {
+  updateValue(ts, _output, _engine.value(ts, _x) * _engine.value(ts, _y));
 }
 
-VarId Times::nextInput(Timestamp ts, Engine&) {
+VarId Times::nextInput(Timestamp ts) {
   switch (_state.incValue(ts, 1)) {
     case 0:
       return _x;
@@ -40,14 +40,8 @@ VarId Times::nextInput(Timestamp ts, Engine&) {
   }
 }
 
-void Times::notifyCurrentInputChanged(Timestamp ts, Engine& engine) {
-  recompute(ts, engine);
-}
+void Times::notifyCurrentInputChanged(Timestamp ts) { recompute(ts); }
 
-void Times::notifyInputChanged(Timestamp ts, Engine& engine, LocalId) {
-  recompute(ts, engine);
-}
+void Times::notifyInputChanged(Timestamp ts, LocalId) { recompute(ts); }
 
-void Times::commit(Timestamp ts, Engine& engine) {
-  Invariant::commit(ts, engine);
-}
+void Times::commit(Timestamp ts) { Invariant::commit(ts); }

--- a/src/propagation/propagationGraph.cpp
+++ b/src/propagation/propagationGraph.cpp
@@ -386,7 +386,8 @@ size_t PropagationGraph::topologicallyOrder(Timestamp ts,
   } else {
     for (const auto& [inputId, isDynamicInput] : inputVariables(defInv)) {
       // The layer has no cycles or defInv is a static invariant:
-      assert(!_layerHasDynamicCycle.at(layer) || !isDynamicInput);
+      assert(layer == 0 || !_layerHasDynamicCycle.at(layer - 1) ||
+             !isDynamicInput);
       // sanity check:
       assert(inputId != NULL_ID);
       // we should have no dependencies to subsequent layers:

--- a/src/search/objective.cpp
+++ b/src/search/objective.cpp
@@ -17,18 +17,20 @@ VarId search::Objective::registerWithEngine(VarId constraintViolation,
       overloaded{
           [&](const fznparser::Satisfy&) { return constraintViolation; },
           [&](const fznparser::Minimise&) {
-            auto violation = registerOptimisation(
+            VarId violation = registerOptimisation(
                 constraintViolation, objectiveVariable,
-                _engine.upperBound(objectiveVariable), [&](auto v, auto b) {
-                  _engine.makeConstraint<LessEqual>(v, objectiveVariable, b);
+                _engine.upperBound(objectiveVariable), [&](VarId v, VarId b) {
+                  _engine.makeConstraint<LessEqual>(_engine, v,
+                                                    objectiveVariable, b);
                 });
             return violation;
           },
           [&](const fznparser::Maximise&) {
-            auto violation = registerOptimisation(
+            VarId violation = registerOptimisation(
                 constraintViolation, objectiveVariable,
-                _engine.lowerBound(objectiveVariable), [&](auto v, auto b) {
-                  _engine.makeConstraint<LessEqual>(v, b, objectiveVariable);
+                _engine.lowerBound(objectiveVariable), [&](VarId v, VarId b) {
+                  _engine.makeConstraint<LessEqual>(_engine, v, b,
+                                                    objectiveVariable);
                 });
             return violation;
           },

--- a/src/views/bool2IntView.cpp
+++ b/src/views/bool2IntView.cpp
@@ -3,11 +3,11 @@
 static inline Int convert(Int value) { return static_cast<Int>(value == 0); }
 
 Int Bool2IntView::value(Timestamp ts) {
-  assert(0 >= _engine->lowerBound(_parentId));
-  return convert(_engine->value(ts, _parentId));
+  assert(0 >= _engine.lowerBound(_parentId));
+  return convert(_engine.value(ts, _parentId));
 }
 
 Int Bool2IntView::committedValue() {
-  assert(0 >= _engine->lowerBound(_parentId));
-  return convert(_engine->committedValue(_parentId));
+  assert(0 >= _engine.lowerBound(_parentId));
+  return convert(_engine.committedValue(_parentId));
 }

--- a/src/views/elementConst.cpp
+++ b/src/views/elementConst.cpp
@@ -2,24 +2,25 @@
 
 #include "core/engine.hpp"
 
-ElementConst::ElementConst(VarId parentId, std::vector<Int> array, Int offset)
-    : IntView(parentId), _array(array), _offset(offset) {}
+ElementConst::ElementConst(Engine& engine, VarId parentId,
+                           std::vector<Int> array, Int offset)
+    : IntView(engine, parentId), _array(array), _offset(offset) {}
 
 Int ElementConst::value(Timestamp ts) {
-  assert(safeIndex(_engine->value(ts, _parentId)) < _array.size());
-  return _array[safeIndex(_engine->value(ts, _parentId))];
+  assert(safeIndex(_engine.value(ts, _parentId)) < _array.size());
+  return _array[safeIndex(_engine.value(ts, _parentId))];
 }
 
 Int ElementConst::committedValue() {
-  assert(safeIndex(_engine->committedValue(_parentId)) < _array.size());
-  return _array[safeIndex(_engine->committedValue(_parentId))];
+  assert(safeIndex(_engine.committedValue(_parentId)) < _array.size());
+  return _array[safeIndex(_engine.committedValue(_parentId))];
 }
 
 Int ElementConst::lowerBound() const {
   const Int indexBegin =
-      std::max<Int>(0, _engine->lowerBound(_parentId) - _offset);
-  const Int indexEnd = std::min<Int>(
-      _array.size(), _engine->upperBound(_parentId) - _offset + 1);
+      std::max<Int>(0, _engine.lowerBound(_parentId) - _offset);
+  const Int indexEnd =
+      std::min<Int>(_array.size(), _engine.upperBound(_parentId) - _offset + 1);
   if (indexBegin >= static_cast<Int>(_array.size())) {
     return _array.back();
   } else if (indexEnd < 0) {
@@ -31,9 +32,9 @@ Int ElementConst::lowerBound() const {
 
 Int ElementConst::upperBound() const {
   const Int indexBegin =
-      std::max<Int>(0, _engine->lowerBound(_parentId) - _offset);
-  const Int indexEnd = std::min<Int>(
-      _array.size(), _engine->upperBound(_parentId) - _offset + 1);
+      std::max<Int>(0, _engine.lowerBound(_parentId) - _offset);
+  const Int indexEnd =
+      std::min<Int>(_array.size(), _engine.upperBound(_parentId) - _offset + 1);
 
   if (indexBegin >= static_cast<Int>(_array.size())) {
     return _array.back();

--- a/src/views/equalConst.cpp
+++ b/src/views/equalConst.cpp
@@ -3,16 +3,16 @@
 inline static Int compute(Int var, Int val) { return std::abs(var - val); }
 
 Int EqualConst::value(Timestamp ts) {
-  return compute(_engine->value(ts, _parentId), _val);
+  return compute(_engine.value(ts, _parentId), _val);
 }
 
 Int EqualConst::committedValue() {
-  return compute(_engine->committedValue(_parentId), _val);
+  return compute(_engine.committedValue(_parentId), _val);
 }
 
 Int EqualConst::lowerBound() const {
-  const Int lb = _engine->lowerBound(_parentId);
-  const Int ub = _engine->upperBound(_parentId);
+  const Int lb = _engine.lowerBound(_parentId);
+  const Int ub = _engine.upperBound(_parentId);
   if (lb <= _val && _val <= ub) {
     return Int(0);
   }
@@ -20,6 +20,6 @@ Int EqualConst::lowerBound() const {
 }
 
 Int EqualConst::upperBound() const {
-  return std::max(compute(_engine->lowerBound(_parentId), _val),
-                  compute(_engine->upperBound(_parentId), _val));
+  return std::max(compute(_engine.lowerBound(_parentId), _val),
+                  compute(_engine.upperBound(_parentId), _val));
 }

--- a/src/views/greaterEqualConst.cpp
+++ b/src/views/greaterEqualConst.cpp
@@ -5,17 +5,17 @@ static inline Int compute(Int var, Int val) {
 }
 
 Int GreaterEqualConst::value(Timestamp ts) {
-  return compute(_engine->value(ts, _parentId), _val);
+  return compute(_engine.value(ts, _parentId), _val);
 }
 
 Int GreaterEqualConst::committedValue() {
-  return compute(_engine->committedValue(_parentId), _val);
+  return compute(_engine.committedValue(_parentId), _val);
 }
 
 Int GreaterEqualConst::lowerBound() const {
-  return compute(_engine->upperBound(_parentId), _val);
+  return compute(_engine.upperBound(_parentId), _val);
 }
 
 Int GreaterEqualConst::upperBound() const {
-  return compute(_engine->lowerBound(_parentId), _val);
+  return compute(_engine.lowerBound(_parentId), _val);
 }

--- a/src/views/inSparseDomain.cpp
+++ b/src/views/inSparseDomain.cpp
@@ -11,9 +11,9 @@ inline bool all_in_range(size_t start, size_t stop,
   return std::all_of(vec.begin(), vec.end(), predicate);
 }
 
-InSparseDomain::InSparseDomain(VarId parentId,
+InSparseDomain::InSparseDomain(Engine& engine, VarId parentId,
                                const std::vector<DomainEntry>& domain)
-    : IntView(parentId), _offset(domain.front().lowerBound) {
+    : IntView(engine, parentId), _offset(domain.front().lowerBound) {
   assert(domain.size() > 0);
   assert(std::all_of(domain.begin(), domain.end(), [&](const auto& domEntry) {
     return domEntry.lowerBound <= domEntry.upperBound;
@@ -32,7 +32,7 @@ InSparseDomain::InSparseDomain(VarId parentId,
 }
 
 Int InSparseDomain::value(Timestamp ts) {
-  const Int val = _engine->value(ts, _parentId);
+  const Int val = _engine.value(ts, _parentId);
   if (val < _offset) {
     return _offset - val;
   }
@@ -43,7 +43,7 @@ Int InSparseDomain::value(Timestamp ts) {
 }
 
 Int InSparseDomain::committedValue() {
-  const Int val = _engine->committedValue(_parentId);
+  const Int val = _engine.committedValue(_parentId);
   if (val < _offset) {
     return _offset - val;
   }
@@ -54,8 +54,8 @@ Int InSparseDomain::committedValue() {
 }
 
 Int InSparseDomain::lowerBound() const {
-  const Int parentLb = _engine->lowerBound(_parentId);
-  const Int parentUb = _engine->upperBound(_parentId);
+  const Int parentLb = _engine.lowerBound(_parentId);
+  const Int parentUb = _engine.upperBound(_parentId);
   const Int dLb = _offset;
   const Int dUb = _offset + _valueViolation.size() - 1;
 
@@ -73,8 +73,8 @@ Int InSparseDomain::lowerBound() const {
 }
 
 Int InSparseDomain::upperBound() const {
-  const Int parentLb = _engine->lowerBound(_parentId);
-  const Int parentUb = _engine->upperBound(_parentId);
+  const Int parentLb = _engine.lowerBound(_parentId);
+  const Int parentUb = _engine.upperBound(_parentId);
   const Int dLb = _offset;
   const Int dUb = _offset + _valueViolation.size() - 1;
 

--- a/src/views/intAbsView.cpp
+++ b/src/views/intAbsView.cpp
@@ -3,20 +3,20 @@
 #include "core/engine.hpp"
 
 Int IntAbsView::value(Timestamp ts) {
-  return std::abs(_engine->value(ts, _parentId));
+  return std::abs(_engine.value(ts, _parentId));
 }
 
 Int IntAbsView::committedValue() {
-  return std::abs(_engine->committedValue(_parentId));
+  return std::abs(_engine.committedValue(_parentId));
 }
 
 Int IntAbsView::lowerBound() const {
-  const Int ub = _engine->upperBound(_parentId);
+  const Int ub = _engine.upperBound(_parentId);
   // the values of the source are always negative:
   if (ub < 0) {
     return -ub;
   }
-  const Int lb = _engine->lowerBound(_parentId);
+  const Int lb = _engine.lowerBound(_parentId);
   // lb <= 0 <= ub:
   if (lb <= 0) {
     return 0;
@@ -26,6 +26,6 @@ Int IntAbsView::lowerBound() const {
 }
 
 Int IntAbsView::upperBound() const {
-  return std::max(std::abs(_engine->lowerBound(_parentId)),
-                  _engine->upperBound(_parentId));
+  return std::max(std::abs(_engine.lowerBound(_parentId)),
+                  _engine.upperBound(_parentId));
 }

--- a/src/views/intMaxView.cpp
+++ b/src/views/intMaxView.cpp
@@ -2,17 +2,17 @@
 
 #include "core/engine.hpp"
 Int IntMaxView::value(Timestamp ts) {
-  return std::max<Int>(_max, _engine->value(ts, _parentId));
+  return std::max<Int>(_max, _engine.value(ts, _parentId));
 }
 
 Int IntMaxView::committedValue() {
-  return std::max<Int>(_max, _engine->committedValue(_parentId));
+  return std::max<Int>(_max, _engine.committedValue(_parentId));
 }
 
 Int IntMaxView::lowerBound() const {
-  return std::max<Int>(_max, _engine->lowerBound(_parentId));
+  return std::max<Int>(_max, _engine.lowerBound(_parentId));
 }
 
 Int IntMaxView::upperBound() const {
-  return std::max<Int>(_max, _engine->upperBound(_parentId));
+  return std::max<Int>(_max, _engine.upperBound(_parentId));
 }

--- a/src/views/intOffsetView.cpp
+++ b/src/views/intOffsetView.cpp
@@ -5,17 +5,17 @@
 extern Id NULL_ID;
 
 Int IntOffsetView::value(Timestamp ts) {
-  return _offset + _engine->value(ts, _parentId);
+  return _offset + _engine.value(ts, _parentId);
 }
 
 Int IntOffsetView::committedValue() {
-  return _offset + _engine->committedValue(_parentId);
+  return _offset + _engine.committedValue(_parentId);
 }
 
 Int IntOffsetView::lowerBound() const {
-  return _offset + _engine->lowerBound(_parentId);
+  return _offset + _engine.lowerBound(_parentId);
 }
 
 Int IntOffsetView::upperBound() const {
-  return _offset + _engine->upperBound(_parentId);
+  return _offset + _engine.upperBound(_parentId);
 }

--- a/src/views/lessEqualConst.cpp
+++ b/src/views/lessEqualConst.cpp
@@ -5,17 +5,17 @@ static inline Int compute(Int var, Int val) {
 }
 
 Int LessEqualConst::value(Timestamp ts) {
-  return compute(_engine->value(ts, _parentId), _val);
+  return compute(_engine.value(ts, _parentId), _val);
 }
 
 Int LessEqualConst::committedValue() {
-  return compute(_engine->committedValue(_parentId), _val);
+  return compute(_engine.committedValue(_parentId), _val);
 }
 
 Int LessEqualConst::lowerBound() const {
-  return compute(_engine->lowerBound(_parentId), _val);
+  return compute(_engine.lowerBound(_parentId), _val);
 }
 
 Int LessEqualConst::upperBound() const {
-  return compute(_engine->upperBound(_parentId), _val);
+  return compute(_engine.upperBound(_parentId), _val);
 }

--- a/src/views/notEqualConst.cpp
+++ b/src/views/notEqualConst.cpp
@@ -1,24 +1,24 @@
 #include "views/notEqualConst.hpp"
 
 Int NotEqualConst::value(Timestamp ts) {
-  return static_cast<Int>(_engine->value(ts, _parentId) == _val);
+  return static_cast<Int>(_engine.value(ts, _parentId) == _val);
 }
 
 Int NotEqualConst::committedValue() {
-  return static_cast<Int>(_engine->committedValue(_parentId) == _val);
+  return static_cast<Int>(_engine.committedValue(_parentId) == _val);
 }
 
 Int NotEqualConst::lowerBound() const {
-  if (_val == _engine->lowerBound(_parentId) &&
-      _val == _engine->upperBound(_parentId)) {
+  if (_val == _engine.lowerBound(_parentId) &&
+      _val == _engine.upperBound(_parentId)) {
     return 1;
   }
   return 0;
 }
 
 Int NotEqualConst::upperBound() const {
-  if (_val < _engine->lowerBound(_parentId) ||
-      _val > _engine->upperBound(_parentId)) {
+  if (_val < _engine.lowerBound(_parentId) ||
+      _val > _engine.upperBound(_parentId)) {
     return 0;
   }
   return 1;

--- a/src/views/notEqualView.cpp
+++ b/src/views/notEqualView.cpp
@@ -1,24 +1,24 @@
 #include "views/notEqualConst.hpp"
 
 Int NotEqualConst::value(Timestamp ts) {
-  return _engine->value(ts, _parentId) == _val;
+  return _engine.value(ts, _parentId) == _val;
 }
 
 Int NotEqualConst::committedValue() {
-  return _engine->committedValue(_parentId) == _val;
+  return _engine.committedValue(_parentId) == _val;
 }
 
 Int NotEqualConst::lowerBound() const {
-  if (_val == _engine->lowerBound(_parentId) &&
-      _val == _engine->upperBound(_parentId)) {
+  if (_val == _engine.lowerBound(_parentId) &&
+      _val == _engine.upperBound(_parentId)) {
     return 1;
   }
   return 0;
 }
 
 Int NotEqualConst::upperBound() const {
-  if (_val < _engine->lowerBound(_parentId) ||
-      _val > _engine->upperBound(_parentId)) {
+  if (_val < _engine.lowerBound(_parentId) ||
+      _val > _engine.upperBound(_parentId)) {
     return 0;
   }
   return 1;

--- a/src/views/scalarView.cpp
+++ b/src/views/scalarView.cpp
@@ -5,19 +5,19 @@
 extern Id NULL_ID;
 
 Int ScalarView::value(Timestamp ts) {
-  return _scalar * _engine->value(ts, _parentId);
+  return _scalar * _engine.value(ts, _parentId);
 }
 
 Int ScalarView::committedValue() {
-  return _scalar * _engine->committedValue(_parentId);
+  return _scalar * _engine.committedValue(_parentId);
 }
 
 Int ScalarView::lowerBound() const {
-  return std::min(_scalar * _engine->lowerBound(_parentId),
-                  _scalar * _engine->upperBound(_parentId));
+  return std::min(_scalar * _engine.lowerBound(_parentId),
+                  _scalar * _engine.upperBound(_parentId));
 }
 
 Int ScalarView::upperBound() const {
-  return std::max(_scalar * _engine->lowerBound(_parentId),
-                  _scalar * _engine->upperBound(_parentId));
+  return std::max(_scalar * _engine.lowerBound(_parentId),
+                  _scalar * _engine.upperBound(_parentId));
 }

--- a/src/views/violation2BoolView.cpp
+++ b/src/views/violation2BoolView.cpp
@@ -5,9 +5,9 @@
 static Int convert(Int value) { return std::min<Int>(value, 1); }
 
 Int Violation2BoolView::value(Timestamp ts) {
-  return convert(_engine->value(ts, _parentId));
+  return convert(_engine.value(ts, _parentId));
 }
 
 Int Violation2BoolView::committedValue() {
-  return convert(_engine->committedValue(_parentId));
+  return convert(_engine.committedValue(_parentId));
 }

--- a/test/benchmarks/tMagicSquare.cpp
+++ b/test/benchmarks/tMagicSquare.cpp
@@ -57,7 +57,7 @@ class MagicSquareTest : public ::testing::Test {
     // {
     //   VarId allDiffViol = engine->makeIntVar(0, 0, n2);
     //   violations.push_back(allDiffViol);
-    //   engine->makeConstraint<AllDifferent>(allDiffViol, flat);
+    //   engine->makeConstraint<AllDifferent>(*engine, allDiffViol, flat);
     // }
 
     {
@@ -68,8 +68,8 @@ class MagicSquareTest : public ::testing::Test {
         VarId rowSum = engine->makeIntVar(0, 0, n2 * n);
         VarId rowViol = engine->makeIntVar(0, 0, n2 * n);
 
-        engine->makeInvariant<Linear>(rowSum, square.at(i));
-        engine->makeConstraint<Equal>(rowViol, rowSum, magicSumVar);
+        engine->makeInvariant<Linear>(*engine, rowSum, square.at(i));
+        engine->makeConstraint<Equal>(*engine, rowViol, rowSum, magicSumVar);
         violations.push_back(rowViol);
       }
     }
@@ -86,8 +86,8 @@ class MagicSquareTest : public ::testing::Test {
         for (int j = 0; j < n; ++j) {
           col.push_back(square.at(j).at(i));
         }
-        engine->makeInvariant<Linear>(colSum, ones, col);
-        engine->makeConstraint<Equal>(colViol, colSum, magicSumVar);
+        engine->makeInvariant<Linear>(*engine, colSum, ones, col);
+        engine->makeConstraint<Equal>(*engine, colViol, colSum, magicSumVar);
         violations.push_back(colViol);
       }
     }
@@ -103,8 +103,9 @@ class MagicSquareTest : public ::testing::Test {
       for (int j = 0; j < n; ++j) {
         diag.push_back(square.at(j).at(j));
       }
-      engine->makeInvariant<Linear>(downDiagSum, ones, diag);
-      engine->makeConstraint<Equal>(downDiagViol, downDiagSum, magicSumVar);
+      engine->makeInvariant<Linear>(*engine, downDiagSum, ones, diag);
+      engine->makeConstraint<Equal>(*engine, downDiagViol, downDiagSum,
+                                    magicSumVar);
       violations.push_back(downDiagViol);
     }
 
@@ -119,15 +120,16 @@ class MagicSquareTest : public ::testing::Test {
       for (int j = 0; j < n; ++j) {
         diag.push_back(square.at(n - j - 1).at(j));
       }
-      engine->makeInvariant<Linear>(upDiagSum, ones, diag);
-      engine->makeConstraint<Equal>(upDiagViol, upDiagSum, magicSumVar);
+      engine->makeInvariant<Linear>(*engine, upDiagSum, ones, diag);
+      engine->makeConstraint<Equal>(*engine, upDiagViol, upDiagSum,
+                                    magicSumVar);
       violations.push_back(upDiagViol);
     }
 
     std::vector<Int> ones{};
     ones.assign(violations.size(), 1);
     totalViolation = engine->makeIntVar(0, 0, n2 * n2 * 2 + 2 * n2);
-    engine->makeInvariant<Linear>(totalViolation, ones, violations);
+    engine->makeInvariant<Linear>(*engine, totalViolation, ones, violations);
     engine->close();
   }
 

--- a/test/benchmarks/tNQueens.cpp
+++ b/test/benchmarks/tNQueens.cpp
@@ -18,22 +18,23 @@ TEST(NQueens, CommitsInvariant) {
   for (Int i = 0; i < n; ++i) {
     const VarId q = engine.makeIntVar(1, 1, n);
     queens.push_back(q);
-    q_offset_minus.push_back(engine.makeIntView<IntOffsetView>(q, -i));
-    q_offset_plus.push_back(engine.makeIntView<IntOffsetView>(q, i));
+    q_offset_minus.push_back(engine.makeIntView<IntOffsetView>(engine, q, -i));
+    q_offset_plus.push_back(engine.makeIntView<IntOffsetView>(engine, q, i));
   }
 
   auto violation1 = engine.makeIntVar(0, 0, n);
   auto violation2 = engine.makeIntVar(0, 0, n);
   auto violation3 = engine.makeIntVar(0, 0, n);
 
-  engine.makeConstraint<AllDifferent>(violation1, queens);
-  engine.makeConstraint<AllDifferent>(violation2, q_offset_minus);
-  engine.makeConstraint<AllDifferent>(violation3, q_offset_plus);
+  engine.makeConstraint<AllDifferent>(engine, violation1, queens);
+  engine.makeConstraint<AllDifferent>(engine, violation2, q_offset_minus);
+  engine.makeConstraint<AllDifferent>(engine, violation3, q_offset_plus);
 
   auto total_violation = engine.makeIntVar(0, 0, 3 * n);
 
   engine.makeInvariant<Linear>(
-      total_violation, std::vector<VarId>{violation1, violation2, violation3});
+      engine, total_violation,
+      std::vector<VarId>{violation1, violation2, violation3});
 
   engine.close();
 

--- a/test/benchmarks/tTSPTW.cpp
+++ b/test/benchmarks/tTSPTW.cpp
@@ -57,30 +57,34 @@ class TSPTWTest : public ::testing::Test {
     // Ignore index 0
     for (int i = 1; i < n; ++i) {
       // timeToPrev[i] = dist[i][pred[i]]
-      timeToPrev[i] = engine->makeIntView<ElementConst>(pred[i], dist[i]);
+      timeToPrev[i] =
+          engine->makeIntView<ElementConst>(*engine, pred[i], dist[i]);
       // arrivalPrev[i] = arrivalTime[pred[i]]
     }
 
     // Ignore index 0
     for (int i = 1; i < n; ++i) {
       // arrivalPrev[i] = arrivalTime[pred[i]]
-      engine->makeInvariant<ElementVar>(arrivalPrev[i], pred[i], arrivalTime);
+      engine->makeInvariant<ElementVar>(*engine, arrivalPrev[i], pred[i],
+                                        arrivalTime);
       // arrivalTime[i] = arrivalPrev[i] + timeToPrev[i]
       engine->makeInvariant<Linear>(
-          arrivalTime[i], std::vector<VarId>({arrivalPrev[i], timeToPrev[i]}));
+          *engine, arrivalTime[i],
+          std::vector<VarId>({arrivalPrev[i], timeToPrev[i]}));
     }
 
     // totalDist = sum(timeToPrev)
     totalDist = engine->makeIntVar(0, 0, MAX_TIME);
-    engine->makeInvariant<Linear>(totalDist, timeToPrev);
+    engine->makeInvariant<Linear>(*engine, totalDist, timeToPrev);
 
     VarId leqConst = engine->makeIntVar(100, 100, 100);
     for (int i = 0; i < n; ++i) {
-      engine->makeConstraint<LessEqual>(violation[i], arrivalTime[i], leqConst);
+      engine->makeConstraint<LessEqual>(*engine, violation[i], arrivalTime[i],
+                                        leqConst);
     }
 
     totalViolation = engine->makeIntVar(0, 0, MAX_TIME * n);
-    engine->makeInvariant<Linear>(totalViolation, violation);
+    engine->makeInvariant<Linear>(*engine, totalViolation, violation);
 
     engine->close();
     for (const VarId p : pred) {

--- a/test/constraints/tAllDifferent.cpp
+++ b/test/constraints/tAllDifferent.cpp
@@ -59,7 +59,7 @@ TEST_F(AllDifferentTest, UpdateBounds) {
                             engine->makeIntVar(0, 0, 0)};
   const VarId violationId = engine->makeIntVar(0, 0, 2);
   AllDifferent& invariant = engine->makeConstraint<AllDifferent>(
-      violationId, std::vector<VarId>(inputs));
+      *engine, violationId, std::vector<VarId>(inputs));
 
   for (const auto& [aLb, aUb] : boundVec) {
     EXPECT_TRUE(aLb <= aUb);
@@ -70,7 +70,7 @@ TEST_F(AllDifferentTest, UpdateBounds) {
       for (const auto& [cLb, cUb] : boundVec) {
         EXPECT_TRUE(cLb <= cUb);
         engine->updateBounds(inputs.at(2), cLb, cUb, false);
-        invariant.updateBounds(*engine);
+        invariant.updateBounds();
         ASSERT_EQ(0, engine->lowerBound(violationId));
         ASSERT_EQ(inputs.size() - 1, engine->upperBound(violationId));
       }
@@ -90,7 +90,7 @@ TEST_F(AllDifferentTest, Recompute) {
     const VarId c = engine->makeIntVar(lb, lb, ub);
     const VarId violationId = engine->makeIntVar(0, 0, 2);
     AllDifferent& invariant = engine->makeConstraint<AllDifferent>(
-        violationId, std::vector<VarId>{a, b, c});
+        *engine, violationId, std::vector<VarId>{a, b, c});
     engine->close();
 
     for (Int aVal = lb; aVal <= ub; ++aVal) {
@@ -101,7 +101,7 @@ TEST_F(AllDifferentTest, Recompute) {
           engine->setValue(engine->currentTimestamp(), c, cVal);
           const Int expectedViolation =
               computeViolation(std::vector{aVal, bVal, cVal});
-          invariant.recompute(engine->currentTimestamp(), *engine);
+          invariant.recompute(engine->currentTimestamp());
           EXPECT_EQ(expectedViolation,
                     engine->value(engine->currentTimestamp(), violationId));
         }
@@ -123,7 +123,7 @@ TEST_F(AllDifferentTest, NotifyInputChanged) {
                               engine->makeIntVar(lb, lb, ub)};
     const VarId violationId = engine->makeIntVar(0, 0, 2);
     AllDifferent& invariant = engine->makeConstraint<AllDifferent>(
-        violationId, std::vector<VarId>(inputs));
+        *engine, violationId, std::vector<VarId>(inputs));
     engine->close();
 
     for (Int val = lb; val <= ub; ++val) {
@@ -132,8 +132,7 @@ TEST_F(AllDifferentTest, NotifyInputChanged) {
         const Int expectedViolation =
             computeViolation(engine->currentTimestamp(), inputs);
 
-        invariant.notifyInputChanged(engine->currentTimestamp(), *engine,
-                                     LocalId(i));
+        invariant.notifyInputChanged(engine->currentTimestamp(), LocalId(i));
         EXPECT_EQ(expectedViolation,
                   engine->value(engine->currentTimestamp(), violationId));
       }
@@ -161,21 +160,21 @@ TEST_F(AllDifferentTest, NextInput) {
 
   const VarId violationId = engine->makeIntVar(0, 0, 2);
   AllDifferent& invariant = engine->makeConstraint<AllDifferent>(
-      violationId, std::vector<VarId>(inputs));
+      *engine, violationId, std::vector<VarId>(inputs));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     std::vector<bool> notified(maxVarId + 1, false);
     for (size_t i = 0; i < numInputs; ++i) {
-      const VarId varId = invariant.nextInput(ts, *engine);
+      const VarId varId = invariant.nextInput(ts);
       EXPECT_NE(varId, NULL_ID);
       EXPECT_TRUE(minVarId <= varId);
       EXPECT_TRUE(varId <= maxVarId);
       EXPECT_FALSE(notified.at(varId));
       notified[varId] = true;
     }
-    EXPECT_EQ(invariant.nextInput(ts, *engine), NULL_ID);
+    EXPECT_EQ(invariant.nextInput(ts), NULL_ID);
     for (size_t varId = minVarId; varId <= maxVarId; ++varId) {
       EXPECT_TRUE(notified.at(varId));
     }
@@ -196,18 +195,18 @@ TEST_F(AllDifferentTest, NotifyCurrentInputChanged) {
   }
   const VarId violationId = engine->makeIntVar(0, 0, numInputs - 1);
   AllDifferent& invariant = engine->makeConstraint<AllDifferent>(
-      violationId, std::vector<VarId>(inputs));
+      *engine, violationId, std::vector<VarId>(inputs));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     for (const VarId varId : inputs) {
-      EXPECT_EQ(invariant.nextInput(ts, *engine), varId);
+      EXPECT_EQ(invariant.nextInput(ts), varId);
       const Int oldVal = engine->value(ts, varId);
       do {
         engine->setValue(ts, varId, valueDist(gen));
       } while (engine->value(ts, varId) == oldVal);
-      invariant.notifyCurrentInputChanged(ts, *engine);
+      invariant.notifyCurrentInputChanged(ts);
       EXPECT_EQ(engine->value(ts, violationId), computeViolation(ts, inputs));
     }
   }
@@ -234,7 +233,7 @@ TEST_F(AllDifferentTest, Commit) {
 
   const VarId violationId = engine->makeIntVar(0, 0, 2);
   AllDifferent& invariant = engine->makeConstraint<AllDifferent>(
-      violationId, std::vector<VarId>(inputs));
+      *engine, violationId, std::vector<VarId>(inputs));
   engine->close();
 
   EXPECT_EQ(engine->value(engine->currentTimestamp(), violationId),
@@ -253,11 +252,11 @@ TEST_F(AllDifferentTest, Commit) {
     } while (oldVal == engine->value(ts, inputs.at(i)));
 
     // notify changes
-    invariant.notifyInputChanged(ts, *engine, LocalId(i));
+    invariant.notifyInputChanged(ts, LocalId(i));
 
     // incremental value
     const Int notifiedViolation = engine->value(ts, violationId);
-    invariant.recompute(ts, *engine);
+    invariant.recompute(ts);
 
     ASSERT_EQ(notifiedViolation, engine->value(ts, violationId));
 
@@ -265,8 +264,8 @@ TEST_F(AllDifferentTest, Commit) {
     committedValues.at(i) = engine->value(ts, inputs.at(i));
     engine->commitIf(ts, violationId);
 
-    invariant.commit(ts, *engine);
-    invariant.recompute(ts + 1, *engine);
+    invariant.commit(ts);
+    invariant.recompute(ts + 1);
     ASSERT_EQ(notifiedViolation, engine->value(ts + 1, violationId));
   }
 }
@@ -274,40 +273,36 @@ TEST_F(AllDifferentTest, Commit) {
 class MockAllDifferent : public AllDifferent {
  public:
   bool registered = false;
-  void registerVars(Engine& engine) override {
+  void registerVars() override {
     registered = true;
-    AllDifferent::registerVars(engine);
+    AllDifferent::registerVars();
   }
-  explicit MockAllDifferent(VarId violationId, std::vector<VarId> t_variables)
-      : AllDifferent(violationId, t_variables) {
-    ON_CALL(*this, recompute)
-        .WillByDefault([this](Timestamp timestamp, Engine& engine) {
-          return AllDifferent::recompute(timestamp, engine);
-        });
-    ON_CALL(*this, nextInput)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          return AllDifferent::nextInput(t, engine);
-        });
+  explicit MockAllDifferent(Engine& engine, VarId violationId,
+                            std::vector<VarId> t_variables)
+      : AllDifferent(engine, violationId, t_variables) {
+    ON_CALL(*this, recompute).WillByDefault([this](Timestamp timestamp) {
+      return AllDifferent::recompute(timestamp);
+    });
+    ON_CALL(*this, nextInput).WillByDefault([this](Timestamp timestamp) {
+      return AllDifferent::nextInput(timestamp);
+    });
     ON_CALL(*this, notifyCurrentInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          AllDifferent::notifyCurrentInputChanged(t, engine);
+        .WillByDefault([this](Timestamp timestamp) {
+          AllDifferent::notifyCurrentInputChanged(timestamp);
         });
     ON_CALL(*this, notifyInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine, LocalId id) {
-          AllDifferent::notifyInputChanged(t, engine, id);
+        .WillByDefault([this](Timestamp timestamp, LocalId id) {
+          AllDifferent::notifyInputChanged(timestamp, id);
         });
-    ON_CALL(*this, commit).WillByDefault([this](Timestamp t, Engine& engine) {
-      AllDifferent::commit(t, engine);
+    ON_CALL(*this, commit).WillByDefault([this](Timestamp timestamp) {
+      AllDifferent::commit(timestamp);
     });
   }
-  MOCK_METHOD(void, recompute, (Timestamp timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(VarId, nextInput, (Timestamp, Engine&), (override));
-  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(void, notifyInputChanged,
-              (Timestamp t, Engine& engine, LocalId id), (override));
-  MOCK_METHOD(void, commit, (Timestamp timestamp, Engine& engine), (override));
+  MOCK_METHOD(void, recompute, (Timestamp), (override));
+  MOCK_METHOD(VarId, nextInput, (Timestamp), (override));
+  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp), (override));
+  MOCK_METHOD(void, notifyInputChanged, (Timestamp, LocalId), (override));
+  MOCK_METHOD(void, commit, (Timestamp), (override));
 };
 
 TEST_F(AllDifferentTest, EngineIntegration) {
@@ -322,8 +317,8 @@ TEST_F(AllDifferentTest, EngineIntegration) {
     }
     const VarId viol = engine->makeIntVar(0, 0, numArgs);
     testNotifications<MockAllDifferent>(
-        &engine->makeConstraint<MockAllDifferent>(viol, args), propMode,
-        markingMode, numArgs + 1, args.front(), 1, viol);
+        &engine->makeConstraint<MockAllDifferent>(*engine, viol, args),
+        propMode, markingMode, numArgs + 1, args.front(), 1, viol);
   }
 }
 

--- a/test/constraints/tBoolEqual.cpp
+++ b/test/constraints/tBoolEqual.cpp
@@ -46,7 +46,8 @@ TEST_F(BoolEqualTest, UpdateBounds) {
   const VarId y = engine->makeIntVar(
       boundVec.front().first, boundVec.front().first, boundVec.front().second);
   const VarId violationId = engine->makeIntVar(0, 0, 2);
-  BoolEqual& invariant = engine->makeConstraint<BoolEqual>(violationId, x, y);
+  BoolEqual& invariant =
+      engine->makeConstraint<BoolEqual>(*engine, violationId, x, y);
   engine->close();
 
   for (const auto& [xLb, xUb] : boundVec) {
@@ -55,13 +56,13 @@ TEST_F(BoolEqualTest, UpdateBounds) {
     for (const auto& [yLb, yUb] : boundVec) {
       EXPECT_TRUE(yLb <= yUb);
       engine->updateBounds(y, yLb, yUb, false);
-      invariant.updateBounds(*engine);
+      invariant.updateBounds();
       for (Int xVal = xLb; xVal <= xUb; ++xVal) {
         engine->setValue(engine->currentTimestamp(), x, xVal);
         for (Int yVal = yLb; yVal <= yUb; ++yVal) {
           engine->setValue(engine->currentTimestamp(), y, yVal);
-          invariant.updateBounds(*engine);
-          invariant.recompute(engine->currentTimestamp(), *engine);
+          invariant.updateBounds();
+          invariant.recompute(engine->currentTimestamp());
         }
       }
       ASSERT_GE(0, engine->lowerBound(violationId));
@@ -84,7 +85,7 @@ TEST_F(BoolEqualTest, Recompute) {
   const VarId violationId =
       engine->makeIntVar(0, 0, std::max(xUb - yLb, yUb - xLb));
   BoolEqual& invariant = engine->makeConstraint<BoolEqual>(
-      violationId, inputs.at(0), inputs.at(1));
+      *engine, violationId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Int xVal = xLb; xVal <= xUb; ++xVal) {
@@ -93,7 +94,7 @@ TEST_F(BoolEqualTest, Recompute) {
       engine->setValue(engine->currentTimestamp(), inputs.at(1), yVal);
 
       const Int expectedViolation = computeViolation(xVal, yVal);
-      invariant.recompute(engine->currentTimestamp(), *engine);
+      invariant.recompute(engine->currentTimestamp());
       EXPECT_EQ(expectedViolation,
                 engine->value(engine->currentTimestamp(), violationId));
     }
@@ -110,7 +111,7 @@ TEST_F(BoolEqualTest, NotifyInputChanged) {
                                           engine->makeIntVar(ub, lb, ub)};
   const VarId violationId = engine->makeIntVar(0, 0, ub - lb);
   BoolEqual& invariant = engine->makeConstraint<BoolEqual>(
-      violationId, inputs.at(0), inputs.at(1));
+      *engine, violationId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Int val = lb; val <= ub; ++val) {
@@ -119,8 +120,7 @@ TEST_F(BoolEqualTest, NotifyInputChanged) {
       const Int expectedViolation =
           computeViolation(engine->currentTimestamp(), inputs);
 
-      invariant.notifyInputChanged(engine->currentTimestamp(), *engine,
-                                   LocalId(i));
+      invariant.notifyInputChanged(engine->currentTimestamp(), LocalId(i));
       EXPECT_EQ(expectedViolation,
                 engine->value(engine->currentTimestamp(), violationId));
     }
@@ -139,21 +139,21 @@ TEST_F(BoolEqualTest, NextInput) {
   const VarId minVarId = *std::min_element(inputs.begin(), inputs.end());
   const VarId maxVarId = *std::max_element(inputs.begin(), inputs.end());
   BoolEqual& invariant = engine->makeConstraint<BoolEqual>(
-      violationId, inputs.at(0), inputs.at(1));
+      *engine, violationId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     std::vector<bool> notified(maxVarId + 1, false);
     for (size_t i = 0; i < inputs.size(); ++i) {
-      const VarId varId = invariant.nextInput(ts, *engine);
+      const VarId varId = invariant.nextInput(ts);
       EXPECT_NE(varId, NULL_ID);
       EXPECT_TRUE(minVarId <= varId);
       EXPECT_TRUE(varId <= maxVarId);
       EXPECT_FALSE(notified.at(varId));
       notified[varId] = true;
     }
-    EXPECT_EQ(invariant.nextInput(ts, *engine), NULL_ID);
+    EXPECT_EQ(invariant.nextInput(ts), NULL_ID);
     for (size_t varId = minVarId; varId <= maxVarId; ++varId) {
       EXPECT_TRUE(notified.at(varId));
     }
@@ -172,18 +172,18 @@ TEST_F(BoolEqualTest, NotifyCurrentInputChanged) {
       engine->makeIntVar(valueDist(gen), lb, ub)};
   const VarId violationId = engine->makeIntVar(0, 0, ub - lb);
   BoolEqual& invariant = engine->makeConstraint<BoolEqual>(
-      violationId, inputs.at(0), inputs.at(1));
+      *engine, violationId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     for (const VarId varId : inputs) {
-      EXPECT_EQ(invariant.nextInput(ts, *engine), varId);
+      EXPECT_EQ(invariant.nextInput(ts), varId);
       const Int oldVal = engine->value(ts, varId);
       do {
         engine->setValue(ts, varId, valueDist(gen));
       } while (engine->value(ts, varId) == oldVal);
-      invariant.notifyCurrentInputChanged(ts, *engine);
+      invariant.notifyCurrentInputChanged(ts);
       EXPECT_EQ(engine->value(ts, violationId), computeViolation(ts, inputs));
     }
   }
@@ -206,7 +206,7 @@ TEST_F(BoolEqualTest, Commit) {
 
   const VarId violationId = engine->makeIntVar(0, 0, 2);
   BoolEqual& invariant = engine->makeConstraint<BoolEqual>(
-      violationId, inputs.at(0), inputs.at(1));
+      *engine, violationId, inputs.at(0), inputs.at(1));
   engine->close();
 
   EXPECT_EQ(engine->value(engine->currentTimestamp(), violationId),
@@ -225,11 +225,11 @@ TEST_F(BoolEqualTest, Commit) {
     } while (oldVal == engine->value(ts, inputs.at(i)));
 
     // notify changes
-    invariant.notifyInputChanged(ts, *engine, LocalId(i));
+    invariant.notifyInputChanged(ts, LocalId(i));
 
     // incremental value
     const Int notifiedViolation = engine->value(ts, violationId);
-    invariant.recompute(ts, *engine);
+    invariant.recompute(ts);
 
     ASSERT_EQ(notifiedViolation, engine->value(ts, violationId));
 
@@ -237,8 +237,8 @@ TEST_F(BoolEqualTest, Commit) {
     committedValues.at(i) = engine->value(ts, inputs.at(i));
     engine->commitIf(ts, violationId);
 
-    invariant.commit(ts, *engine);
-    invariant.recompute(ts + 1, *engine);
+    invariant.commit(ts);
+    invariant.recompute(ts + 1);
     ASSERT_EQ(notifiedViolation, engine->value(ts + 1, violationId));
   }
 }
@@ -246,40 +246,35 @@ TEST_F(BoolEqualTest, Commit) {
 class MockBoolEqual : public BoolEqual {
  public:
   bool registered = false;
-  void registerVars(Engine& engine) override {
+  void registerVars() override {
     registered = true;
-    BoolEqual::registerVars(engine);
+    BoolEqual::registerVars();
   }
-  explicit MockBoolEqual(VarId violationId, VarId x, VarId y)
-      : BoolEqual(violationId, x, y) {
-    ON_CALL(*this, recompute)
-        .WillByDefault([this](Timestamp timestamp, Engine& engine) {
-          return BoolEqual::recompute(timestamp, engine);
-        });
-    ON_CALL(*this, nextInput)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          return BoolEqual::nextInput(t, engine);
-        });
+  explicit MockBoolEqual(Engine& engine, VarId violationId, VarId x, VarId y)
+      : BoolEqual(engine, violationId, x, y) {
+    ON_CALL(*this, recompute).WillByDefault([this](Timestamp timestamp) {
+      return BoolEqual::recompute(timestamp);
+    });
+    ON_CALL(*this, nextInput).WillByDefault([this](Timestamp timestamp) {
+      return BoolEqual::nextInput(timestamp);
+    });
     ON_CALL(*this, notifyCurrentInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          BoolEqual::notifyCurrentInputChanged(t, engine);
+        .WillByDefault([this](Timestamp timestamp) {
+          BoolEqual::notifyCurrentInputChanged(timestamp);
         });
     ON_CALL(*this, notifyInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine, LocalId id) {
-          BoolEqual::notifyInputChanged(t, engine, id);
+        .WillByDefault([this](Timestamp timestamp, LocalId id) {
+          BoolEqual::notifyInputChanged(timestamp, id);
         });
-    ON_CALL(*this, commit).WillByDefault([this](Timestamp t, Engine& engine) {
-      BoolEqual::commit(t, engine);
+    ON_CALL(*this, commit).WillByDefault([this](Timestamp timestamp) {
+      BoolEqual::commit(timestamp);
     });
   }
-  MOCK_METHOD(void, recompute, (Timestamp timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(VarId, nextInput, (Timestamp, Engine&), (override));
-  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(void, notifyInputChanged,
-              (Timestamp t, Engine& engine, LocalId id), (override));
-  MOCK_METHOD(void, commit, (Timestamp timestamp, Engine& engine), (override));
+  MOCK_METHOD(void, recompute, (Timestamp), (override));
+  MOCK_METHOD(VarId, nextInput, (Timestamp), (override));
+  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp), (override));
+  MOCK_METHOD(void, notifyInputChanged, (Timestamp, LocalId), (override));
+  MOCK_METHOD(void, commit, (Timestamp), (override));
 };
 TEST_F(BoolEqualTest, EngineIntegration) {
   for (const auto& [propMode, markingMode] : propMarkModes) {
@@ -290,7 +285,7 @@ TEST_F(BoolEqualTest, EngineIntegration) {
     const VarId y = engine->makeIntVar(0, 0, 100);
     const VarId viol = engine->makeIntVar(0, 0, 200);
     testNotifications<MockBoolEqual>(
-        &engine->makeConstraint<MockBoolEqual>(viol, x, y), propMode,
+        &engine->makeConstraint<MockBoolEqual>(*engine, viol, x, y), propMode,
         markingMode, 3, x, 1, viol);
   }
 }

--- a/test/constraints/tBoolLessEqual.cpp
+++ b/test/constraints/tBoolLessEqual.cpp
@@ -50,7 +50,7 @@ TEST_F(BoolLessEqualTest, UpdateBounds) {
       boundVec.front().first, boundVec.front().first, boundVec.front().second);
   const VarId violationId = engine->makeIntVar(0, 0, 2);
   BoolLessEqual& invariant =
-      engine->makeConstraint<BoolLessEqual>(violationId, x, y);
+      engine->makeConstraint<BoolLessEqual>(*engine, violationId, x, y);
   engine->close();
 
   for (const auto& [xLb, xUb] : boundVec) {
@@ -59,13 +59,13 @@ TEST_F(BoolLessEqualTest, UpdateBounds) {
     for (const auto& [yLb, yUb] : boundVec) {
       EXPECT_TRUE(yLb <= yUb);
       engine->updateBounds(y, yLb, yUb, false);
-      invariant.updateBounds(*engine);
+      invariant.updateBounds();
       for (Int xVal = xLb; xVal <= xUb; ++xVal) {
         engine->setValue(engine->currentTimestamp(), x, xVal);
         for (Int yVal = yLb; yVal <= yUb; ++yVal) {
           engine->setValue(engine->currentTimestamp(), y, yVal);
-          invariant.updateBounds(*engine);
-          invariant.recompute(engine->currentTimestamp(), *engine);
+          invariant.updateBounds();
+          invariant.recompute(engine->currentTimestamp());
         }
       }
       ASSERT_GE(0, engine->lowerBound(violationId));
@@ -88,7 +88,7 @@ TEST_F(BoolLessEqualTest, Recompute) {
   const VarId violationId =
       engine->makeIntVar(0, 0, std::max(xUb - yLb, yUb - xLb));
   BoolLessEqual& invariant = engine->makeConstraint<BoolLessEqual>(
-      violationId, inputs.at(0), inputs.at(1));
+      *engine, violationId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Int xVal = xLb; xVal <= xUb; ++xVal) {
@@ -97,7 +97,7 @@ TEST_F(BoolLessEqualTest, Recompute) {
       engine->setValue(engine->currentTimestamp(), inputs.at(1), yVal);
 
       const Int expectedViolation = computeViolation(xVal, yVal);
-      invariant.recompute(engine->currentTimestamp(), *engine);
+      invariant.recompute(engine->currentTimestamp());
       EXPECT_EQ(expectedViolation,
                 engine->value(engine->currentTimestamp(), violationId));
     }
@@ -114,7 +114,7 @@ TEST_F(BoolLessEqualTest, NotifyInputChanged) {
                                           engine->makeIntVar(ub, lb, ub)};
   const VarId violationId = engine->makeIntVar(0, 0, ub - lb);
   BoolLessEqual& invariant = engine->makeConstraint<BoolLessEqual>(
-      violationId, inputs.at(0), inputs.at(1));
+      *engine, violationId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Int val = lb; val <= ub; ++val) {
@@ -123,8 +123,7 @@ TEST_F(BoolLessEqualTest, NotifyInputChanged) {
       const Int expectedViolation =
           computeViolation(engine->currentTimestamp(), inputs);
 
-      invariant.notifyInputChanged(engine->currentTimestamp(), *engine,
-                                   LocalId(i));
+      invariant.notifyInputChanged(engine->currentTimestamp(), LocalId(i));
       EXPECT_EQ(expectedViolation,
                 engine->value(engine->currentTimestamp(), violationId));
     }
@@ -143,21 +142,21 @@ TEST_F(BoolLessEqualTest, NextInput) {
   const VarId minVarId = *std::min_element(inputs.begin(), inputs.end());
   const VarId maxVarId = *std::max_element(inputs.begin(), inputs.end());
   BoolLessEqual& invariant = engine->makeConstraint<BoolLessEqual>(
-      violationId, inputs.at(0), inputs.at(1));
+      *engine, violationId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     std::vector<bool> notified(maxVarId + 1, false);
     for (size_t i = 0; i < inputs.size(); ++i) {
-      const VarId varId = invariant.nextInput(ts, *engine);
+      const VarId varId = invariant.nextInput(ts);
       EXPECT_NE(varId, NULL_ID);
       EXPECT_TRUE(minVarId <= varId);
       EXPECT_TRUE(varId <= maxVarId);
       EXPECT_FALSE(notified.at(varId));
       notified[varId] = true;
     }
-    EXPECT_EQ(invariant.nextInput(ts, *engine), NULL_ID);
+    EXPECT_EQ(invariant.nextInput(ts), NULL_ID);
     for (size_t varId = minVarId; varId <= maxVarId; ++varId) {
       EXPECT_TRUE(notified.at(varId));
     }
@@ -176,18 +175,18 @@ TEST_F(BoolLessEqualTest, NotifyCurrentInputChanged) {
       engine->makeIntVar(valueDist(gen), lb, ub)};
   const VarId violationId = engine->makeIntVar(0, 0, ub - lb);
   BoolLessEqual& invariant = engine->makeConstraint<BoolLessEqual>(
-      violationId, inputs.at(0), inputs.at(1));
+      *engine, violationId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     for (const VarId varId : inputs) {
-      EXPECT_EQ(invariant.nextInput(ts, *engine), varId);
+      EXPECT_EQ(invariant.nextInput(ts), varId);
       const Int oldVal = engine->value(ts, varId);
       do {
         engine->setValue(ts, varId, valueDist(gen));
       } while (engine->value(ts, varId) == oldVal);
-      invariant.notifyCurrentInputChanged(ts, *engine);
+      invariant.notifyCurrentInputChanged(ts);
       EXPECT_EQ(engine->value(ts, violationId), computeViolation(ts, inputs));
     }
   }
@@ -210,7 +209,7 @@ TEST_F(BoolLessEqualTest, Commit) {
 
   const VarId violationId = engine->makeIntVar(0, 0, 2);
   BoolLessEqual& invariant = engine->makeConstraint<BoolLessEqual>(
-      violationId, inputs.at(0), inputs.at(1));
+      *engine, violationId, inputs.at(0), inputs.at(1));
   engine->close();
 
   EXPECT_EQ(engine->value(engine->currentTimestamp(), violationId),
@@ -229,11 +228,11 @@ TEST_F(BoolLessEqualTest, Commit) {
     } while (oldVal == engine->value(ts, inputs.at(i)));
 
     // notify changes
-    invariant.notifyInputChanged(ts, *engine, LocalId(i));
+    invariant.notifyInputChanged(ts, LocalId(i));
 
     // incremental value
     const Int notifiedViolation = engine->value(ts, violationId);
-    invariant.recompute(ts, *engine);
+    invariant.recompute(ts);
 
     ASSERT_EQ(notifiedViolation, engine->value(ts, violationId));
 
@@ -241,8 +240,8 @@ TEST_F(BoolLessEqualTest, Commit) {
     committedValues.at(i) = engine->value(ts, inputs.at(i));
     engine->commitIf(ts, violationId);
 
-    invariant.commit(ts, *engine);
-    invariant.recompute(ts + 1, *engine);
+    invariant.commit(ts);
+    invariant.recompute(ts + 1);
     ASSERT_EQ(notifiedViolation, engine->value(ts + 1, violationId));
   }
 }
@@ -250,40 +249,36 @@ TEST_F(BoolLessEqualTest, Commit) {
 class MockBoolLessEqual : public BoolLessEqual {
  public:
   bool registered = false;
-  void registerVars(Engine& engine) override {
+  void registerVars() override {
     registered = true;
-    BoolLessEqual::registerVars(engine);
+    BoolLessEqual::registerVars();
   }
-  explicit MockBoolLessEqual(VarId violationId, VarId x, VarId y)
-      : BoolLessEqual(violationId, x, y) {
-    ON_CALL(*this, recompute)
-        .WillByDefault([this](Timestamp timestamp, Engine& engine) {
-          return BoolLessEqual::recompute(timestamp, engine);
-        });
-    ON_CALL(*this, nextInput)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          return BoolLessEqual::nextInput(t, engine);
-        });
+  explicit MockBoolLessEqual(Engine& engine, VarId violationId, VarId x,
+                             VarId y)
+      : BoolLessEqual(engine, violationId, x, y) {
+    ON_CALL(*this, recompute).WillByDefault([this](Timestamp timestamp) {
+      return BoolLessEqual::recompute(timestamp);
+    });
+    ON_CALL(*this, nextInput).WillByDefault([this](Timestamp timestamp) {
+      return BoolLessEqual::nextInput(timestamp);
+    });
     ON_CALL(*this, notifyCurrentInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          BoolLessEqual::notifyCurrentInputChanged(t, engine);
+        .WillByDefault([this](Timestamp timestamp) {
+          BoolLessEqual::notifyCurrentInputChanged(timestamp);
         });
     ON_CALL(*this, notifyInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine, LocalId id) {
-          BoolLessEqual::notifyInputChanged(t, engine, id);
+        .WillByDefault([this](Timestamp timestamp, LocalId id) {
+          BoolLessEqual::notifyInputChanged(timestamp, id);
         });
-    ON_CALL(*this, commit).WillByDefault([this](Timestamp t, Engine& engine) {
-      BoolLessEqual::commit(t, engine);
+    ON_CALL(*this, commit).WillByDefault([this](Timestamp timestamp) {
+      BoolLessEqual::commit(timestamp);
     });
   }
-  MOCK_METHOD(void, recompute, (Timestamp timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(VarId, nextInput, (Timestamp, Engine&), (override));
-  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(void, notifyInputChanged,
-              (Timestamp t, Engine& engine, LocalId id), (override));
-  MOCK_METHOD(void, commit, (Timestamp timestamp, Engine& engine), (override));
+  MOCK_METHOD(void, recompute, (Timestamp), (override));
+  MOCK_METHOD(VarId, nextInput, (Timestamp), (override));
+  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp), (override));
+  MOCK_METHOD(void, notifyInputChanged, (Timestamp, LocalId), (override));
+  MOCK_METHOD(void, commit, (Timestamp), (override));
 };
 TEST_F(BoolLessEqualTest, EngineIntegration) {
   for (const auto& [propMode, markingMode] : propMarkModes) {
@@ -294,8 +289,8 @@ TEST_F(BoolLessEqualTest, EngineIntegration) {
     const VarId y = engine->makeIntVar(0, 0, 100);
     const VarId viol = engine->makeIntVar(0, 0, 200);
     testNotifications<MockBoolLessEqual>(
-        &engine->makeConstraint<MockBoolLessEqual>(viol, x, y), propMode,
-        markingMode, 3, x, 1, viol);
+        &engine->makeConstraint<MockBoolLessEqual>(*engine, viol, x, y),
+        propMode, markingMode, 3, x, 1, viol);
   }
 }
 }  // namespace

--- a/test/constraints/tBoolLessThan.cpp
+++ b/test/constraints/tBoolLessThan.cpp
@@ -68,7 +68,7 @@ TEST_F(BoolLessThanTest, UpdateBounds) {
       boundVec.front().first, boundVec.front().first, boundVec.front().second);
   const VarId violationId = engine->makeIntVar(0, 0, 2);
   BoolLessThan& invariant =
-      engine->makeConstraint<BoolLessThan>(violationId, x, y);
+      engine->makeConstraint<BoolLessThan>(*engine, violationId, x, y);
   engine->close();
 
   for (const auto& [xLb, xUb] : boundVec) {
@@ -77,13 +77,13 @@ TEST_F(BoolLessThanTest, UpdateBounds) {
     for (const auto& [yLb, yUb] : boundVec) {
       EXPECT_TRUE(yLb <= yUb);
       engine->updateBounds(y, yLb, yUb, false);
-      invariant.updateBounds(*engine);
+      invariant.updateBounds();
       for (Int xVal = xLb; xVal <= xUb; ++xVal) {
         engine->setValue(engine->currentTimestamp(), x, xVal);
         for (Int yVal = yLb; yVal <= yUb; ++yVal) {
           engine->setValue(engine->currentTimestamp(), y, yVal);
-          invariant.updateBounds(*engine);
-          invariant.recompute(engine->currentTimestamp(), *engine);
+          invariant.updateBounds();
+          invariant.recompute(engine->currentTimestamp());
         }
       }
       ASSERT_GE(0, engine->lowerBound(violationId));
@@ -106,7 +106,7 @@ TEST_F(BoolLessThanTest, Recompute) {
   const VarId violationId =
       engine->makeIntVar(0, 0, std::max(xUb - yLb, yUb - xLb));
   BoolLessThan& invariant = engine->makeConstraint<BoolLessThan>(
-      violationId, inputs.at(0), inputs.at(1));
+      *engine, violationId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Int xVal = xLb; xVal <= xUb; ++xVal) {
@@ -115,7 +115,7 @@ TEST_F(BoolLessThanTest, Recompute) {
       engine->setValue(engine->currentTimestamp(), inputs.at(1), yVal);
 
       const Int expectedViolation = computeViolation(xVal, yVal);
-      invariant.recompute(engine->currentTimestamp(), *engine);
+      invariant.recompute(engine->currentTimestamp());
       EXPECT_EQ(expectedViolation,
                 engine->value(engine->currentTimestamp(), violationId));
     }
@@ -132,7 +132,7 @@ TEST_F(BoolLessThanTest, NotifyInputChanged) {
                                           engine->makeIntVar(ub, lb, ub)};
   const VarId violationId = engine->makeIntVar(0, 0, ub - lb);
   BoolLessThan& invariant = engine->makeConstraint<BoolLessThan>(
-      violationId, inputs.at(0), inputs.at(1));
+      *engine, violationId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Int val = lb; val <= ub; ++val) {
@@ -141,8 +141,7 @@ TEST_F(BoolLessThanTest, NotifyInputChanged) {
       const Int expectedViolation =
           computeViolation(engine->currentTimestamp(), inputs);
 
-      invariant.notifyInputChanged(engine->currentTimestamp(), *engine,
-                                   LocalId(i));
+      invariant.notifyInputChanged(engine->currentTimestamp(), LocalId(i));
       EXPECT_EQ(expectedViolation,
                 engine->value(engine->currentTimestamp(), violationId));
     }
@@ -161,21 +160,21 @@ TEST_F(BoolLessThanTest, NextInput) {
   const VarId minVarId = *std::min_element(inputs.begin(), inputs.end());
   const VarId maxVarId = *std::max_element(inputs.begin(), inputs.end());
   BoolLessThan& invariant = engine->makeConstraint<BoolLessThan>(
-      violationId, inputs.at(0), inputs.at(1));
+      *engine, violationId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     std::vector<bool> notified(maxVarId + 1, false);
     for (size_t i = 0; i < inputs.size(); ++i) {
-      const VarId varId = invariant.nextInput(ts, *engine);
+      const VarId varId = invariant.nextInput(ts);
       EXPECT_NE(varId, NULL_ID);
       EXPECT_TRUE(minVarId <= varId);
       EXPECT_TRUE(varId <= maxVarId);
       EXPECT_FALSE(notified.at(varId));
       notified[varId] = true;
     }
-    EXPECT_EQ(invariant.nextInput(ts, *engine), NULL_ID);
+    EXPECT_EQ(invariant.nextInput(ts), NULL_ID);
     for (size_t varId = minVarId; varId <= maxVarId; ++varId) {
       EXPECT_TRUE(notified.at(varId));
     }
@@ -194,18 +193,18 @@ TEST_F(BoolLessThanTest, NotifyCurrentInputChanged) {
       engine->makeIntVar(valueDist(gen), lb, ub)};
   const VarId violationId = engine->makeIntVar(0, 0, ub - lb);
   BoolLessThan& invariant = engine->makeConstraint<BoolLessThan>(
-      violationId, inputs.at(0), inputs.at(1));
+      *engine, violationId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     for (const VarId varId : inputs) {
-      EXPECT_EQ(invariant.nextInput(ts, *engine), varId);
+      EXPECT_EQ(invariant.nextInput(ts), varId);
       const Int oldVal = engine->value(ts, varId);
       do {
         engine->setValue(ts, varId, valueDist(gen));
       } while (engine->value(ts, varId) == oldVal);
-      invariant.notifyCurrentInputChanged(ts, *engine);
+      invariant.notifyCurrentInputChanged(ts);
       EXPECT_EQ(engine->value(ts, violationId), computeViolation(ts, inputs));
     }
   }
@@ -228,7 +227,7 @@ TEST_F(BoolLessThanTest, Commit) {
 
   const VarId violationId = engine->makeIntVar(0, 0, 2);
   BoolLessThan& invariant = engine->makeConstraint<BoolLessThan>(
-      violationId, inputs.at(0), inputs.at(1));
+      *engine, violationId, inputs.at(0), inputs.at(1));
   engine->close();
 
   EXPECT_EQ(engine->value(engine->currentTimestamp(), violationId),
@@ -247,11 +246,11 @@ TEST_F(BoolLessThanTest, Commit) {
     } while (oldVal == engine->value(ts, inputs.at(i)));
 
     // notify changes
-    invariant.notifyInputChanged(ts, *engine, LocalId(i));
+    invariant.notifyInputChanged(ts, LocalId(i));
 
     // incremental value
     const Int notifiedViolation = engine->value(ts, violationId);
-    invariant.recompute(ts, *engine);
+    invariant.recompute(ts);
 
     ASSERT_EQ(notifiedViolation, engine->value(ts, violationId));
 
@@ -259,8 +258,8 @@ TEST_F(BoolLessThanTest, Commit) {
     committedValues.at(i) = engine->value(ts, inputs.at(i));
     engine->commitIf(ts, violationId);
 
-    invariant.commit(ts, *engine);
-    invariant.recompute(ts + 1, *engine);
+    invariant.commit(ts);
+    invariant.recompute(ts + 1);
     ASSERT_EQ(notifiedViolation, engine->value(ts + 1, violationId));
   }
 }
@@ -268,40 +267,35 @@ TEST_F(BoolLessThanTest, Commit) {
 class MockBoolLessThan : public BoolLessThan {
  public:
   bool registered = false;
-  void registerVars(Engine& engine) override {
+  void registerVars() override {
     registered = true;
-    BoolLessThan::registerVars(engine);
+    BoolLessThan::registerVars();
   }
-  explicit MockBoolLessThan(VarId violationId, VarId x, VarId y)
-      : BoolLessThan(violationId, x, y) {
-    ON_CALL(*this, recompute)
-        .WillByDefault([this](Timestamp timestamp, Engine& engine) {
-          return BoolLessThan::recompute(timestamp, engine);
-        });
-    ON_CALL(*this, nextInput)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          return BoolLessThan::nextInput(t, engine);
-        });
+  explicit MockBoolLessThan(Engine& engine, VarId violationId, VarId x, VarId y)
+      : BoolLessThan(engine, violationId, x, y) {
+    ON_CALL(*this, recompute).WillByDefault([this](Timestamp timestamp) {
+      return BoolLessThan::recompute(timestamp);
+    });
+    ON_CALL(*this, nextInput).WillByDefault([this](Timestamp timestamp) {
+      return BoolLessThan::nextInput(timestamp);
+    });
     ON_CALL(*this, notifyCurrentInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          BoolLessThan::notifyCurrentInputChanged(t, engine);
+        .WillByDefault([this](Timestamp timestamp) {
+          BoolLessThan::notifyCurrentInputChanged(timestamp);
         });
     ON_CALL(*this, notifyInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine, LocalId id) {
-          BoolLessThan::notifyInputChanged(t, engine, id);
+        .WillByDefault([this](Timestamp timestamp, LocalId id) {
+          BoolLessThan::notifyInputChanged(timestamp, id);
         });
-    ON_CALL(*this, commit).WillByDefault([this](Timestamp t, Engine& engine) {
-      BoolLessThan::commit(t, engine);
+    ON_CALL(*this, commit).WillByDefault([this](Timestamp timestamp) {
+      BoolLessThan::commit(timestamp);
     });
   }
-  MOCK_METHOD(void, recompute, (Timestamp timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(VarId, nextInput, (Timestamp, Engine&), (override));
-  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(void, notifyInputChanged,
-              (Timestamp t, Engine& engine, LocalId id), (override));
-  MOCK_METHOD(void, commit, (Timestamp timestamp, Engine& engine), (override));
+  MOCK_METHOD(void, recompute, (Timestamp), (override));
+  MOCK_METHOD(VarId, nextInput, (Timestamp), (override));
+  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp), (override));
+  MOCK_METHOD(void, notifyInputChanged, (Timestamp, LocalId), (override));
+  MOCK_METHOD(void, commit, (Timestamp), (override));
 };
 TEST_F(BoolLessThanTest, EngineIntegration) {
   for (const auto& [propMode, markingMode] : propMarkModes) {
@@ -312,8 +306,8 @@ TEST_F(BoolLessThanTest, EngineIntegration) {
     const VarId y = engine->makeIntVar(0, 0, 100);
     const VarId viol = engine->makeIntVar(0, 0, 200);
     testNotifications<MockBoolLessThan>(
-        &engine->makeConstraint<MockBoolLessThan>(viol, x, y), propMode,
-        markingMode, 3, x, 1, viol);
+        &engine->makeConstraint<MockBoolLessThan>(*engine, viol, x, y),
+        propMode, markingMode, 3, x, 1, viol);
   }
 }
 }  // namespace

--- a/test/constraints/tEqual.cpp
+++ b/test/constraints/tEqual.cpp
@@ -46,7 +46,7 @@ TEST_F(EqualTest, UpdateBounds) {
   const VarId y = engine->makeIntVar(
       boundVec.front().first, boundVec.front().first, boundVec.front().second);
   const VarId violationId = engine->makeIntVar(0, 0, 2);
-  Equal& invariant = engine->makeConstraint<Equal>(violationId, x, y);
+  Equal& invariant = engine->makeConstraint<Equal>(*engine, violationId, x, y);
   engine->close();
 
   for (const auto& [xLb, xUb] : boundVec) {
@@ -55,14 +55,14 @@ TEST_F(EqualTest, UpdateBounds) {
     for (const auto& [yLb, yUb] : boundVec) {
       EXPECT_TRUE(yLb <= yUb);
       engine->updateBounds(y, yLb, yUb, false);
-      invariant.updateBounds(*engine);
+      invariant.updateBounds();
       std::vector<Int> violations;
       for (Int xVal = xLb; xVal <= xUb; ++xVal) {
         engine->setValue(engine->currentTimestamp(), x, xVal);
         for (Int yVal = yLb; yVal <= yUb; ++yVal) {
           engine->setValue(engine->currentTimestamp(), y, yVal);
-          invariant.updateBounds(*engine);
-          invariant.recompute(engine->currentTimestamp(), *engine);
+          invariant.updateBounds();
+          invariant.recompute(engine->currentTimestamp());
           violations.emplace_back(
               engine->value(engine->currentTimestamp(), violationId));
         }
@@ -88,8 +88,8 @@ TEST_F(EqualTest, Recompute) {
                                           engine->makeIntVar(yUb, yLb, yUb)};
   const VarId violationId =
       engine->makeIntVar(0, 0, std::max(xUb - yLb, yUb - xLb));
-  Equal& invariant =
-      engine->makeConstraint<Equal>(violationId, inputs.at(0), inputs.at(1));
+  Equal& invariant = engine->makeConstraint<Equal>(*engine, violationId,
+                                                   inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Int xVal = xLb; xVal <= xUb; ++xVal) {
@@ -98,7 +98,7 @@ TEST_F(EqualTest, Recompute) {
       engine->setValue(engine->currentTimestamp(), inputs.at(1), yVal);
 
       const Int expectedViolation = computeViolation(xVal, yVal);
-      invariant.recompute(engine->currentTimestamp(), *engine);
+      invariant.recompute(engine->currentTimestamp());
       EXPECT_EQ(expectedViolation,
                 engine->value(engine->currentTimestamp(), violationId));
     }
@@ -114,8 +114,8 @@ TEST_F(EqualTest, NotifyInputChanged) {
   const std::array<const VarId, 2> inputs{engine->makeIntVar(ub, lb, ub),
                                           engine->makeIntVar(ub, lb, ub)};
   const VarId violationId = engine->makeIntVar(0, 0, ub - lb);
-  Equal& invariant =
-      engine->makeConstraint<Equal>(violationId, inputs.at(0), inputs.at(1));
+  Equal& invariant = engine->makeConstraint<Equal>(*engine, violationId,
+                                                   inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Int val = lb; val <= ub; ++val) {
@@ -124,8 +124,7 @@ TEST_F(EqualTest, NotifyInputChanged) {
       const Int expectedViolation =
           computeViolation(engine->currentTimestamp(), inputs);
 
-      invariant.notifyInputChanged(engine->currentTimestamp(), *engine,
-                                   LocalId(i));
+      invariant.notifyInputChanged(engine->currentTimestamp(), LocalId(i));
       EXPECT_EQ(expectedViolation,
                 engine->value(engine->currentTimestamp(), violationId));
     }
@@ -143,22 +142,22 @@ TEST_F(EqualTest, NextInput) {
   const VarId violationId = engine->makeIntVar(0, 0, 2);
   const VarId minVarId = *std::min_element(inputs.begin(), inputs.end());
   const VarId maxVarId = *std::max_element(inputs.begin(), inputs.end());
-  Equal& invariant =
-      engine->makeConstraint<Equal>(violationId, inputs.at(0), inputs.at(1));
+  Equal& invariant = engine->makeConstraint<Equal>(*engine, violationId,
+                                                   inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     std::vector<bool> notified(maxVarId + 1, false);
     for (size_t i = 0; i < inputs.size(); ++i) {
-      const VarId varId = invariant.nextInput(ts, *engine);
+      const VarId varId = invariant.nextInput(ts);
       EXPECT_NE(varId, NULL_ID);
       EXPECT_TRUE(minVarId <= varId);
       EXPECT_TRUE(varId <= maxVarId);
       EXPECT_FALSE(notified.at(varId));
       notified[varId] = true;
     }
-    EXPECT_EQ(invariant.nextInput(ts, *engine), NULL_ID);
+    EXPECT_EQ(invariant.nextInput(ts), NULL_ID);
     for (size_t varId = minVarId; varId <= maxVarId; ++varId) {
       EXPECT_TRUE(notified.at(varId));
     }
@@ -176,19 +175,19 @@ TEST_F(EqualTest, NotifyCurrentInputChanged) {
       engine->makeIntVar(valueDist(gen), lb, ub),
       engine->makeIntVar(valueDist(gen), lb, ub)};
   const VarId violationId = engine->makeIntVar(0, 0, ub - lb);
-  Equal& invariant =
-      engine->makeConstraint<Equal>(violationId, inputs.at(0), inputs.at(1));
+  Equal& invariant = engine->makeConstraint<Equal>(*engine, violationId,
+                                                   inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     for (const VarId varId : inputs) {
-      EXPECT_EQ(invariant.nextInput(ts, *engine), varId);
+      EXPECT_EQ(invariant.nextInput(ts), varId);
       const Int oldVal = engine->value(ts, varId);
       do {
         engine->setValue(ts, varId, valueDist(gen));
       } while (engine->value(ts, varId) == oldVal);
-      invariant.notifyCurrentInputChanged(ts, *engine);
+      invariant.notifyCurrentInputChanged(ts);
       EXPECT_EQ(engine->value(ts, violationId), computeViolation(ts, inputs));
     }
   }
@@ -210,8 +209,8 @@ TEST_F(EqualTest, Commit) {
       engine->makeIntVar(committedValues.at(1), lb, ub)};
 
   const VarId violationId = engine->makeIntVar(0, 0, 2);
-  Equal& invariant =
-      engine->makeConstraint<Equal>(violationId, inputs.at(0), inputs.at(1));
+  Equal& invariant = engine->makeConstraint<Equal>(*engine, violationId,
+                                                   inputs.at(0), inputs.at(1));
   engine->close();
 
   EXPECT_EQ(engine->value(engine->currentTimestamp(), violationId),
@@ -230,11 +229,11 @@ TEST_F(EqualTest, Commit) {
     } while (oldVal == engine->value(ts, inputs.at(i)));
 
     // notify changes
-    invariant.notifyInputChanged(ts, *engine, LocalId(i));
+    invariant.notifyInputChanged(ts, LocalId(i));
 
     // incremental value
     const Int notifiedViolation = engine->value(ts, violationId);
-    invariant.recompute(ts, *engine);
+    invariant.recompute(ts);
 
     ASSERT_EQ(notifiedViolation, engine->value(ts, violationId));
 
@@ -242,8 +241,8 @@ TEST_F(EqualTest, Commit) {
     committedValues.at(i) = engine->value(ts, inputs.at(i));
     engine->commitIf(ts, violationId);
 
-    invariant.commit(ts, *engine);
-    invariant.recompute(ts + 1, *engine);
+    invariant.commit(ts);
+    invariant.recompute(ts + 1);
     ASSERT_EQ(notifiedViolation, engine->value(ts + 1, violationId));
   }
 }
@@ -251,40 +250,35 @@ TEST_F(EqualTest, Commit) {
 class MockEqual : public Equal {
  public:
   bool registered = false;
-  void registerVars(Engine& engine) override {
+  void registerVars() override {
     registered = true;
-    Equal::registerVars(engine);
+    Equal::registerVars();
   }
-  explicit MockEqual(VarId violationId, VarId x, VarId y)
-      : Equal(violationId, x, y) {
-    ON_CALL(*this, recompute)
-        .WillByDefault([this](Timestamp timestamp, Engine& engine) {
-          return Equal::recompute(timestamp, engine);
-        });
-    ON_CALL(*this, nextInput)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          return Equal::nextInput(t, engine);
-        });
+  explicit MockEqual(Engine& engine, VarId violationId, VarId x, VarId y)
+      : Equal(engine, violationId, x, y) {
+    ON_CALL(*this, recompute).WillByDefault([this](Timestamp timestamp) {
+      return Equal::recompute(timestamp);
+    });
+    ON_CALL(*this, nextInput).WillByDefault([this](Timestamp timestamp) {
+      return Equal::nextInput(timestamp);
+    });
     ON_CALL(*this, notifyCurrentInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          Equal::notifyCurrentInputChanged(t, engine);
+        .WillByDefault([this](Timestamp timestamp) {
+          Equal::notifyCurrentInputChanged(timestamp);
         });
     ON_CALL(*this, notifyInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine, LocalId id) {
-          Equal::notifyInputChanged(t, engine, id);
+        .WillByDefault([this](Timestamp timestamp, LocalId id) {
+          Equal::notifyInputChanged(timestamp, id);
         });
-    ON_CALL(*this, commit).WillByDefault([this](Timestamp t, Engine& engine) {
-      Equal::commit(t, engine);
+    ON_CALL(*this, commit).WillByDefault([this](Timestamp timestamp) {
+      Equal::commit(timestamp);
     });
   }
-  MOCK_METHOD(void, recompute, (Timestamp timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(VarId, nextInput, (Timestamp, Engine&), (override));
-  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(void, notifyInputChanged,
-              (Timestamp t, Engine& engine, LocalId id), (override));
-  MOCK_METHOD(void, commit, (Timestamp timestamp, Engine& engine), (override));
+  MOCK_METHOD(void, recompute, (Timestamp), (override));
+  MOCK_METHOD(VarId, nextInput, (Timestamp), (override));
+  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp), (override));
+  MOCK_METHOD(void, notifyInputChanged, (Timestamp, LocalId), (override));
+  MOCK_METHOD(void, commit, (Timestamp), (override));
 };
 TEST_F(EqualTest, EngineIntegration) {
   for (const auto& [propMode, markingMode] : propMarkModes) {
@@ -294,8 +288,9 @@ TEST_F(EqualTest, EngineIntegration) {
     const VarId x = engine->makeIntVar(5, -100, 100);
     const VarId y = engine->makeIntVar(0, -100, 100);
     const VarId viol = engine->makeIntVar(0, 0, 200);
-    testNotifications<MockEqual>(&engine->makeConstraint<MockEqual>(viol, x, y),
-                                 propMode, markingMode, 3, x, 1, viol);
+    testNotifications<MockEqual>(
+        &engine->makeConstraint<MockEqual>(*engine, viol, x, y), propMode,
+        markingMode, 3, x, 1, viol);
   }
 }
 }  // namespace

--- a/test/constraints/tLessEqual.cpp
+++ b/test/constraints/tLessEqual.cpp
@@ -47,7 +47,8 @@ TEST_F(LessEqualTest, UpdateBounds) {
   const VarId y = engine->makeIntVar(
       boundVec.front().first, boundVec.front().first, boundVec.front().second);
   const VarId violationId = engine->makeIntVar(0, 0, 2);
-  LessEqual& invariant = engine->makeConstraint<LessEqual>(violationId, x, y);
+  LessEqual& invariant =
+      engine->makeConstraint<LessEqual>(*engine, violationId, x, y);
   engine->close();
 
   for (const auto& [xLb, xUb] : boundVec) {
@@ -56,14 +57,14 @@ TEST_F(LessEqualTest, UpdateBounds) {
     for (const auto& [yLb, yUb] : boundVec) {
       EXPECT_TRUE(yLb <= yUb);
       engine->updateBounds(y, yLb, yUb, false);
-      invariant.updateBounds(*engine);
+      invariant.updateBounds();
       std::vector<Int> violations;
       for (Int xVal = xLb; xVal <= xUb; ++xVal) {
         engine->setValue(engine->currentTimestamp(), x, xVal);
         for (Int yVal = yLb; yVal <= yUb; ++yVal) {
           engine->setValue(engine->currentTimestamp(), y, yVal);
-          invariant.updateBounds(*engine);
-          invariant.recompute(engine->currentTimestamp(), *engine);
+          invariant.updateBounds();
+          invariant.recompute(engine->currentTimestamp());
           violations.emplace_back(
               engine->value(engine->currentTimestamp(), violationId));
         }
@@ -89,7 +90,8 @@ TEST_F(LessEqualTest, Recompute) {
   const VarId y = engine->makeIntVar(yUb, yLb, yUb);
   const VarId violationId =
       engine->makeIntVar(0, 0, std::max(xUb - yLb, yUb - xLb));
-  LessEqual& invariant = engine->makeConstraint<LessEqual>(violationId, x, y);
+  LessEqual& invariant =
+      engine->makeConstraint<LessEqual>(*engine, violationId, x, y);
   engine->close();
 
   for (Int xVal = xLb; xVal <= xUb; ++xVal) {
@@ -98,7 +100,7 @@ TEST_F(LessEqualTest, Recompute) {
       engine->setValue(engine->currentTimestamp(), y, yVal);
 
       const Int expectedViolation = computeViolation(xVal, yVal);
-      invariant.recompute(engine->currentTimestamp(), *engine);
+      invariant.recompute(engine->currentTimestamp());
       EXPECT_EQ(expectedViolation,
                 engine->value(engine->currentTimestamp(), violationId));
     }
@@ -115,7 +117,7 @@ TEST_F(LessEqualTest, NotifyInputChanged) {
                               engine->makeIntVar(ub, lb, ub)};
   const VarId violationId = engine->makeIntVar(0, 0, ub - lb);
   LessEqual& invariant = engine->makeConstraint<LessEqual>(
-      violationId, inputs.at(0), inputs.at(1));
+      *engine, violationId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Int val = lb; val <= ub; ++val) {
@@ -124,8 +126,7 @@ TEST_F(LessEqualTest, NotifyInputChanged) {
       const Int expectedViolation =
           computeViolation(engine->currentTimestamp(), inputs);
 
-      invariant.notifyInputChanged(engine->currentTimestamp(), *engine,
-                                   LocalId(i));
+      invariant.notifyInputChanged(engine->currentTimestamp(), LocalId(i));
       EXPECT_EQ(expectedViolation,
                 engine->value(engine->currentTimestamp(), violationId));
     }
@@ -145,21 +146,21 @@ TEST_F(LessEqualTest, NextInput) {
   const VarId maxVarId = *std::max_element(inputs.begin(), inputs.end());
 
   LessEqual& invariant = engine->makeConstraint<LessEqual>(
-      violationId, inputs.at(0), inputs.at(1));
+      *engine, violationId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     std::vector<bool> notified(maxVarId + 1, false);
     for (size_t i = 0; i < inputs.size(); ++i) {
-      const VarId varId = invariant.nextInput(ts, *engine);
+      const VarId varId = invariant.nextInput(ts);
       EXPECT_NE(varId, NULL_ID);
       EXPECT_TRUE(minVarId <= varId);
       EXPECT_TRUE(varId <= maxVarId);
       EXPECT_FALSE(notified.at(varId));
       notified[varId] = true;
     }
-    EXPECT_EQ(invariant.nextInput(ts, *engine), NULL_ID);
+    EXPECT_EQ(invariant.nextInput(ts), NULL_ID);
     for (size_t varId = minVarId; varId <= maxVarId; ++varId) {
       EXPECT_TRUE(notified.at(varId));
     }
@@ -178,18 +179,18 @@ TEST_F(LessEqualTest, NotifyCurrentInputChanged) {
       engine->makeIntVar(valueDist(gen), lb, ub)};
   const VarId violationId = engine->makeIntVar(0, 0, ub - lb);
   LessEqual& invariant = engine->makeConstraint<LessEqual>(
-      violationId, inputs.at(0), inputs.at(1));
+      *engine, violationId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     for (const VarId varId : inputs) {
-      EXPECT_EQ(invariant.nextInput(ts, *engine), varId);
+      EXPECT_EQ(invariant.nextInput(ts), varId);
       const Int oldVal = engine->value(ts, varId);
       do {
         engine->setValue(ts, varId, valueDist(gen));
       } while (engine->value(ts, varId) == oldVal);
-      invariant.notifyCurrentInputChanged(ts, *engine);
+      invariant.notifyCurrentInputChanged(ts);
       EXPECT_EQ(engine->value(ts, violationId), computeViolation(ts, inputs));
     }
   }
@@ -211,7 +212,7 @@ TEST_F(LessEqualTest, Commit) {
 
   const VarId violationId = engine->makeIntVar(0, 0, 2);
   LessEqual& invariant = engine->makeConstraint<LessEqual>(
-      violationId, inputs.at(0), inputs.at(1));
+      *engine, violationId, inputs.at(0), inputs.at(1));
   engine->close();
 
   EXPECT_EQ(engine->value(engine->currentTimestamp(), violationId),
@@ -230,11 +231,11 @@ TEST_F(LessEqualTest, Commit) {
     } while (oldVal == engine->value(ts, inputs.at(i)));
 
     // notify changes
-    invariant.notifyInputChanged(ts, *engine, LocalId(i));
+    invariant.notifyInputChanged(ts, LocalId(i));
 
     // incremental value
     const Int notifiedViolation = engine->value(ts, violationId);
-    invariant.recompute(ts, *engine);
+    invariant.recompute(ts);
 
     ASSERT_EQ(notifiedViolation, engine->value(ts, violationId));
 
@@ -242,8 +243,8 @@ TEST_F(LessEqualTest, Commit) {
     committedValues.at(i) = engine->value(ts, inputs.at(i));
     engine->commitIf(ts, violationId);
 
-    invariant.commit(ts, *engine);
-    invariant.recompute(ts + 1, *engine);
+    invariant.commit(ts);
+    invariant.recompute(ts + 1);
     ASSERT_EQ(notifiedViolation, engine->value(ts + 1, violationId));
   }
 }
@@ -251,40 +252,35 @@ TEST_F(LessEqualTest, Commit) {
 class MockLessEqual : public LessEqual {
  public:
   bool registered = false;
-  void registerVars(Engine& engine) override {
+  void registerVars() override {
     registered = true;
-    LessEqual::registerVars(engine);
+    LessEqual::registerVars();
   }
-  explicit MockLessEqual(VarId violationId, VarId x, VarId y)
-      : LessEqual(violationId, x, y) {
-    ON_CALL(*this, recompute)
-        .WillByDefault([this](Timestamp timestamp, Engine& engine) {
-          return LessEqual::recompute(timestamp, engine);
-        });
-    ON_CALL(*this, nextInput)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          return LessEqual::nextInput(t, engine);
-        });
+  explicit MockLessEqual(Engine& engine, VarId violationId, VarId x, VarId y)
+      : LessEqual(engine, violationId, x, y) {
+    ON_CALL(*this, recompute).WillByDefault([this](Timestamp timestamp) {
+      return LessEqual::recompute(timestamp);
+    });
+    ON_CALL(*this, nextInput).WillByDefault([this](Timestamp timestamp) {
+      return LessEqual::nextInput(timestamp);
+    });
     ON_CALL(*this, notifyCurrentInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          LessEqual::notifyCurrentInputChanged(t, engine);
+        .WillByDefault([this](Timestamp timestamp) {
+          LessEqual::notifyCurrentInputChanged(timestamp);
         });
     ON_CALL(*this, notifyInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine, LocalId id) {
-          LessEqual::notifyInputChanged(t, engine, id);
+        .WillByDefault([this](Timestamp timestamp, LocalId id) {
+          LessEqual::notifyInputChanged(timestamp, id);
         });
-    ON_CALL(*this, commit).WillByDefault([this](Timestamp t, Engine& engine) {
-      LessEqual::commit(t, engine);
+    ON_CALL(*this, commit).WillByDefault([this](Timestamp timestamp) {
+      LessEqual::commit(timestamp);
     });
   }
-  MOCK_METHOD(void, recompute, (Timestamp timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(VarId, nextInput, (Timestamp, Engine&), (override));
-  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(void, notifyInputChanged,
-              (Timestamp t, Engine& engine, LocalId id), (override));
-  MOCK_METHOD(void, commit, (Timestamp timestamp, Engine& engine), (override));
+  MOCK_METHOD(void, recompute, (Timestamp), (override));
+  MOCK_METHOD(VarId, nextInput, (Timestamp), (override));
+  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp), (override));
+  MOCK_METHOD(void, notifyInputChanged, (Timestamp, LocalId), (override));
+  MOCK_METHOD(void, commit, (Timestamp), (override));
 };
 TEST_F(LessEqualTest, EngineIntegration) {
   for (const auto& [propMode, markingMode] : propMarkModes) {
@@ -295,7 +291,7 @@ TEST_F(LessEqualTest, EngineIntegration) {
     const VarId y = engine->makeIntVar(0, -100, 100);
     const VarId viol = engine->makeIntVar(0, 0, 200);
     testNotifications<MockLessEqual>(
-        &engine->makeConstraint<MockLessEqual>(viol, x, y), propMode,
+        &engine->makeConstraint<MockLessEqual>(*engine, viol, x, y), propMode,
         markingMode, 3, x, -5, viol);
   }
 }

--- a/test/constraints/tNotEqual.cpp
+++ b/test/constraints/tNotEqual.cpp
@@ -43,7 +43,8 @@ TEST_F(NotEqualTest, UpdateBounds) {
   const VarId y = engine->makeIntVar(
       boundVec.front().first, boundVec.front().first, boundVec.front().second);
   const VarId violationId = engine->makeIntVar(0, 0, 2);
-  NotEqual& invariant = engine->makeConstraint<NotEqual>(violationId, x, y);
+  NotEqual& invariant =
+      engine->makeConstraint<NotEqual>(*engine, violationId, x, y);
   engine->close();
 
   for (const auto& [xLb, xUb] : boundVec) {
@@ -52,14 +53,14 @@ TEST_F(NotEqualTest, UpdateBounds) {
     for (const auto& [yLb, yUb] : boundVec) {
       EXPECT_TRUE(yLb <= yUb);
       engine->updateBounds(y, yLb, yUb, false);
-      invariant.updateBounds(*engine);
+      invariant.updateBounds();
       std::vector<Int> violations;
       for (Int xVal = xLb; xVal <= xUb; ++xVal) {
         engine->setValue(engine->currentTimestamp(), x, xVal);
         for (Int yVal = yLb; yVal <= yUb; ++yVal) {
           engine->setValue(engine->currentTimestamp(), y, yVal);
-          invariant.updateBounds(*engine);
-          invariant.recompute(engine->currentTimestamp(), *engine);
+          invariant.updateBounds();
+          invariant.recompute(engine->currentTimestamp());
           violations.emplace_back(
               engine->value(engine->currentTimestamp(), violationId));
         }
@@ -87,7 +88,8 @@ TEST_F(NotEqualTest, Recompute) {
   const VarId y = engine->makeIntVar(yUb, yLb, yUb);
   const VarId violationId =
       engine->makeIntVar(0, 0, std::max(xUb - yLb, yUb - xLb));
-  NotEqual& invariant = engine->makeConstraint<NotEqual>(violationId, x, y);
+  NotEqual& invariant =
+      engine->makeConstraint<NotEqual>(*engine, violationId, x, y);
   engine->close();
 
   for (Int xVal = xLb; xVal <= xUb; ++xVal) {
@@ -96,7 +98,7 @@ TEST_F(NotEqualTest, Recompute) {
       engine->setValue(engine->currentTimestamp(), y, yVal);
 
       const Int expectedViolation = computeViolation(xVal, yVal);
-      invariant.recompute(engine->currentTimestamp(), *engine);
+      invariant.recompute(engine->currentTimestamp());
       EXPECT_EQ(expectedViolation,
                 engine->value(engine->currentTimestamp(), violationId));
     }
@@ -112,8 +114,8 @@ TEST_F(NotEqualTest, NotifyInputChanged) {
   std::array<VarId, 2> inputs{engine->makeIntVar(ub, lb, ub),
                               engine->makeIntVar(ub, lb, ub)};
   const VarId violationId = engine->makeIntVar(0, 0, ub - lb);
-  NotEqual& invariant =
-      engine->makeConstraint<NotEqual>(violationId, inputs.at(0), inputs.at(1));
+  NotEqual& invariant = engine->makeConstraint<NotEqual>(
+      *engine, violationId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Int val = lb; val <= ub; ++val) {
@@ -122,8 +124,7 @@ TEST_F(NotEqualTest, NotifyInputChanged) {
       const Int expectedViolation =
           computeViolation(engine->currentTimestamp(), inputs);
 
-      invariant.notifyInputChanged(engine->currentTimestamp(), *engine,
-                                   LocalId(i));
+      invariant.notifyInputChanged(engine->currentTimestamp(), LocalId(i));
       EXPECT_EQ(expectedViolation,
                 engine->value(engine->currentTimestamp(), violationId));
     }
@@ -141,22 +142,22 @@ TEST_F(NotEqualTest, NextInput) {
   const VarId violationId = engine->makeIntVar(0, 0, 2);
   const VarId minVarId = *std::min_element(inputs.begin(), inputs.end());
   const VarId maxVarId = *std::max_element(inputs.begin(), inputs.end());
-  NotEqual& invariant =
-      engine->makeConstraint<NotEqual>(violationId, inputs.at(0), inputs.at(1));
+  NotEqual& invariant = engine->makeConstraint<NotEqual>(
+      *engine, violationId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     std::vector<bool> notified(maxVarId + 1, false);
     for (size_t i = 0; i < inputs.size(); ++i) {
-      const VarId varId = invariant.nextInput(ts, *engine);
+      const VarId varId = invariant.nextInput(ts);
       EXPECT_NE(varId, NULL_ID);
       EXPECT_TRUE(minVarId <= varId);
       EXPECT_TRUE(varId <= maxVarId);
       EXPECT_FALSE(notified.at(varId));
       notified[varId] = true;
     }
-    EXPECT_EQ(invariant.nextInput(ts, *engine), NULL_ID);
+    EXPECT_EQ(invariant.nextInput(ts), NULL_ID);
     for (size_t varId = minVarId; varId <= maxVarId; ++varId) {
       EXPECT_TRUE(notified.at(varId));
     }
@@ -174,19 +175,19 @@ TEST_F(NotEqualTest, NotifyCurrentInputChanged) {
       engine->makeIntVar(valueDist(gen), lb, ub),
       engine->makeIntVar(valueDist(gen), lb, ub)};
   const VarId violationId = engine->makeIntVar(0, 0, ub - lb);
-  NotEqual& invariant =
-      engine->makeConstraint<NotEqual>(violationId, inputs.at(0), inputs.at(1));
+  NotEqual& invariant = engine->makeConstraint<NotEqual>(
+      *engine, violationId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     for (const VarId varId : inputs) {
-      EXPECT_EQ(invariant.nextInput(ts, *engine), varId);
+      EXPECT_EQ(invariant.nextInput(ts), varId);
       const Int oldVal = engine->value(ts, varId);
       do {
         engine->setValue(ts, varId, valueDist(gen));
       } while (engine->value(ts, varId) == oldVal);
-      invariant.notifyCurrentInputChanged(ts, *engine);
+      invariant.notifyCurrentInputChanged(ts);
       EXPECT_EQ(engine->value(ts, violationId), computeViolation(ts, inputs));
     }
   }
@@ -207,8 +208,8 @@ TEST_F(NotEqualTest, Commit) {
   std::shuffle(indices.begin(), indices.end(), rng);
 
   const VarId violationId = engine->makeIntVar(0, 0, 2);
-  NotEqual& invariant =
-      engine->makeConstraint<NotEqual>(violationId, inputs.at(0), inputs.at(1));
+  NotEqual& invariant = engine->makeConstraint<NotEqual>(
+      *engine, violationId, inputs.at(0), inputs.at(1));
   engine->close();
 
   EXPECT_EQ(engine->value(engine->currentTimestamp(), violationId),
@@ -227,11 +228,11 @@ TEST_F(NotEqualTest, Commit) {
     } while (oldVal == engine->value(ts, inputs.at(i)));
 
     // notify changes
-    invariant.notifyInputChanged(ts, *engine, LocalId(i));
+    invariant.notifyInputChanged(ts, LocalId(i));
 
     // incremental value
     const Int notifiedViolation = engine->value(ts, violationId);
-    invariant.recompute(ts, *engine);
+    invariant.recompute(ts);
 
     ASSERT_EQ(notifiedViolation, engine->value(ts, violationId));
 
@@ -239,8 +240,8 @@ TEST_F(NotEqualTest, Commit) {
     committedValues.at(i) = engine->value(ts, inputs.at(i));
     engine->commitIf(ts, violationId);
 
-    invariant.commit(ts, *engine);
-    invariant.recompute(ts + 1, *engine);
+    invariant.commit(ts);
+    invariant.recompute(ts + 1);
     ASSERT_EQ(notifiedViolation, engine->value(ts + 1, violationId));
   }
 }
@@ -248,40 +249,35 @@ TEST_F(NotEqualTest, Commit) {
 class MockNotEqual : public NotEqual {
  public:
   bool registered = false;
-  void registerVars(Engine& engine) override {
+  void registerVars() override {
     registered = true;
-    NotEqual::registerVars(engine);
+    NotEqual::registerVars();
   }
-  explicit MockNotEqual(VarId violationId, VarId x, VarId y)
-      : NotEqual(violationId, x, y) {
-    ON_CALL(*this, recompute)
-        .WillByDefault([this](Timestamp timestamp, Engine& engine) {
-          return NotEqual::recompute(timestamp, engine);
-        });
-    ON_CALL(*this, nextInput)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          return NotEqual::nextInput(t, engine);
-        });
+  explicit MockNotEqual(Engine& engine, VarId violationId, VarId x, VarId y)
+      : NotEqual(engine, violationId, x, y) {
+    ON_CALL(*this, recompute).WillByDefault([this](Timestamp timestamp) {
+      return NotEqual::recompute(timestamp);
+    });
+    ON_CALL(*this, nextInput).WillByDefault([this](Timestamp timestamp) {
+      return NotEqual::nextInput(timestamp);
+    });
     ON_CALL(*this, notifyCurrentInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          NotEqual::notifyCurrentInputChanged(t, engine);
+        .WillByDefault([this](Timestamp timestamp) {
+          NotEqual::notifyCurrentInputChanged(timestamp);
         });
     ON_CALL(*this, notifyInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine, LocalId id) {
-          NotEqual::notifyInputChanged(t, engine, id);
+        .WillByDefault([this](Timestamp timestamp, LocalId id) {
+          NotEqual::notifyInputChanged(timestamp, id);
         });
-    ON_CALL(*this, commit).WillByDefault([this](Timestamp t, Engine& engine) {
-      NotEqual::commit(t, engine);
+    ON_CALL(*this, commit).WillByDefault([this](Timestamp timestamp) {
+      NotEqual::commit(timestamp);
     });
   }
-  MOCK_METHOD(void, recompute, (Timestamp timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(VarId, nextInput, (Timestamp, Engine&), (override));
-  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(void, notifyInputChanged,
-              (Timestamp t, Engine& engine, LocalId id), (override));
-  MOCK_METHOD(void, commit, (Timestamp timestamp, Engine& engine), (override));
+  MOCK_METHOD(void, recompute, (Timestamp), (override));
+  MOCK_METHOD(VarId, nextInput, (Timestamp), (override));
+  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp), (override));
+  MOCK_METHOD(void, notifyInputChanged, (Timestamp, LocalId), (override));
+  MOCK_METHOD(void, commit, (Timestamp), (override));
 };
 TEST_F(NotEqualTest, EngineIntegration) {
   for (const auto& [propMode, markingMode] : propMarkModes) {
@@ -292,7 +288,7 @@ TEST_F(NotEqualTest, EngineIntegration) {
     const VarId y = engine->makeIntVar(0, -100, 100);
     const VarId viol = engine->makeIntVar(0, 0, 1);
     testNotifications<MockNotEqual>(
-        &engine->makeConstraint<MockNotEqual>(viol, x, y), propMode,
+        &engine->makeConstraint<MockNotEqual>(*engine, viol, x, y), propMode,
         markingMode, 3, x, 0, viol);
   }
 }

--- a/test/constraints/tPowDomain.cpp
+++ b/test/constraints/tPowDomain.cpp
@@ -34,7 +34,8 @@ TEST_F(PowDomainTest, UpdateBounds) {
   const VarId y = engine->makeIntVar(
       boundVec.front().first, boundVec.front().first, boundVec.front().second);
   const VarId violationId = engine->makeIntVar(0, 0, 1);
-  PowDomain& invariant = engine->makeConstraint<PowDomain>(violationId, x, y);
+  PowDomain& invariant =
+      engine->makeConstraint<PowDomain>(*engine, violationId, x, y);
   engine->close();
 
   for (const auto& [xLb, xUb] : boundVec) {
@@ -43,14 +44,14 @@ TEST_F(PowDomainTest, UpdateBounds) {
     for (const auto& [yLb, yUb] : boundVec) {
       EXPECT_TRUE(yLb <= yUb);
       engine->updateBounds(y, yLb, yUb, false);
-      invariant.updateBounds(*engine);
+      invariant.updateBounds();
       std::vector<Int> violations;
       for (Int xVal = xLb; xVal <= xUb; ++xVal) {
         engine->setValue(engine->currentTimestamp(), x, xVal);
         for (Int yVal = yLb; yVal <= yUb; ++yVal) {
           engine->setValue(engine->currentTimestamp(), y, yVal);
-          invariant.updateBounds(*engine);
-          invariant.recompute(engine->currentTimestamp(), *engine);
+          invariant.updateBounds();
+          invariant.recompute(engine->currentTimestamp());
           violations.emplace_back(
               engine->value(engine->currentTimestamp(), violationId));
         }
@@ -77,7 +78,8 @@ TEST_F(PowDomainTest, Recompute) {
   const VarId x = engine->makeIntVar(xUb, xLb, xUb);
   const VarId y = engine->makeIntVar(yUb, yLb, yUb);
   const VarId violationId = engine->makeIntVar(0, 0, 1);
-  PowDomain& invariant = engine->makeConstraint<PowDomain>(violationId, x, y);
+  PowDomain& invariant =
+      engine->makeConstraint<PowDomain>(*engine, violationId, x, y);
   engine->close();
 
   for (Int xVal = xLb; xVal <= xUb; ++xVal) {
@@ -86,7 +88,7 @@ TEST_F(PowDomainTest, Recompute) {
       engine->setValue(engine->currentTimestamp(), y, yVal);
 
       const Int expectedViolation = computeViolation(xVal, yVal);
-      invariant.recompute(engine->currentTimestamp(), *engine);
+      invariant.recompute(engine->currentTimestamp());
       EXPECT_EQ(expectedViolation,
                 engine->value(engine->currentTimestamp(), violationId));
     }
@@ -103,7 +105,7 @@ TEST_F(PowDomainTest, NotifyInputChanged) {
                               engine->makeIntVar(ub, lb, ub)};
   const VarId violationId = engine->makeIntVar(0, 0, 1);
   PowDomain& invariant = engine->makeConstraint<PowDomain>(
-      violationId, inputs.at(0), inputs.at(1));
+      *engine, violationId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Int val = lb; val <= ub; ++val) {
@@ -112,8 +114,7 @@ TEST_F(PowDomainTest, NotifyInputChanged) {
       const Int expectedViolation = computeViolation(
           engine->currentTimestamp(), inputs.at(0), inputs.at(1));
 
-      invariant.notifyInputChanged(engine->currentTimestamp(), *engine,
-                                   LocalId(i));
+      invariant.notifyInputChanged(engine->currentTimestamp(), LocalId(i));
       EXPECT_EQ(expectedViolation,
                 engine->value(engine->currentTimestamp(), violationId));
     }
@@ -132,21 +133,21 @@ TEST_F(PowDomainTest, NextInput) {
   const VarId minVarId = *std::min_element(inputs.begin(), inputs.end());
   const VarId maxVarId = *std::max_element(inputs.begin(), inputs.end());
   PowDomain& invariant = engine->makeConstraint<PowDomain>(
-      violationId, inputs.at(0), inputs.at(1));
+      *engine, violationId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     std::vector<bool> notified(maxVarId + 1, false);
     for (size_t i = 0; i < inputs.size(); ++i) {
-      const VarId varId = invariant.nextInput(ts, *engine);
+      const VarId varId = invariant.nextInput(ts);
       EXPECT_NE(varId, NULL_ID);
       EXPECT_TRUE(minVarId <= varId);
       EXPECT_TRUE(varId <= maxVarId);
       EXPECT_FALSE(notified.at(varId));
       notified[varId] = true;
     }
-    EXPECT_EQ(invariant.nextInput(ts, *engine), NULL_ID);
+    EXPECT_EQ(invariant.nextInput(ts), NULL_ID);
     for (size_t varId = minVarId; varId <= maxVarId; ++varId) {
       EXPECT_TRUE(notified.at(varId));
     }
@@ -165,18 +166,18 @@ TEST_F(PowDomainTest, NotifyCurrentInputChanged) {
       engine->makeIntVar(valueDist(gen), lb, ub)};
   const VarId violationId = engine->makeIntVar(0, 0, ub - lb);
   PowDomain& invariant = engine->makeConstraint<PowDomain>(
-      violationId, inputs.at(0), inputs.at(1));
+      *engine, violationId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     for (const VarId varId : inputs) {
-      EXPECT_EQ(invariant.nextInput(ts, *engine), varId);
+      EXPECT_EQ(invariant.nextInput(ts), varId);
       const Int oldVal = engine->value(ts, varId);
       do {
         engine->setValue(ts, varId, valueDist(gen));
       } while (engine->value(ts, varId) == oldVal);
-      invariant.notifyCurrentInputChanged(ts, *engine);
+      invariant.notifyCurrentInputChanged(ts);
       EXPECT_EQ(engine->value(ts, violationId),
                 computeViolation(ts, inputs.at(0), inputs.at(1)));
     }
@@ -199,7 +200,7 @@ TEST_F(PowDomainTest, Commit) {
 
   const VarId violationId = engine->makeIntVar(0, 0, 2);
   PowDomain& invariant = engine->makeConstraint<PowDomain>(
-      violationId, inputs.at(0), inputs.at(1));
+      *engine, violationId, inputs.at(0), inputs.at(1));
   engine->close();
 
   EXPECT_EQ(
@@ -219,11 +220,11 @@ TEST_F(PowDomainTest, Commit) {
     } while (oldVal == engine->value(ts, inputs.at(i)));
 
     // notify changes
-    invariant.notifyInputChanged(ts, *engine, LocalId(i));
+    invariant.notifyInputChanged(ts, LocalId(i));
 
     // incremental value
     const Int notifiedViolation = engine->value(ts, violationId);
-    invariant.recompute(ts, *engine);
+    invariant.recompute(ts);
 
     ASSERT_EQ(notifiedViolation, engine->value(ts, violationId));
 
@@ -231,8 +232,8 @@ TEST_F(PowDomainTest, Commit) {
     committedValues.at(i) = engine->value(ts, inputs.at(i));
     engine->commitIf(ts, violationId);
 
-    invariant.commit(ts, *engine);
-    invariant.recompute(ts + 1, *engine);
+    invariant.commit(ts);
+    invariant.recompute(ts + 1);
     ASSERT_EQ(notifiedViolation, engine->value(ts + 1, violationId));
   }
 }
@@ -240,40 +241,35 @@ TEST_F(PowDomainTest, Commit) {
 class MockPowDomain : public PowDomain {
  public:
   bool registered = false;
-  void registerVars(Engine& engine) override {
+  void registerVars() override {
     registered = true;
-    PowDomain::registerVars(engine);
+    PowDomain::registerVars();
   }
-  explicit MockPowDomain(VarId violationId, VarId x, VarId y)
-      : PowDomain(violationId, x, y) {
-    ON_CALL(*this, recompute)
-        .WillByDefault([this](Timestamp timestamp, Engine& engine) {
-          return PowDomain::recompute(timestamp, engine);
-        });
-    ON_CALL(*this, nextInput)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          return PowDomain::nextInput(t, engine);
-        });
+  explicit MockPowDomain(Engine& engine, VarId violationId, VarId x, VarId y)
+      : PowDomain(engine, violationId, x, y) {
+    ON_CALL(*this, recompute).WillByDefault([this](Timestamp timestamp) {
+      return PowDomain::recompute(timestamp);
+    });
+    ON_CALL(*this, nextInput).WillByDefault([this](Timestamp timestamp) {
+      return PowDomain::nextInput(timestamp);
+    });
     ON_CALL(*this, notifyCurrentInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          PowDomain::notifyCurrentInputChanged(t, engine);
+        .WillByDefault([this](Timestamp timestamp) {
+          PowDomain::notifyCurrentInputChanged(timestamp);
         });
     ON_CALL(*this, notifyInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine, LocalId id) {
-          PowDomain::notifyInputChanged(t, engine, id);
+        .WillByDefault([this](Timestamp timestamp, LocalId id) {
+          PowDomain::notifyInputChanged(timestamp, id);
         });
-    ON_CALL(*this, commit).WillByDefault([this](Timestamp t, Engine& engine) {
-      PowDomain::commit(t, engine);
+    ON_CALL(*this, commit).WillByDefault([this](Timestamp timestamp) {
+      PowDomain::commit(timestamp);
     });
   }
-  MOCK_METHOD(void, recompute, (Timestamp timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(VarId, nextInput, (Timestamp, Engine&), (override));
-  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(void, notifyInputChanged,
-              (Timestamp t, Engine& engine, LocalId id), (override));
-  MOCK_METHOD(void, commit, (Timestamp timestamp, Engine& engine), (override));
+  MOCK_METHOD(void, recompute, (Timestamp), (override));
+  MOCK_METHOD(VarId, nextInput, (Timestamp), (override));
+  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp), (override));
+  MOCK_METHOD(void, notifyInputChanged, (Timestamp, LocalId), (override));
+  MOCK_METHOD(void, commit, (Timestamp), (override));
 };
 TEST_F(PowDomainTest, EngineIntegration) {
   for (const auto& [propMode, markingMode] : propMarkModes) {
@@ -284,7 +280,7 @@ TEST_F(PowDomainTest, EngineIntegration) {
     const VarId y = engine->makeIntVar(0, -100, 100);
     const VarId viol = engine->makeIntVar(0, 0, 1);
     testNotifications<MockPowDomain>(
-        &engine->makeConstraint<MockPowDomain>(viol, x, y), propMode,
+        &engine->makeConstraint<MockPowDomain>(*engine, viol, x, y), propMode,
         markingMode, 3, x, 0, viol);
   }
 }

--- a/test/invariants/tBinaryMax.cpp
+++ b/test/invariants/tBinaryMax.cpp
@@ -44,7 +44,8 @@ TEST_F(BinaryMaxTest, UpdateBounds) {
   const VarId y = engine->makeIntVar(
       boundVec.front().first, boundVec.front().first, boundVec.front().second);
   const VarId outputId = engine->makeIntVar(0, 0, 2);
-  BinaryMax& invariant = engine->makeInvariant<BinaryMax>(outputId, x, y);
+  BinaryMax& invariant =
+      engine->makeInvariant<BinaryMax>(*engine, outputId, x, y);
   engine->close();
 
   for (const auto& [xLb, xUb] : boundVec) {
@@ -54,7 +55,7 @@ TEST_F(BinaryMaxTest, UpdateBounds) {
       EXPECT_TRUE(yLb <= yUb);
       engine->updateBounds(y, yLb, yUb, false);
       engine->open();
-      invariant.updateBounds(*engine);
+      invariant.updateBounds();
       engine->close();
       EXPECT_EQ(engine->lowerBound(outputId), std::max(xLb, yLb));
       EXPECT_EQ(engine->upperBound(outputId), std::max(xUb, yUb));
@@ -75,7 +76,8 @@ TEST_F(BinaryMaxTest, Recompute) {
   const VarId y = engine->makeIntVar(yUb, yLb, yUb);
   const VarId outputId =
       engine->makeIntVar(0, 0, std::max(xUb - yLb, yUb - xLb));
-  BinaryMax& invariant = engine->makeInvariant<BinaryMax>(outputId, x, y);
+  BinaryMax& invariant =
+      engine->makeInvariant<BinaryMax>(*engine, outputId, x, y);
   engine->close();
 
   for (Int xVal = xLb; xVal <= xUb; ++xVal) {
@@ -84,7 +86,7 @@ TEST_F(BinaryMaxTest, Recompute) {
       engine->setValue(engine->currentTimestamp(), y, yVal);
 
       const Int expectedOutput = computeOutput(xVal, yVal);
-      invariant.recompute(engine->currentTimestamp(), *engine);
+      invariant.recompute(engine->currentTimestamp());
       EXPECT_EQ(expectedOutput,
                 engine->value(engine->currentTimestamp(), outputId));
     }
@@ -100,8 +102,8 @@ TEST_F(BinaryMaxTest, NotifyInputChanged) {
   std::array<VarId, 2> inputs{engine->makeIntVar(ub, lb, ub),
                               engine->makeIntVar(ub, lb, ub)};
   VarId outputId = engine->makeIntVar(0, 0, ub - lb);
-  BinaryMax& invariant =
-      engine->makeInvariant<BinaryMax>(outputId, inputs.at(0), inputs.at(1));
+  BinaryMax& invariant = engine->makeInvariant<BinaryMax>(
+      *engine, outputId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Int val = lb; val <= ub; ++val) {
@@ -110,8 +112,7 @@ TEST_F(BinaryMaxTest, NotifyInputChanged) {
       const Int expectedOutput =
           computeOutput(engine->currentTimestamp(), inputs);
 
-      invariant.notifyInputChanged(engine->currentTimestamp(), *engine,
-                                   LocalId(i));
+      invariant.notifyInputChanged(engine->currentTimestamp(), LocalId(i));
       EXPECT_EQ(expectedOutput,
                 engine->value(engine->currentTimestamp(), outputId));
     }
@@ -129,22 +130,22 @@ TEST_F(BinaryMaxTest, NextInput) {
   const VarId outputId = engine->makeIntVar(0, 0, 2);
   const VarId minVarId = *std::min_element(inputs.begin(), inputs.end());
   const VarId maxVarId = *std::max_element(inputs.begin(), inputs.end());
-  BinaryMax& invariant =
-      engine->makeInvariant<BinaryMax>(outputId, inputs.at(0), inputs.at(1));
+  BinaryMax& invariant = engine->makeInvariant<BinaryMax>(
+      *engine, outputId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     std::vector<bool> notified(maxVarId + 1, false);
     for (size_t i = 0; i < inputs.size(); ++i) {
-      const VarId varId = invariant.nextInput(ts, *engine);
+      const VarId varId = invariant.nextInput(ts);
       EXPECT_NE(varId, NULL_ID);
       EXPECT_TRUE(minVarId <= varId);
       EXPECT_TRUE(varId <= maxVarId);
       EXPECT_FALSE(notified.at(varId));
       notified[varId] = true;
     }
-    EXPECT_EQ(invariant.nextInput(ts, *engine), NULL_ID);
+    EXPECT_EQ(invariant.nextInput(ts), NULL_ID);
     for (size_t varId = minVarId; varId <= maxVarId; ++varId) {
       EXPECT_TRUE(notified.at(varId));
     }
@@ -162,19 +163,19 @@ TEST_F(BinaryMaxTest, NotifyCurrentInputChanged) {
       engine->makeIntVar(valueDist(gen), lb, ub),
       engine->makeIntVar(valueDist(gen), lb, ub)};
   const VarId outputId = engine->makeIntVar(0, 0, ub - lb);
-  BinaryMax& invariant =
-      engine->makeInvariant<BinaryMax>(outputId, inputs.at(0), inputs.at(1));
+  BinaryMax& invariant = engine->makeInvariant<BinaryMax>(
+      *engine, outputId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     for (const VarId varId : inputs) {
-      EXPECT_EQ(invariant.nextInput(ts, *engine), varId);
+      EXPECT_EQ(invariant.nextInput(ts), varId);
       const Int oldVal = engine->value(ts, varId);
       do {
         engine->setValue(ts, varId, valueDist(gen));
       } while (engine->value(ts, varId) == oldVal);
-      invariant.notifyCurrentInputChanged(ts, *engine);
+      invariant.notifyCurrentInputChanged(ts);
       EXPECT_EQ(engine->value(ts, outputId), computeOutput(ts, inputs));
     }
   }
@@ -195,8 +196,8 @@ TEST_F(BinaryMaxTest, Commit) {
   std::shuffle(indices.begin(), indices.end(), rng);
 
   VarId outputId = engine->makeIntVar(0, 0, 2);
-  BinaryMax& invariant =
-      engine->makeInvariant<BinaryMax>(outputId, inputs.at(0), inputs.at(1));
+  BinaryMax& invariant = engine->makeInvariant<BinaryMax>(
+      *engine, outputId, inputs.at(0), inputs.at(1));
   engine->close();
 
   EXPECT_EQ(engine->value(engine->currentTimestamp(), outputId),
@@ -215,11 +216,11 @@ TEST_F(BinaryMaxTest, Commit) {
     } while (oldVal == engine->value(ts, inputs.at(i)));
 
     // notify changes
-    invariant.notifyInputChanged(ts, *engine, LocalId(i));
+    invariant.notifyInputChanged(ts, LocalId(i));
 
     // incremental value
     const Int notifiedOutput = engine->value(ts, outputId);
-    invariant.recompute(ts, *engine);
+    invariant.recompute(ts);
 
     ASSERT_EQ(notifiedOutput, engine->value(ts, outputId));
 
@@ -227,8 +228,8 @@ TEST_F(BinaryMaxTest, Commit) {
     committedValues.at(i) = engine->value(ts, inputs.at(i));
     engine->commitIf(ts, outputId);
 
-    invariant.commit(ts, *engine);
-    invariant.recompute(ts + 1, *engine);
+    invariant.commit(ts);
+    invariant.recompute(ts + 1);
     ASSERT_EQ(notifiedOutput, engine->value(ts + 1, outputId));
   }
 }
@@ -236,40 +237,35 @@ TEST_F(BinaryMaxTest, Commit) {
 class MockBinaryMax : public BinaryMax {
  public:
   bool registered = false;
-  void registerVars(Engine& engine) override {
+  void registerVars() override {
     registered = true;
-    BinaryMax::registerVars(engine);
+    BinaryMax::registerVars();
   }
-  explicit MockBinaryMax(VarId output, VarId x, VarId y)
-      : BinaryMax(output, x, y) {
-    ON_CALL(*this, recompute)
-        .WillByDefault([this](Timestamp timestamp, Engine& engine) {
-          return BinaryMax::recompute(timestamp, engine);
-        });
-    ON_CALL(*this, nextInput)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          return BinaryMax::nextInput(t, engine);
-        });
+  explicit MockBinaryMax(Engine& engine, VarId output, VarId x, VarId y)
+      : BinaryMax(engine, output, x, y) {
+    ON_CALL(*this, recompute).WillByDefault([this](Timestamp timestamp) {
+      return BinaryMax::recompute(timestamp);
+    });
+    ON_CALL(*this, nextInput).WillByDefault([this](Timestamp timestamp) {
+      return BinaryMax::nextInput(timestamp);
+    });
     ON_CALL(*this, notifyCurrentInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          BinaryMax::notifyCurrentInputChanged(t, engine);
+        .WillByDefault([this](Timestamp timestamp) {
+          BinaryMax::notifyCurrentInputChanged(timestamp);
         });
     ON_CALL(*this, notifyInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine, LocalId id) {
-          BinaryMax::notifyInputChanged(t, engine, id);
+        .WillByDefault([this](Timestamp timestamp, LocalId id) {
+          BinaryMax::notifyInputChanged(timestamp, id);
         });
-    ON_CALL(*this, commit).WillByDefault([this](Timestamp t, Engine& engine) {
-      BinaryMax::commit(t, engine);
+    ON_CALL(*this, commit).WillByDefault([this](Timestamp timestamp) {
+      BinaryMax::commit(timestamp);
     });
   }
-  MOCK_METHOD(void, recompute, (Timestamp timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(VarId, nextInput, (Timestamp, Engine&), (override));
-  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(void, notifyInputChanged,
-              (Timestamp t, Engine& engine, LocalId id), (override));
-  MOCK_METHOD(void, commit, (Timestamp timestamp, Engine& engine), (override));
+  MOCK_METHOD(void, recompute, (Timestamp), (override));
+  MOCK_METHOD(VarId, nextInput, (Timestamp), (override));
+  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp), (override));
+  MOCK_METHOD(void, notifyInputChanged, (Timestamp, LocalId), (override));
+  MOCK_METHOD(void, commit, (Timestamp), (override));
 };
 TEST_F(BinaryMaxTest, EngineIntegration) {
   for (const auto& [propMode, markingMode] : propMarkModes) {
@@ -280,7 +276,7 @@ TEST_F(BinaryMaxTest, EngineIntegration) {
     const VarId y = engine->makeIntVar(10, -100, 100);
     const VarId output = engine->makeIntVar(0, 0, 200);
     testNotifications<MockBinaryMax>(
-        &engine->makeInvariant<MockBinaryMax>(output, x, y), propMode,
+        &engine->makeInvariant<MockBinaryMax>(*engine, output, x, y), propMode,
         markingMode, 3, x, 0, output);
   }
 }

--- a/test/invariants/tBinaryMin.cpp
+++ b/test/invariants/tBinaryMin.cpp
@@ -44,7 +44,8 @@ TEST_F(BinaryMinTest, UpdateBounds) {
   const VarId y = engine->makeIntVar(
       boundVec.front().first, boundVec.front().first, boundVec.front().second);
   const VarId outputId = engine->makeIntVar(0, 0, 2);
-  BinaryMin& invariant = engine->makeInvariant<BinaryMin>(outputId, x, y);
+  BinaryMin& invariant =
+      engine->makeInvariant<BinaryMin>(*engine, outputId, x, y);
   engine->close();
 
   for (const auto& [xLb, xUb] : boundVec) {
@@ -54,7 +55,7 @@ TEST_F(BinaryMinTest, UpdateBounds) {
       EXPECT_TRUE(yLb <= yUb);
       engine->updateBounds(y, yLb, yUb, false);
       engine->open();
-      invariant.updateBounds(*engine);
+      invariant.updateBounds();
       engine->close();
       EXPECT_EQ(engine->lowerBound(outputId), std::min(xLb, yLb));
       EXPECT_EQ(engine->upperBound(outputId), std::min(xUb, yUb));
@@ -75,7 +76,8 @@ TEST_F(BinaryMinTest, Recompute) {
   const VarId y = engine->makeIntVar(yUb, yLb, yUb);
   const VarId outputId =
       engine->makeIntVar(0, 0, std::max(xUb - yLb, yUb - xLb));
-  BinaryMin& invariant = engine->makeInvariant<BinaryMin>(outputId, x, y);
+  BinaryMin& invariant =
+      engine->makeInvariant<BinaryMin>(*engine, outputId, x, y);
   engine->close();
 
   for (Int xVal = xLb; xVal <= xUb; ++xVal) {
@@ -84,7 +86,7 @@ TEST_F(BinaryMinTest, Recompute) {
       engine->setValue(engine->currentTimestamp(), y, yVal);
 
       const Int expectedOutput = computeOutput(xVal, yVal);
-      invariant.recompute(engine->currentTimestamp(), *engine);
+      invariant.recompute(engine->currentTimestamp());
       EXPECT_EQ(expectedOutput,
                 engine->value(engine->currentTimestamp(), outputId));
     }
@@ -100,8 +102,8 @@ TEST_F(BinaryMinTest, NotifyInputChanged) {
   std::array<VarId, 2> inputs{engine->makeIntVar(ub, lb, ub),
                               engine->makeIntVar(ub, lb, ub)};
   VarId outputId = engine->makeIntVar(0, 0, ub - lb);
-  BinaryMin& invariant =
-      engine->makeInvariant<BinaryMin>(outputId, inputs.at(0), inputs.at(1));
+  BinaryMin& invariant = engine->makeInvariant<BinaryMin>(
+      *engine, outputId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Int val = lb; val <= ub; ++val) {
@@ -110,8 +112,7 @@ TEST_F(BinaryMinTest, NotifyInputChanged) {
       const Int expectedOutput =
           computeOutput(engine->currentTimestamp(), inputs);
 
-      invariant.notifyInputChanged(engine->currentTimestamp(), *engine,
-                                   LocalId(i));
+      invariant.notifyInputChanged(engine->currentTimestamp(), LocalId(i));
       EXPECT_EQ(expectedOutput,
                 engine->value(engine->currentTimestamp(), outputId));
     }
@@ -129,22 +130,22 @@ TEST_F(BinaryMinTest, NextInput) {
   const VarId outputId = engine->makeIntVar(0, 0, 2);
   const VarId minVarId = *std::min_element(inputs.begin(), inputs.end());
   const VarId maxVarId = *std::max_element(inputs.begin(), inputs.end());
-  BinaryMin& invariant =
-      engine->makeInvariant<BinaryMin>(outputId, inputs.at(0), inputs.at(1));
+  BinaryMin& invariant = engine->makeInvariant<BinaryMin>(
+      *engine, outputId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     std::vector<bool> notified(maxVarId + 1, false);
     for (size_t i = 0; i < inputs.size(); ++i) {
-      const VarId varId = invariant.nextInput(ts, *engine);
+      const VarId varId = invariant.nextInput(ts);
       EXPECT_NE(varId, NULL_ID);
       EXPECT_TRUE(minVarId <= varId);
       EXPECT_TRUE(varId <= maxVarId);
       EXPECT_FALSE(notified.at(varId));
       notified[varId] = true;
     }
-    EXPECT_EQ(invariant.nextInput(ts, *engine), NULL_ID);
+    EXPECT_EQ(invariant.nextInput(ts), NULL_ID);
     for (size_t varId = minVarId; varId <= maxVarId; ++varId) {
       EXPECT_TRUE(notified.at(varId));
     }
@@ -162,19 +163,19 @@ TEST_F(BinaryMinTest, NotifyCurrentInputChanged) {
       engine->makeIntVar(valueDist(gen), lb, ub),
       engine->makeIntVar(valueDist(gen), lb, ub)};
   const VarId outputId = engine->makeIntVar(0, 0, ub - lb);
-  BinaryMin& invariant =
-      engine->makeInvariant<BinaryMin>(outputId, inputs.at(0), inputs.at(1));
+  BinaryMin& invariant = engine->makeInvariant<BinaryMin>(
+      *engine, outputId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     for (const VarId varId : inputs) {
-      EXPECT_EQ(invariant.nextInput(ts, *engine), varId);
+      EXPECT_EQ(invariant.nextInput(ts), varId);
       const Int oldVal = engine->value(ts, varId);
       do {
         engine->setValue(ts, varId, valueDist(gen));
       } while (engine->value(ts, varId) == oldVal);
-      invariant.notifyCurrentInputChanged(ts, *engine);
+      invariant.notifyCurrentInputChanged(ts);
       EXPECT_EQ(engine->value(ts, outputId), computeOutput(ts, inputs));
     }
   }
@@ -195,8 +196,8 @@ TEST_F(BinaryMinTest, Commit) {
   std::shuffle(indices.begin(), indices.end(), rng);
 
   VarId outputId = engine->makeIntVar(0, 0, 2);
-  BinaryMin& invariant =
-      engine->makeInvariant<BinaryMin>(outputId, inputs.at(0), inputs.at(1));
+  BinaryMin& invariant = engine->makeInvariant<BinaryMin>(
+      *engine, outputId, inputs.at(0), inputs.at(1));
   engine->close();
 
   EXPECT_EQ(engine->value(engine->currentTimestamp(), outputId),
@@ -215,11 +216,11 @@ TEST_F(BinaryMinTest, Commit) {
     } while (oldVal == engine->value(ts, inputs.at(i)));
 
     // notify changes
-    invariant.notifyInputChanged(ts, *engine, LocalId(i));
+    invariant.notifyInputChanged(ts, LocalId(i));
 
     // incremental value
     const Int notifiedOutput = engine->value(ts, outputId);
-    invariant.recompute(ts, *engine);
+    invariant.recompute(ts);
 
     ASSERT_EQ(notifiedOutput, engine->value(ts, outputId));
 
@@ -227,8 +228,8 @@ TEST_F(BinaryMinTest, Commit) {
     committedValues.at(i) = engine->value(ts, inputs.at(i));
     engine->commitIf(ts, outputId);
 
-    invariant.commit(ts, *engine);
-    invariant.recompute(ts + 1, *engine);
+    invariant.commit(ts);
+    invariant.recompute(ts + 1);
     ASSERT_EQ(notifiedOutput, engine->value(ts + 1, outputId));
   }
 }
@@ -236,40 +237,35 @@ TEST_F(BinaryMinTest, Commit) {
 class MockBinaryMin : public BinaryMin {
  public:
   bool registered = false;
-  void registerVars(Engine& engine) override {
+  void registerVars() override {
     registered = true;
-    BinaryMin::registerVars(engine);
+    BinaryMin::registerVars();
   }
-  explicit MockBinaryMin(VarId output, VarId x, VarId y)
-      : BinaryMin(output, x, y) {
-    ON_CALL(*this, recompute)
-        .WillByDefault([this](Timestamp timestamp, Engine& engine) {
-          return BinaryMin::recompute(timestamp, engine);
-        });
-    ON_CALL(*this, nextInput)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          return BinaryMin::nextInput(t, engine);
-        });
+  explicit MockBinaryMin(Engine& engine, VarId output, VarId x, VarId y)
+      : BinaryMin(engine, output, x, y) {
+    ON_CALL(*this, recompute).WillByDefault([this](Timestamp timestamp) {
+      return BinaryMin::recompute(timestamp);
+    });
+    ON_CALL(*this, nextInput).WillByDefault([this](Timestamp timestamp) {
+      return BinaryMin::nextInput(timestamp);
+    });
     ON_CALL(*this, notifyCurrentInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          BinaryMin::notifyCurrentInputChanged(t, engine);
+        .WillByDefault([this](Timestamp timestamp) {
+          BinaryMin::notifyCurrentInputChanged(timestamp);
         });
     ON_CALL(*this, notifyInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine, LocalId id) {
-          BinaryMin::notifyInputChanged(t, engine, id);
+        .WillByDefault([this](Timestamp timestamp, LocalId id) {
+          BinaryMin::notifyInputChanged(timestamp, id);
         });
-    ON_CALL(*this, commit).WillByDefault([this](Timestamp t, Engine& engine) {
-      BinaryMin::commit(t, engine);
+    ON_CALL(*this, commit).WillByDefault([this](Timestamp timestamp) {
+      BinaryMin::commit(timestamp);
     });
   }
-  MOCK_METHOD(void, recompute, (Timestamp timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(VarId, nextInput, (Timestamp, Engine&), (override));
-  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(void, notifyInputChanged,
-              (Timestamp t, Engine& engine, LocalId id), (override));
-  MOCK_METHOD(void, commit, (Timestamp timestamp, Engine& engine), (override));
+  MOCK_METHOD(void, recompute, (Timestamp), (override));
+  MOCK_METHOD(VarId, nextInput, (Timestamp), (override));
+  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp), (override));
+  MOCK_METHOD(void, notifyInputChanged, (Timestamp, LocalId), (override));
+  MOCK_METHOD(void, commit, (Timestamp), (override));
 };
 TEST_F(BinaryMinTest, EngineIntegration) {
   for (const auto& [propMode, markingMode] : propMarkModes) {
@@ -280,7 +276,7 @@ TEST_F(BinaryMinTest, EngineIntegration) {
     const VarId y = engine->makeIntVar(10, -100, 100);
     const VarId output = engine->makeIntVar(0, 0, 200);
     testNotifications<MockBinaryMin>(
-        &engine->makeInvariant<MockBinaryMin>(output, x, y), propMode,
+        &engine->makeInvariant<MockBinaryMin>(*engine, output, x, y), propMode,
         markingMode, 3, x, 0, output);
   }
 }

--- a/test/invariants/tBoolAnd.cpp
+++ b/test/invariants/tBoolAnd.cpp
@@ -46,7 +46,7 @@ TEST_F(BoolAndTest, UpdateBounds) {
   const VarId y = engine->makeIntVar(
       boundVec.front().first, boundVec.front().first, boundVec.front().second);
   const VarId outputId = engine->makeIntVar(0, 0, 2);
-  BoolAnd& invariant = engine->makeInvariant<BoolAnd>(outputId, x, y);
+  BoolAnd& invariant = engine->makeInvariant<BoolAnd>(*engine, outputId, x, y);
   engine->close();
 
   for (const auto& [xLb, xUb] : boundVec) {
@@ -55,13 +55,13 @@ TEST_F(BoolAndTest, UpdateBounds) {
     for (const auto& [yLb, yUb] : boundVec) {
       EXPECT_TRUE(yLb <= yUb);
       engine->updateBounds(y, yLb, yUb, false);
-      invariant.updateBounds(*engine);
+      invariant.updateBounds();
       for (Int xVal = xLb; xVal <= xUb; ++xVal) {
         engine->setValue(engine->currentTimestamp(), x, xVal);
         for (Int yVal = yLb; yVal <= yUb; ++yVal) {
           engine->setValue(engine->currentTimestamp(), y, yVal);
-          invariant.updateBounds(*engine);
-          invariant.recompute(engine->currentTimestamp(), *engine);
+          invariant.updateBounds();
+          invariant.recompute(engine->currentTimestamp());
         }
       }
       ASSERT_GE(std::max(xLb, yLb), engine->lowerBound(outputId));
@@ -83,8 +83,8 @@ TEST_F(BoolAndTest, Recompute) {
                                           engine->makeIntVar(yUb, yLb, yUb)};
   const VarId outputId =
       engine->makeIntVar(0, 0, std::max(xUb - yLb, yUb - xLb));
-  BoolAnd& invariant =
-      engine->makeInvariant<BoolAnd>(outputId, inputs.at(0), inputs.at(1));
+  BoolAnd& invariant = engine->makeInvariant<BoolAnd>(
+      *engine, outputId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Int xVal = xLb; xVal <= xUb; ++xVal) {
@@ -93,7 +93,7 @@ TEST_F(BoolAndTest, Recompute) {
       engine->setValue(engine->currentTimestamp(), inputs.at(1), yVal);
 
       const Int expectedViolation = computeViolation(xVal, yVal);
-      invariant.recompute(engine->currentTimestamp(), *engine);
+      invariant.recompute(engine->currentTimestamp());
       EXPECT_EQ(expectedViolation,
                 engine->value(engine->currentTimestamp(), outputId));
     }
@@ -109,8 +109,8 @@ TEST_F(BoolAndTest, NotifyInputChanged) {
   const std::array<const VarId, 2> inputs{engine->makeIntVar(ub, lb, ub),
                                           engine->makeIntVar(ub, lb, ub)};
   const VarId outputId = engine->makeIntVar(0, 0, ub - lb);
-  BoolAnd& invariant =
-      engine->makeInvariant<BoolAnd>(outputId, inputs.at(0), inputs.at(1));
+  BoolAnd& invariant = engine->makeInvariant<BoolAnd>(
+      *engine, outputId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Int val = lb; val <= ub; ++val) {
@@ -119,8 +119,7 @@ TEST_F(BoolAndTest, NotifyInputChanged) {
       const Int expectedViolation =
           computeViolation(engine->currentTimestamp(), inputs);
 
-      invariant.notifyInputChanged(engine->currentTimestamp(), *engine,
-                                   LocalId(i));
+      invariant.notifyInputChanged(engine->currentTimestamp(), LocalId(i));
       EXPECT_EQ(expectedViolation,
                 engine->value(engine->currentTimestamp(), outputId));
     }
@@ -138,22 +137,22 @@ TEST_F(BoolAndTest, NextInput) {
   const VarId outputId = engine->makeIntVar(0, 0, 2);
   const VarId minVarId = *std::min_element(inputs.begin(), inputs.end());
   const VarId maxVarId = *std::max_element(inputs.begin(), inputs.end());
-  BoolAnd& invariant =
-      engine->makeInvariant<BoolAnd>(outputId, inputs.at(0), inputs.at(1));
+  BoolAnd& invariant = engine->makeInvariant<BoolAnd>(
+      *engine, outputId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     std::vector<bool> notified(maxVarId + 1, false);
     for (size_t i = 0; i < inputs.size(); ++i) {
-      const VarId varId = invariant.nextInput(ts, *engine);
+      const VarId varId = invariant.nextInput(ts);
       EXPECT_NE(varId, NULL_ID);
       EXPECT_TRUE(minVarId <= varId);
       EXPECT_TRUE(varId <= maxVarId);
       EXPECT_FALSE(notified.at(varId));
       notified[varId] = true;
     }
-    EXPECT_EQ(invariant.nextInput(ts, *engine), NULL_ID);
+    EXPECT_EQ(invariant.nextInput(ts), NULL_ID);
     for (size_t varId = minVarId; varId <= maxVarId; ++varId) {
       EXPECT_TRUE(notified.at(varId));
     }
@@ -171,19 +170,19 @@ TEST_F(BoolAndTest, NotifyCurrentInputChanged) {
       engine->makeIntVar(valueDist(gen), lb, ub),
       engine->makeIntVar(valueDist(gen), lb, ub)};
   const VarId outputId = engine->makeIntVar(0, 0, ub - lb);
-  BoolAnd& invariant =
-      engine->makeInvariant<BoolAnd>(outputId, inputs.at(0), inputs.at(1));
+  BoolAnd& invariant = engine->makeInvariant<BoolAnd>(
+      *engine, outputId, inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     for (const VarId varId : inputs) {
-      EXPECT_EQ(invariant.nextInput(ts, *engine), varId);
+      EXPECT_EQ(invariant.nextInput(ts), varId);
       const Int oldVal = engine->value(ts, varId);
       do {
         engine->setValue(ts, varId, valueDist(gen));
       } while (engine->value(ts, varId) == oldVal);
-      invariant.notifyCurrentInputChanged(ts, *engine);
+      invariant.notifyCurrentInputChanged(ts);
       EXPECT_EQ(engine->value(ts, outputId), computeViolation(ts, inputs));
     }
   }
@@ -205,8 +204,8 @@ TEST_F(BoolAndTest, Commit) {
       engine->makeIntVar(committedValues.at(1), lb, ub)};
 
   const VarId outputId = engine->makeIntVar(0, 0, 2);
-  BoolAnd& invariant =
-      engine->makeInvariant<BoolAnd>(outputId, inputs.at(0), inputs.at(1));
+  BoolAnd& invariant = engine->makeInvariant<BoolAnd>(
+      *engine, outputId, inputs.at(0), inputs.at(1));
   engine->close();
 
   EXPECT_EQ(engine->value(engine->currentTimestamp(), outputId),
@@ -225,11 +224,11 @@ TEST_F(BoolAndTest, Commit) {
     } while (oldVal == engine->value(ts, inputs.at(i)));
 
     // notify changes
-    invariant.notifyInputChanged(ts, *engine, LocalId(i));
+    invariant.notifyInputChanged(ts, LocalId(i));
 
     // incremental value
     const Int notifiedViolation = engine->value(ts, outputId);
-    invariant.recompute(ts, *engine);
+    invariant.recompute(ts);
 
     ASSERT_EQ(notifiedViolation, engine->value(ts, outputId));
 
@@ -237,8 +236,8 @@ TEST_F(BoolAndTest, Commit) {
     committedValues.at(i) = engine->value(ts, inputs.at(i));
     engine->commitIf(ts, outputId);
 
-    invariant.commit(ts, *engine);
-    invariant.recompute(ts + 1, *engine);
+    invariant.commit(ts);
+    invariant.recompute(ts + 1);
     ASSERT_EQ(notifiedViolation, engine->value(ts + 1, outputId));
   }
 }
@@ -246,40 +245,35 @@ TEST_F(BoolAndTest, Commit) {
 class MockBoolAnd : public BoolAnd {
  public:
   bool registered = false;
-  void registerVars(Engine& engine) override {
+  void registerVars() override {
     registered = true;
-    BoolAnd::registerVars(engine);
+    BoolAnd::registerVars();
   }
-  explicit MockBoolAnd(VarId outputId, VarId x, VarId y)
-      : BoolAnd(outputId, x, y) {
-    ON_CALL(*this, recompute)
-        .WillByDefault([this](Timestamp timestamp, Engine& engine) {
-          return BoolAnd::recompute(timestamp, engine);
-        });
-    ON_CALL(*this, nextInput)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          return BoolAnd::nextInput(t, engine);
-        });
+  explicit MockBoolAnd(Engine& engine, VarId outputId, VarId x, VarId y)
+      : BoolAnd(engine, outputId, x, y) {
+    ON_CALL(*this, recompute).WillByDefault([this](Timestamp timestamp) {
+      return BoolAnd::recompute(timestamp);
+    });
+    ON_CALL(*this, nextInput).WillByDefault([this](Timestamp timestamp) {
+      return BoolAnd::nextInput(timestamp);
+    });
     ON_CALL(*this, notifyCurrentInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          BoolAnd::notifyCurrentInputChanged(t, engine);
+        .WillByDefault([this](Timestamp timestamp) {
+          BoolAnd::notifyCurrentInputChanged(timestamp);
         });
     ON_CALL(*this, notifyInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine, LocalId id) {
-          BoolAnd::notifyInputChanged(t, engine, id);
+        .WillByDefault([this](Timestamp timestamp, LocalId id) {
+          BoolAnd::notifyInputChanged(timestamp, id);
         });
-    ON_CALL(*this, commit).WillByDefault([this](Timestamp t, Engine& engine) {
-      BoolAnd::commit(t, engine);
+    ON_CALL(*this, commit).WillByDefault([this](Timestamp timestamp) {
+      BoolAnd::commit(timestamp);
     });
   }
-  MOCK_METHOD(void, recompute, (Timestamp timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(VarId, nextInput, (Timestamp, Engine&), (override));
-  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(void, notifyInputChanged,
-              (Timestamp t, Engine& engine, LocalId id), (override));
-  MOCK_METHOD(void, commit, (Timestamp timestamp, Engine& engine), (override));
+  MOCK_METHOD(void, recompute, (Timestamp), (override));
+  MOCK_METHOD(VarId, nextInput, (Timestamp), (override));
+  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp), (override));
+  MOCK_METHOD(void, notifyInputChanged, (Timestamp, LocalId), (override));
+  MOCK_METHOD(void, commit, (Timestamp), (override));
 };
 TEST_F(BoolAndTest, EngineIntegration) {
   for (const auto& [propMode, markingMode] : propMarkModes) {
@@ -290,7 +284,7 @@ TEST_F(BoolAndTest, EngineIntegration) {
     const VarId y = engine->makeIntVar(0, 0, 100);
     const VarId output = engine->makeIntVar(0, 0, 200);
     testNotifications<MockBoolAnd>(
-        &engine->makeInvariant<MockBoolAnd>(output, x, y), propMode,
+        &engine->makeInvariant<MockBoolAnd>(*engine, output, x, y), propMode,
         markingMode, 3, x, 1, output);
   }
 }

--- a/test/invariants/tBoolOr.cpp
+++ b/test/invariants/tBoolOr.cpp
@@ -46,7 +46,7 @@ TEST_F(BoolOrTest, UpdateBounds) {
   const VarId y = engine->makeIntVar(
       boundVec.front().first, boundVec.front().first, boundVec.front().second);
   const VarId outputId = engine->makeIntVar(0, 0, 2);
-  BoolOr& invariant = engine->makeInvariant<BoolOr>(outputId, x, y);
+  BoolOr& invariant = engine->makeInvariant<BoolOr>(*engine, outputId, x, y);
   engine->close();
 
   for (const auto& [xLb, xUb] : boundVec) {
@@ -55,13 +55,13 @@ TEST_F(BoolOrTest, UpdateBounds) {
     for (const auto& [yLb, yUb] : boundVec) {
       EXPECT_TRUE(yLb <= yUb);
       engine->updateBounds(y, yLb, yUb, false);
-      invariant.updateBounds(*engine);
+      invariant.updateBounds();
       for (Int xVal = xLb; xVal <= xUb; ++xVal) {
         engine->setValue(engine->currentTimestamp(), x, xVal);
         for (Int yVal = yLb; yVal <= yUb; ++yVal) {
           engine->setValue(engine->currentTimestamp(), y, yVal);
-          invariant.updateBounds(*engine);
-          invariant.recompute(engine->currentTimestamp(), *engine);
+          invariant.updateBounds();
+          invariant.recompute(engine->currentTimestamp());
         }
       }
       ASSERT_GE(std::min(xLb, yLb), engine->lowerBound(outputId));
@@ -83,8 +83,8 @@ TEST_F(BoolOrTest, Recompute) {
                                           engine->makeIntVar(yUb, yLb, yUb)};
   const VarId outputId =
       engine->makeIntVar(0, 0, std::max(xUb - yLb, yUb - xLb));
-  BoolOr& invariant =
-      engine->makeInvariant<BoolOr>(outputId, inputs.at(0), inputs.at(1));
+  BoolOr& invariant = engine->makeInvariant<BoolOr>(*engine, outputId,
+                                                    inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Int xVal = xLb; xVal <= xUb; ++xVal) {
@@ -93,7 +93,7 @@ TEST_F(BoolOrTest, Recompute) {
       engine->setValue(engine->currentTimestamp(), inputs.at(1), yVal);
 
       const Int expectedViolation = computeViolation(xVal, yVal);
-      invariant.recompute(engine->currentTimestamp(), *engine);
+      invariant.recompute(engine->currentTimestamp());
       EXPECT_EQ(expectedViolation,
                 engine->value(engine->currentTimestamp(), outputId));
     }
@@ -109,8 +109,8 @@ TEST_F(BoolOrTest, NotifyInputChanged) {
   const std::array<const VarId, 2> inputs{engine->makeIntVar(ub, lb, ub),
                                           engine->makeIntVar(ub, lb, ub)};
   const VarId outputId = engine->makeIntVar(0, 0, ub - lb);
-  BoolOr& invariant =
-      engine->makeInvariant<BoolOr>(outputId, inputs.at(0), inputs.at(1));
+  BoolOr& invariant = engine->makeInvariant<BoolOr>(*engine, outputId,
+                                                    inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Int val = lb; val <= ub; ++val) {
@@ -119,8 +119,7 @@ TEST_F(BoolOrTest, NotifyInputChanged) {
       const Int expectedViolation =
           computeViolation(engine->currentTimestamp(), inputs);
 
-      invariant.notifyInputChanged(engine->currentTimestamp(), *engine,
-                                   LocalId(i));
+      invariant.notifyInputChanged(engine->currentTimestamp(), LocalId(i));
       EXPECT_EQ(expectedViolation,
                 engine->value(engine->currentTimestamp(), outputId));
     }
@@ -138,22 +137,22 @@ TEST_F(BoolOrTest, NextInput) {
   const VarId outputId = engine->makeIntVar(0, 0, 2);
   const VarId minVarId = *std::min_element(inputs.begin(), inputs.end());
   const VarId maxVarId = *std::max_element(inputs.begin(), inputs.end());
-  BoolOr& invariant =
-      engine->makeInvariant<BoolOr>(outputId, inputs.at(0), inputs.at(1));
+  BoolOr& invariant = engine->makeInvariant<BoolOr>(*engine, outputId,
+                                                    inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     std::vector<bool> notified(maxVarId + 1, false);
     for (size_t i = 0; i < inputs.size(); ++i) {
-      const VarId varId = invariant.nextInput(ts, *engine);
+      const VarId varId = invariant.nextInput(ts);
       EXPECT_NE(varId, NULL_ID);
       EXPECT_TRUE(minVarId <= varId);
       EXPECT_TRUE(varId <= maxVarId);
       EXPECT_FALSE(notified.at(varId));
       notified[varId] = true;
     }
-    EXPECT_EQ(invariant.nextInput(ts, *engine), NULL_ID);
+    EXPECT_EQ(invariant.nextInput(ts), NULL_ID);
     for (size_t varId = minVarId; varId <= maxVarId; ++varId) {
       EXPECT_TRUE(notified.at(varId));
     }
@@ -171,19 +170,19 @@ TEST_F(BoolOrTest, NotifyCurrentInputChanged) {
       engine->makeIntVar(valueDist(gen), lb, ub),
       engine->makeIntVar(valueDist(gen), lb, ub)};
   const VarId outputId = engine->makeIntVar(0, 0, ub - lb);
-  BoolOr& invariant =
-      engine->makeInvariant<BoolOr>(outputId, inputs.at(0), inputs.at(1));
+  BoolOr& invariant = engine->makeInvariant<BoolOr>(*engine, outputId,
+                                                    inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     for (const VarId varId : inputs) {
-      EXPECT_EQ(invariant.nextInput(ts, *engine), varId);
+      EXPECT_EQ(invariant.nextInput(ts), varId);
       const Int oldVal = engine->value(ts, varId);
       do {
         engine->setValue(ts, varId, valueDist(gen));
       } while (engine->value(ts, varId) == oldVal);
-      invariant.notifyCurrentInputChanged(ts, *engine);
+      invariant.notifyCurrentInputChanged(ts);
       EXPECT_EQ(engine->value(ts, outputId), computeViolation(ts, inputs));
     }
   }
@@ -205,8 +204,8 @@ TEST_F(BoolOrTest, Commit) {
       engine->makeIntVar(committedValues.at(1), lb, ub)};
 
   const VarId outputId = engine->makeIntVar(0, 0, 2);
-  BoolOr& invariant =
-      engine->makeInvariant<BoolOr>(outputId, inputs.at(0), inputs.at(1));
+  BoolOr& invariant = engine->makeInvariant<BoolOr>(*engine, outputId,
+                                                    inputs.at(0), inputs.at(1));
   engine->close();
 
   EXPECT_EQ(engine->value(engine->currentTimestamp(), outputId),
@@ -225,11 +224,11 @@ TEST_F(BoolOrTest, Commit) {
     } while (oldVal == engine->value(ts, inputs.at(i)));
 
     // notify changes
-    invariant.notifyInputChanged(ts, *engine, LocalId(i));
+    invariant.notifyInputChanged(ts, LocalId(i));
 
     // incremental value
     const Int notifiedViolation = engine->value(ts, outputId);
-    invariant.recompute(ts, *engine);
+    invariant.recompute(ts);
 
     ASSERT_EQ(notifiedViolation, engine->value(ts, outputId));
 
@@ -237,8 +236,8 @@ TEST_F(BoolOrTest, Commit) {
     committedValues.at(i) = engine->value(ts, inputs.at(i));
     engine->commitIf(ts, outputId);
 
-    invariant.commit(ts, *engine);
-    invariant.recompute(ts + 1, *engine);
+    invariant.commit(ts);
+    invariant.recompute(ts + 1);
     ASSERT_EQ(notifiedViolation, engine->value(ts + 1, outputId));
   }
 }
@@ -246,40 +245,35 @@ TEST_F(BoolOrTest, Commit) {
 class MockBoolOr : public BoolOr {
  public:
   bool registered = false;
-  void registerVars(Engine& engine) override {
+  void registerVars() override {
     registered = true;
-    BoolOr::registerVars(engine);
+    BoolOr::registerVars();
   }
-  explicit MockBoolOr(VarId outputId, VarId x, VarId y)
-      : BoolOr(outputId, x, y) {
-    ON_CALL(*this, recompute)
-        .WillByDefault([this](Timestamp timestamp, Engine& engine) {
-          return BoolOr::recompute(timestamp, engine);
-        });
-    ON_CALL(*this, nextInput)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          return BoolOr::nextInput(t, engine);
-        });
+  explicit MockBoolOr(Engine& engine, VarId outputId, VarId x, VarId y)
+      : BoolOr(engine, outputId, x, y) {
+    ON_CALL(*this, recompute).WillByDefault([this](Timestamp timestamp) {
+      return BoolOr::recompute(timestamp);
+    });
+    ON_CALL(*this, nextInput).WillByDefault([this](Timestamp timestamp) {
+      return BoolOr::nextInput(timestamp);
+    });
     ON_CALL(*this, notifyCurrentInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          BoolOr::notifyCurrentInputChanged(t, engine);
+        .WillByDefault([this](Timestamp timestamp) {
+          BoolOr::notifyCurrentInputChanged(timestamp);
         });
     ON_CALL(*this, notifyInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine, LocalId id) {
-          BoolOr::notifyInputChanged(t, engine, id);
+        .WillByDefault([this](Timestamp timestamp, LocalId id) {
+          BoolOr::notifyInputChanged(timestamp, id);
         });
-    ON_CALL(*this, commit).WillByDefault([this](Timestamp t, Engine& engine) {
-      BoolOr::commit(t, engine);
+    ON_CALL(*this, commit).WillByDefault([this](Timestamp timestamp) {
+      BoolOr::commit(timestamp);
     });
   }
-  MOCK_METHOD(void, recompute, (Timestamp timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(VarId, nextInput, (Timestamp, Engine&), (override));
-  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(void, notifyInputChanged,
-              (Timestamp t, Engine& engine, LocalId id), (override));
-  MOCK_METHOD(void, commit, (Timestamp timestamp, Engine& engine), (override));
+  MOCK_METHOD(void, recompute, (Timestamp), (override));
+  MOCK_METHOD(VarId, nextInput, (Timestamp), (override));
+  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp), (override));
+  MOCK_METHOD(void, notifyInputChanged, (Timestamp, LocalId), (override));
+  MOCK_METHOD(void, commit, (Timestamp), (override));
 };
 TEST_F(BoolOrTest, EngineIntegration) {
   for (const auto& [propMode, markingMode] : propMarkModes) {
@@ -290,8 +284,8 @@ TEST_F(BoolOrTest, EngineIntegration) {
     const VarId y = engine->makeIntVar(0, 0, 100);
     const VarId output = engine->makeIntVar(0, 0, 200);
     testNotifications<MockBoolOr>(
-        &engine->makeInvariant<MockBoolOr>(output, x, y), propMode, markingMode,
-        3, x, 1, output);
+        &engine->makeInvariant<MockBoolOr>(*engine, output, x, y), propMode,
+        markingMode, 3, x, 1, output);
   }
 }
 }  // namespace

--- a/test/invariants/tBoolXor.cpp
+++ b/test/invariants/tBoolXor.cpp
@@ -46,7 +46,7 @@ TEST_F(BoolXorTest, UpdateBounds) {
   const VarId y = engine->makeIntVar(
       boundVec.front().first, boundVec.front().first, boundVec.front().second);
   const VarId outputId = engine->makeIntVar(0, 0, 2);
-  BoolOr& invariant = engine->makeInvariant<BoolOr>(outputId, x, y);
+  BoolOr& invariant = engine->makeInvariant<BoolOr>(*engine, outputId, x, y);
   engine->close();
 
   for (const auto& [xLb, xUb] : boundVec) {
@@ -55,13 +55,13 @@ TEST_F(BoolXorTest, UpdateBounds) {
     for (const auto& [yLb, yUb] : boundVec) {
       EXPECT_TRUE(yLb <= yUb);
       engine->updateBounds(y, yLb, yUb, false);
-      invariant.updateBounds(*engine);
+      invariant.updateBounds();
       for (Int xVal = xLb; xVal <= xUb; ++xVal) {
         engine->setValue(engine->currentTimestamp(), x, xVal);
         for (Int yVal = yLb; yVal <= yUb; ++yVal) {
           engine->setValue(engine->currentTimestamp(), y, yVal);
-          invariant.updateBounds(*engine);
-          invariant.recompute(engine->currentTimestamp(), *engine);
+          invariant.updateBounds();
+          invariant.recompute(engine->currentTimestamp());
         }
       }
       ASSERT_GE(std::min(xLb, yLb), engine->lowerBound(outputId));
@@ -83,8 +83,8 @@ TEST_F(BoolXorTest, Recompute) {
                                           engine->makeIntVar(yUb, yLb, yUb)};
   const VarId outputId =
       engine->makeIntVar(0, 0, std::max(xUb - yLb, yUb - xLb));
-  BoolOr& invariant =
-      engine->makeInvariant<BoolOr>(outputId, inputs.at(0), inputs.at(1));
+  BoolOr& invariant = engine->makeInvariant<BoolOr>(*engine, outputId,
+                                                    inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Int xVal = xLb; xVal <= xUb; ++xVal) {
@@ -93,7 +93,7 @@ TEST_F(BoolXorTest, Recompute) {
       engine->setValue(engine->currentTimestamp(), inputs.at(1), yVal);
 
       const Int expectedViolation = computeViolation(xVal, yVal);
-      invariant.recompute(engine->currentTimestamp(), *engine);
+      invariant.recompute(engine->currentTimestamp());
       EXPECT_EQ(expectedViolation,
                 engine->value(engine->currentTimestamp(), outputId));
     }
@@ -109,8 +109,8 @@ TEST_F(BoolXorTest, NotifyInputChanged) {
   const std::array<const VarId, 2> inputs{engine->makeIntVar(ub, lb, ub),
                                           engine->makeIntVar(ub, lb, ub)};
   const VarId outputId = engine->makeIntVar(0, 0, ub - lb);
-  BoolOr& invariant =
-      engine->makeInvariant<BoolOr>(outputId, inputs.at(0), inputs.at(1));
+  BoolOr& invariant = engine->makeInvariant<BoolOr>(*engine, outputId,
+                                                    inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Int val = lb; val <= ub; ++val) {
@@ -119,8 +119,7 @@ TEST_F(BoolXorTest, NotifyInputChanged) {
       const Int expectedViolation =
           computeViolation(engine->currentTimestamp(), inputs);
 
-      invariant.notifyInputChanged(engine->currentTimestamp(), *engine,
-                                   LocalId(i));
+      invariant.notifyInputChanged(engine->currentTimestamp(), LocalId(i));
       EXPECT_EQ(expectedViolation,
                 engine->value(engine->currentTimestamp(), outputId));
     }
@@ -138,22 +137,22 @@ TEST_F(BoolXorTest, NextInput) {
   const VarId outputId = engine->makeIntVar(0, 0, 2);
   const VarId minVarId = *std::min_element(inputs.begin(), inputs.end());
   const VarId maxVarId = *std::max_element(inputs.begin(), inputs.end());
-  BoolOr& invariant =
-      engine->makeInvariant<BoolOr>(outputId, inputs.at(0), inputs.at(1));
+  BoolOr& invariant = engine->makeInvariant<BoolOr>(*engine, outputId,
+                                                    inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     std::vector<bool> notified(maxVarId + 1, false);
     for (size_t i = 0; i < inputs.size(); ++i) {
-      const VarId varId = invariant.nextInput(ts, *engine);
+      const VarId varId = invariant.nextInput(ts);
       EXPECT_NE(varId, NULL_ID);
       EXPECT_TRUE(minVarId <= varId);
       EXPECT_TRUE(varId <= maxVarId);
       EXPECT_FALSE(notified.at(varId));
       notified[varId] = true;
     }
-    EXPECT_EQ(invariant.nextInput(ts, *engine), NULL_ID);
+    EXPECT_EQ(invariant.nextInput(ts), NULL_ID);
     for (size_t varId = minVarId; varId <= maxVarId; ++varId) {
       EXPECT_TRUE(notified.at(varId));
     }
@@ -171,19 +170,19 @@ TEST_F(BoolXorTest, NotifyCurrentInputChanged) {
       engine->makeIntVar(valueDist(gen), lb, ub),
       engine->makeIntVar(valueDist(gen), lb, ub)};
   const VarId outputId = engine->makeIntVar(0, 0, ub - lb);
-  BoolOr& invariant =
-      engine->makeInvariant<BoolOr>(outputId, inputs.at(0), inputs.at(1));
+  BoolOr& invariant = engine->makeInvariant<BoolOr>(*engine, outputId,
+                                                    inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     for (const VarId varId : inputs) {
-      EXPECT_EQ(invariant.nextInput(ts, *engine), varId);
+      EXPECT_EQ(invariant.nextInput(ts), varId);
       const Int oldVal = engine->value(ts, varId);
       do {
         engine->setValue(ts, varId, valueDist(gen));
       } while (engine->value(ts, varId) == oldVal);
-      invariant.notifyCurrentInputChanged(ts, *engine);
+      invariant.notifyCurrentInputChanged(ts);
       EXPECT_EQ(engine->value(ts, outputId), computeViolation(ts, inputs));
     }
   }
@@ -205,8 +204,8 @@ TEST_F(BoolXorTest, Commit) {
       engine->makeIntVar(committedValues.at(1), lb, ub)};
 
   const VarId outputId = engine->makeIntVar(0, 0, 2);
-  BoolOr& invariant =
-      engine->makeInvariant<BoolOr>(outputId, inputs.at(0), inputs.at(1));
+  BoolOr& invariant = engine->makeInvariant<BoolOr>(*engine, outputId,
+                                                    inputs.at(0), inputs.at(1));
   engine->close();
 
   EXPECT_EQ(engine->value(engine->currentTimestamp(), outputId),
@@ -225,11 +224,11 @@ TEST_F(BoolXorTest, Commit) {
     } while (oldVal == engine->value(ts, inputs.at(i)));
 
     // notify changes
-    invariant.notifyInputChanged(ts, *engine, LocalId(i));
+    invariant.notifyInputChanged(ts, LocalId(i));
 
     // incremental value
     const Int notifiedViolation = engine->value(ts, outputId);
-    invariant.recompute(ts, *engine);
+    invariant.recompute(ts);
 
     ASSERT_EQ(notifiedViolation, engine->value(ts, outputId));
 
@@ -237,8 +236,8 @@ TEST_F(BoolXorTest, Commit) {
     committedValues.at(i) = engine->value(ts, inputs.at(i));
     engine->commitIf(ts, outputId);
 
-    invariant.commit(ts, *engine);
-    invariant.recompute(ts + 1, *engine);
+    invariant.commit(ts);
+    invariant.recompute(ts + 1);
     ASSERT_EQ(notifiedViolation, engine->value(ts + 1, outputId));
   }
 }
@@ -246,40 +245,35 @@ TEST_F(BoolXorTest, Commit) {
 class MockBoolXor : public BoolOr {
  public:
   bool registered = false;
-  void registerVars(Engine& engine) override {
+  void registerVars() override {
     registered = true;
-    BoolOr::registerVars(engine);
+    BoolOr::registerVars();
   }
-  explicit MockBoolXor(VarId outputId, VarId x, VarId y)
-      : BoolOr(outputId, x, y) {
-    ON_CALL(*this, recompute)
-        .WillByDefault([this](Timestamp timestamp, Engine& engine) {
-          return BoolOr::recompute(timestamp, engine);
-        });
-    ON_CALL(*this, nextInput)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          return BoolOr::nextInput(t, engine);
-        });
+  explicit MockBoolXor(Engine& engine, VarId outputId, VarId x, VarId y)
+      : BoolOr(engine, outputId, x, y) {
+    ON_CALL(*this, recompute).WillByDefault([this](Timestamp timestamp) {
+      return BoolOr::recompute(timestamp);
+    });
+    ON_CALL(*this, nextInput).WillByDefault([this](Timestamp timestamp) {
+      return BoolOr::nextInput(timestamp);
+    });
     ON_CALL(*this, notifyCurrentInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          BoolOr::notifyCurrentInputChanged(t, engine);
+        .WillByDefault([this](Timestamp timestamp) {
+          BoolOr::notifyCurrentInputChanged(timestamp);
         });
     ON_CALL(*this, notifyInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine, LocalId id) {
-          BoolOr::notifyInputChanged(t, engine, id);
+        .WillByDefault([this](Timestamp timestamp, LocalId id) {
+          BoolOr::notifyInputChanged(timestamp, id);
         });
-    ON_CALL(*this, commit).WillByDefault([this](Timestamp t, Engine& engine) {
-      BoolOr::commit(t, engine);
+    ON_CALL(*this, commit).WillByDefault([this](Timestamp timestamp) {
+      BoolOr::commit(timestamp);
     });
   }
-  MOCK_METHOD(void, recompute, (Timestamp timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(VarId, nextInput, (Timestamp, Engine&), (override));
-  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(void, notifyInputChanged,
-              (Timestamp t, Engine& engine, LocalId id), (override));
-  MOCK_METHOD(void, commit, (Timestamp timestamp, Engine& engine), (override));
+  MOCK_METHOD(void, recompute, (Timestamp), (override));
+  MOCK_METHOD(VarId, nextInput, (Timestamp), (override));
+  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp), (override));
+  MOCK_METHOD(void, notifyInputChanged, (Timestamp, LocalId), (override));
+  MOCK_METHOD(void, commit, (Timestamp), (override));
 };
 TEST_F(BoolXorTest, EngineIntegration) {
   for (const auto& [propMode, markingMode] : propMarkModes) {
@@ -290,7 +284,7 @@ TEST_F(BoolXorTest, EngineIntegration) {
     const VarId y = engine->makeIntVar(0, 0, 100);
     const VarId output = engine->makeIntVar(0, 0, 200);
     testNotifications<MockBoolXor>(
-        &engine->makeInvariant<MockBoolXor>(output, x, y), propMode,
+        &engine->makeInvariant<MockBoolXor>(*engine, output, x, y), propMode,
         markingMode, 3, x, 1, output);
   }
 }

--- a/test/invariants/tCount.cpp
+++ b/test/invariants/tCount.cpp
@@ -49,7 +49,7 @@ TEST_F(CountTest, UpdateBounds) {
                           engine->makeIntVar(0, 0, 10),
                           engine->makeIntVar(0, 0, 10)};
   const VarId outputId = engine->makeIntVar(0, 0, 2);
-  Count& invariant = engine->makeInvariant<Count>(outputId, y, vars);
+  Count& invariant = engine->makeInvariant<Count>(*engine, outputId, y, vars);
 
   for (const auto& [yLb, yUb] : boundVec) {
     EXPECT_TRUE(yLb <= yUb);
@@ -63,7 +63,7 @@ TEST_F(CountTest, UpdateBounds) {
         for (const auto& [cLb, cUb] : boundVec) {
           EXPECT_TRUE(cLb <= cUb);
           engine->updateBounds(vars.at(2), cLb, cUb, false);
-          invariant.updateBounds(*engine);
+          invariant.updateBounds();
 
           ASSERT_GE(0, engine->lowerBound(outputId));
           ASSERT_LE(vars.size(), engine->upperBound(outputId));
@@ -93,7 +93,7 @@ TEST_F(CountTest, Recompute) {
   const VarId outputId = engine->makeIntVar(0, std::numeric_limits<Int>::min(),
                                             std::numeric_limits<Int>::max());
 
-  Count& invariant = engine->makeInvariant<Count>(outputId, y, inputs);
+  Count& invariant = engine->makeInvariant<Count>(*engine, outputId, y, inputs);
   engine->close();
 
   for (Int yVal = lb; yVal <= ub; ++yVal) {
@@ -106,7 +106,7 @@ TEST_F(CountTest, Recompute) {
           engine->setValue(engine->currentTimestamp(), c, cVal);
           const Int expectedOutput =
               computeOutput(engine->currentTimestamp(), y, inputs);
-          invariant.recompute(engine->currentTimestamp(), *engine);
+          invariant.recompute(engine->currentTimestamp());
           EXPECT_EQ(expectedOutput,
                     engine->value(engine->currentTimestamp(), outputId));
         }
@@ -129,7 +129,7 @@ TEST_F(CountTest, NotifyInputChanged) {
   }
   const VarId outputId = engine->makeIntVar(0, std::numeric_limits<Int>::min(),
                                             std::numeric_limits<Int>::max());
-  Count& invariant = engine->makeInvariant<Count>(outputId, y, inputs);
+  Count& invariant = engine->makeInvariant<Count>(*engine, outputId, y, inputs);
   engine->close();
 
   std::vector<VarId> allInputs(inputs);
@@ -146,8 +146,7 @@ TEST_F(CountTest, NotifyInputChanged) {
     const Int expectedOutput =
         computeOutput(engine->currentTimestamp(), y, inputs);
 
-    invariant.notifyInputChanged(engine->currentTimestamp(), *engine,
-                                 LocalId(i));
+    invariant.notifyInputChanged(engine->currentTimestamp(), LocalId(i));
     EXPECT_EQ(expectedOutput,
               engine->value(engine->currentTimestamp(), outputId));
   }
@@ -168,7 +167,7 @@ TEST_F(CountTest, NextInput) {
   }
   const VarId outputId = engine->makeIntVar(0, std::numeric_limits<Int>::min(),
                                             std::numeric_limits<Int>::max());
-  Count& invariant = engine->makeInvariant<Count>(outputId, y, inputs);
+  Count& invariant = engine->makeInvariant<Count>(*engine, outputId, y, inputs);
   engine->close();
 
   std::shuffle(inputs.begin(), inputs.end(), rng);
@@ -182,14 +181,14 @@ TEST_F(CountTest, NextInput) {
        ts < engine->currentTimestamp() + 4; ++ts) {
     std::vector<bool> notified(maxVarId + 1, false);
     for (size_t i = 0; i <= numInputs; ++i) {
-      const VarId varId = invariant.nextInput(ts, *engine);
+      const VarId varId = invariant.nextInput(ts);
       EXPECT_NE(varId, NULL_ID);
       EXPECT_TRUE(minVarId <= varId);
       EXPECT_TRUE(varId <= maxVarId);
       EXPECT_FALSE(notified.at(varId));
       notified[varId] = true;
     }
-    EXPECT_EQ(invariant.nextInput(ts, *engine), NULL_ID);
+    EXPECT_EQ(invariant.nextInput(ts), NULL_ID);
     for (size_t varId = minVarId; varId <= maxVarId; ++varId) {
       EXPECT_TRUE(notified.at(varId));
     }
@@ -211,7 +210,7 @@ TEST_F(CountTest, NotifyCurrentInputChanged) {
 
   const VarId outputId = engine->makeIntVar(0, std::numeric_limits<Int>::min(),
                                             std::numeric_limits<Int>::max());
-  Count& invariant = engine->makeInvariant<Count>(outputId, y, inputs);
+  Count& invariant = engine->makeInvariant<Count>(*engine, outputId, y, inputs);
   engine->close();
 
   std::vector<VarId> allInputs(inputs);
@@ -220,12 +219,12 @@ TEST_F(CountTest, NotifyCurrentInputChanged) {
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     for (const VarId varId : allInputs) {
-      EXPECT_EQ(invariant.nextInput(ts, *engine), varId);
+      EXPECT_EQ(invariant.nextInput(ts), varId);
       const Int oldVal = engine->value(ts, varId);
       do {
         engine->setValue(ts, varId, dist(gen));
       } while (engine->value(ts, varId) == oldVal);
-      invariant.notifyCurrentInputChanged(ts, *engine);
+      invariant.notifyCurrentInputChanged(ts);
       EXPECT_EQ(engine->value(ts, outputId), computeOutput(ts, y, inputs));
     }
   }
@@ -252,7 +251,7 @@ TEST_F(CountTest, Commit) {
 
   const VarId outputId = engine->makeIntVar(0, std::numeric_limits<Int>::min(),
                                             std::numeric_limits<Int>::max());
-  Count& invariant = engine->makeInvariant<Count>(outputId, y, inputs);
+  Count& invariant = engine->makeInvariant<Count>(*engine, outputId, y, inputs);
 
   std::shuffle(indices.begin(), indices.end(), rng);
 
@@ -276,11 +275,11 @@ TEST_F(CountTest, Commit) {
     } while (oldVal == engine->value(ts, allInputs.at(i)));
 
     // notify changes
-    invariant.notifyInputChanged(ts, *engine, LocalId(i));
+    invariant.notifyInputChanged(ts, LocalId(i));
 
     // incremental value
     const Int notifiedOutput = engine->value(ts, outputId);
-    invariant.recompute(ts, *engine);
+    invariant.recompute(ts);
 
     ASSERT_EQ(notifiedOutput, engine->value(ts, outputId));
 
@@ -288,8 +287,8 @@ TEST_F(CountTest, Commit) {
     committedValues.at(i) = engine->value(ts, allInputs.at(i));
     engine->commitIf(ts, outputId);
 
-    invariant.commit(ts, *engine);
-    invariant.recompute(ts + 1, *engine);
+    invariant.commit(ts);
+    invariant.recompute(ts + 1);
     ASSERT_EQ(notifiedOutput, engine->value(ts + 1, outputId));
   }
 }
@@ -297,40 +296,36 @@ TEST_F(CountTest, Commit) {
 class MockCount : public Count {
  public:
   bool registered = false;
-  void registerVars(Engine& engine) override {
+  void registerVars() override {
     registered = true;
-    Count::registerVars(engine);
+    Count::registerVars();
   }
-  explicit MockCount(VarId output, VarId y, std::vector<VarId> varArray)
-      : Count(output, y, varArray) {
-    ON_CALL(*this, recompute)
-        .WillByDefault([this](Timestamp timestamp, Engine& engine) {
-          return Count::recompute(timestamp, engine);
-        });
-    ON_CALL(*this, nextInput)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          return Count::nextInput(t, engine);
-        });
+  explicit MockCount(Engine& engine, VarId output, VarId y,
+                     std::vector<VarId> varArray)
+      : Count(engine, output, y, varArray) {
+    ON_CALL(*this, recompute).WillByDefault([this](Timestamp timestamp) {
+      return Count::recompute(timestamp);
+    });
+    ON_CALL(*this, nextInput).WillByDefault([this](Timestamp timestamp) {
+      return Count::nextInput(timestamp);
+    });
     ON_CALL(*this, notifyCurrentInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          Count::notifyCurrentInputChanged(t, engine);
+        .WillByDefault([this](Timestamp timestamp) {
+          Count::notifyCurrentInputChanged(timestamp);
         });
     ON_CALL(*this, notifyInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine, LocalId id) {
-          Count::notifyInputChanged(t, engine, id);
+        .WillByDefault([this](Timestamp timestamp, LocalId id) {
+          Count::notifyInputChanged(timestamp, id);
         });
-    ON_CALL(*this, commit).WillByDefault([this](Timestamp t, Engine& engine) {
-      Count::commit(t, engine);
+    ON_CALL(*this, commit).WillByDefault([this](Timestamp timestamp) {
+      Count::commit(timestamp);
     });
   }
-  MOCK_METHOD(void, recompute, (Timestamp timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(VarId, nextInput, (Timestamp, Engine&), (override));
-  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(void, notifyInputChanged,
-              (Timestamp t, Engine& engine, LocalId id), (override));
-  MOCK_METHOD(void, commit, (Timestamp timestamp, Engine& engine), (override));
+  MOCK_METHOD(void, recompute, (Timestamp), (override));
+  MOCK_METHOD(VarId, nextInput, (Timestamp), (override));
+  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp), (override));
+  MOCK_METHOD(void, notifyInputChanged, (Timestamp, LocalId), (override));
+  MOCK_METHOD(void, commit, (Timestamp), (override));
 };
 TEST_F(CountTest, EngineIntegration) {
   for (const auto& [propMode, markingMode] : propMarkModes) {
@@ -346,7 +341,7 @@ TEST_F(CountTest, EngineIntegration) {
     const VarId modifiedVarId = args.front();
     const VarId output = engine->makeIntVar(-10, -100, numArgs * numArgs);
     testNotifications<MockCount>(
-        &engine->makeInvariant<MockCount>(output, y, args), propMode,
+        &engine->makeInvariant<MockCount>(*engine, output, y, args), propMode,
         markingMode, numArgs + 2, modifiedVarId, 5, output);
   }
 }

--- a/test/invariants/tPlus.cpp
+++ b/test/invariants/tPlus.cpp
@@ -42,7 +42,7 @@ TEST_F(PlusTest, UpdateBounds) {
   const VarId y = engine->makeIntVar(
       boundVec.front().first, boundVec.front().first, boundVec.front().second);
   const VarId outputId = engine->makeIntVar(0, 0, 2);
-  Plus& invariant = engine->makeInvariant<Plus>(outputId, x, y);
+  Plus& invariant = engine->makeInvariant<Plus>(*engine, outputId, x, y);
   engine->close();
 
   for (const auto& [xLb, xUb] : boundVec) {
@@ -52,13 +52,13 @@ TEST_F(PlusTest, UpdateBounds) {
       EXPECT_TRUE(yLb <= yUb);
       engine->updateBounds(y, yLb, yUb, false);
       engine->open();
-      invariant.updateBounds(*engine);
+      invariant.updateBounds();
       engine->close();
       for (Int xVal = xLb; xVal <= xUb; ++xVal) {
         engine->setValue(engine->currentTimestamp(), x, xVal);
         for (Int yVal = yLb; yVal <= yUb; ++yVal) {
           engine->setValue(engine->currentTimestamp(), y, yVal);
-          invariant.recompute(engine->currentTimestamp(), *engine);
+          invariant.recompute(engine->currentTimestamp());
           const Int o = engine->value(engine->currentTimestamp(), outputId);
           if (o < engine->lowerBound(outputId) ||
               engine->upperBound(outputId) < o) {
@@ -84,7 +84,7 @@ TEST_F(PlusTest, Recompute) {
   const VarId y = engine->makeIntVar(yUb, yLb, yUb);
   const VarId outputId =
       engine->makeIntVar(0, 0, std::max(xUb - yLb, yUb - xLb));
-  Plus& invariant = engine->makeInvariant<Plus>(outputId, x, y);
+  Plus& invariant = engine->makeInvariant<Plus>(*engine, outputId, x, y);
   engine->close();
 
   for (Int xVal = xLb; xVal <= xUb; ++xVal) {
@@ -93,7 +93,7 @@ TEST_F(PlusTest, Recompute) {
       engine->setValue(engine->currentTimestamp(), y, yVal);
 
       const Int expectedOutput = computeOutput(xVal, yVal);
-      invariant.recompute(engine->currentTimestamp(), *engine);
+      invariant.recompute(engine->currentTimestamp());
       EXPECT_EQ(expectedOutput,
                 engine->value(engine->currentTimestamp(), outputId));
     }
@@ -109,8 +109,8 @@ TEST_F(PlusTest, NotifyInputChanged) {
   std::array<VarId, 2> inputs{engine->makeIntVar(ub, lb, ub),
                               engine->makeIntVar(ub, lb, ub)};
   VarId outputId = engine->makeIntVar(0, 0, ub - lb);
-  Plus& invariant =
-      engine->makeInvariant<Plus>(outputId, inputs.at(0), inputs.at(1));
+  Plus& invariant = engine->makeInvariant<Plus>(*engine, outputId, inputs.at(0),
+                                                inputs.at(1));
   engine->close();
 
   for (Int val = lb; val <= ub; ++val) {
@@ -119,8 +119,7 @@ TEST_F(PlusTest, NotifyInputChanged) {
       const Int expectedOutput =
           computeOutput(engine->currentTimestamp(), inputs);
 
-      invariant.notifyInputChanged(engine->currentTimestamp(), *engine,
-                                   LocalId(i));
+      invariant.notifyInputChanged(engine->currentTimestamp(), LocalId(i));
       EXPECT_EQ(expectedOutput,
                 engine->value(engine->currentTimestamp(), outputId));
     }
@@ -138,22 +137,22 @@ TEST_F(PlusTest, NextInput) {
   const VarId outputId = engine->makeIntVar(0, 0, 2);
   const VarId minVarId = *std::min_element(inputs.begin(), inputs.end());
   const VarId maxVarId = *std::max_element(inputs.begin(), inputs.end());
-  Plus& invariant =
-      engine->makeInvariant<Plus>(outputId, inputs.at(0), inputs.at(1));
+  Plus& invariant = engine->makeInvariant<Plus>(*engine, outputId, inputs.at(0),
+                                                inputs.at(1));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     std::vector<bool> notified(maxVarId + 1, false);
     for (size_t i = 0; i < inputs.size(); ++i) {
-      const VarId varId = invariant.nextInput(ts, *engine);
+      const VarId varId = invariant.nextInput(ts);
       EXPECT_NE(varId, NULL_ID);
       EXPECT_TRUE(minVarId <= varId);
       EXPECT_TRUE(varId <= maxVarId);
       EXPECT_FALSE(notified.at(varId));
       notified[varId] = true;
     }
-    EXPECT_EQ(invariant.nextInput(ts, *engine), NULL_ID);
+    EXPECT_EQ(invariant.nextInput(ts), NULL_ID);
     for (size_t varId = minVarId; varId <= maxVarId; ++varId) {
       EXPECT_TRUE(notified.at(varId));
     }
@@ -171,19 +170,19 @@ TEST_F(PlusTest, NotifyCurrentInputChanged) {
       engine->makeIntVar(valueDist(gen), lb, ub),
       engine->makeIntVar(valueDist(gen), lb, ub)};
   const VarId outputId = engine->makeIntVar(0, 0, ub - lb);
-  Plus& invariant =
-      engine->makeInvariant<Plus>(outputId, inputs.at(0), inputs.at(1));
+  Plus& invariant = engine->makeInvariant<Plus>(*engine, outputId, inputs.at(0),
+                                                inputs.at(1));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     for (const VarId varId : inputs) {
-      EXPECT_EQ(invariant.nextInput(ts, *engine), varId);
+      EXPECT_EQ(invariant.nextInput(ts), varId);
       const Int oldVal = engine->value(ts, varId);
       do {
         engine->setValue(ts, varId, valueDist(gen));
       } while (engine->value(ts, varId) == oldVal);
-      invariant.notifyCurrentInputChanged(ts, *engine);
+      invariant.notifyCurrentInputChanged(ts);
       EXPECT_EQ(engine->value(ts, outputId), computeOutput(ts, inputs));
     }
   }
@@ -204,8 +203,8 @@ TEST_F(PlusTest, Commit) {
   std::shuffle(indices.begin(), indices.end(), rng);
 
   VarId outputId = engine->makeIntVar(0, 0, 2);
-  Plus& invariant =
-      engine->makeInvariant<Plus>(outputId, inputs.at(0), inputs.at(1));
+  Plus& invariant = engine->makeInvariant<Plus>(*engine, outputId, inputs.at(0),
+                                                inputs.at(1));
   engine->close();
 
   EXPECT_EQ(engine->value(engine->currentTimestamp(), outputId),
@@ -224,11 +223,11 @@ TEST_F(PlusTest, Commit) {
     } while (oldVal == engine->value(ts, inputs.at(i)));
 
     // notify changes
-    invariant.notifyInputChanged(ts, *engine, LocalId(i));
+    invariant.notifyInputChanged(ts, LocalId(i));
 
     // incremental value
     const Int notifiedOutput = engine->value(ts, outputId);
-    invariant.recompute(ts, *engine);
+    invariant.recompute(ts);
 
     ASSERT_EQ(notifiedOutput, engine->value(ts, outputId));
 
@@ -236,8 +235,8 @@ TEST_F(PlusTest, Commit) {
     committedValues.at(i) = engine->value(ts, inputs.at(i));
     engine->commitIf(ts, outputId);
 
-    invariant.commit(ts, *engine);
-    invariant.recompute(ts + 1, *engine);
+    invariant.commit(ts);
+    invariant.recompute(ts + 1);
     ASSERT_EQ(notifiedOutput, engine->value(ts + 1, outputId));
   }
 }
@@ -245,39 +244,35 @@ TEST_F(PlusTest, Commit) {
 class MockPlus : public Plus {
  public:
   bool registered = false;
-  void registerVars(Engine& engine) override {
+  void registerVars() override {
     registered = true;
-    Plus::registerVars(engine);
+    Plus::registerVars();
   }
-  explicit MockPlus(VarId output, VarId x, VarId y) : Plus(output, x, y) {
-    ON_CALL(*this, recompute)
-        .WillByDefault([this](Timestamp timestamp, Engine& engine) {
-          return Plus::recompute(timestamp, engine);
-        });
-    ON_CALL(*this, nextInput)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          return Plus::nextInput(t, engine);
-        });
+  explicit MockPlus(Engine& engine, VarId output, VarId x, VarId y)
+      : Plus(engine, output, x, y) {
+    ON_CALL(*this, recompute).WillByDefault([this](Timestamp timestamp) {
+      return Plus::recompute(timestamp);
+    });
+    ON_CALL(*this, nextInput).WillByDefault([this](Timestamp timestamp) {
+      return Plus::nextInput(timestamp);
+    });
     ON_CALL(*this, notifyCurrentInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          Plus::notifyCurrentInputChanged(t, engine);
+        .WillByDefault([this](Timestamp timestamp) {
+          Plus::notifyCurrentInputChanged(timestamp);
         });
     ON_CALL(*this, notifyInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine, LocalId id) {
-          Plus::notifyInputChanged(t, engine, id);
+        .WillByDefault([this](Timestamp timestamp, LocalId id) {
+          Plus::notifyInputChanged(timestamp, id);
         });
-    ON_CALL(*this, commit).WillByDefault([this](Timestamp t, Engine& engine) {
-      Plus::commit(t, engine);
+    ON_CALL(*this, commit).WillByDefault([this](Timestamp timestamp) {
+      Plus::commit(timestamp);
     });
   }
-  MOCK_METHOD(void, recompute, (Timestamp timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(VarId, nextInput, (Timestamp, Engine&), (override));
-  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(void, notifyInputChanged,
-              (Timestamp t, Engine& engine, LocalId id), (override));
-  MOCK_METHOD(void, commit, (Timestamp timestamp, Engine& engine), (override));
+  MOCK_METHOD(void, recompute, (Timestamp), (override));
+  MOCK_METHOD(VarId, nextInput, (Timestamp), (override));
+  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp), (override));
+  MOCK_METHOD(void, notifyInputChanged, (Timestamp, LocalId), (override));
+  MOCK_METHOD(void, commit, (Timestamp), (override));
 };
 TEST_F(PlusTest, EngineIntegration) {
   for (const auto& [propMode, markingMode] : propMarkModes) {
@@ -287,8 +282,9 @@ TEST_F(PlusTest, EngineIntegration) {
     const VarId x = engine->makeIntVar(-10, -100, 100);
     const VarId y = engine->makeIntVar(10, -100, 100);
     const VarId output = engine->makeIntVar(0, 0, 200);
-    testNotifications<MockPlus>(&engine->makeInvariant<MockPlus>(output, x, y),
-                                propMode, markingMode, 3, x, 0, output);
+    testNotifications<MockPlus>(
+        &engine->makeInvariant<MockPlus>(*engine, output, x, y), propMode,
+        markingMode, 3, x, 0, output);
   }
 }
 

--- a/test/invariants/tTimes.cpp
+++ b/test/invariants/tTimes.cpp
@@ -42,7 +42,7 @@ TEST_F(TimesTest, UpdateBounds) {
   const VarId y = engine->makeIntVar(
       boundVec.front().first, boundVec.front().first, boundVec.front().second);
   const VarId outputId = engine->makeIntVar(0, 0, 2);
-  Times& invariant = engine->makeInvariant<Times>(outputId, x, y);
+  Times& invariant = engine->makeInvariant<Times>(*engine, outputId, x, y);
   engine->close();
 
   for (const auto& [xLb, xUb] : boundVec) {
@@ -52,13 +52,13 @@ TEST_F(TimesTest, UpdateBounds) {
       EXPECT_TRUE(yLb <= yUb);
       engine->updateBounds(y, yLb, yUb, false);
       engine->open();
-      invariant.updateBounds(*engine);
+      invariant.updateBounds();
       engine->close();
       for (Int xVal = xLb; xVal <= xUb; ++xVal) {
         engine->setValue(engine->currentTimestamp(), x, xVal);
         for (Int yVal = yLb; yVal <= yUb; ++yVal) {
           engine->setValue(engine->currentTimestamp(), y, yVal);
-          invariant.recompute(engine->currentTimestamp(), *engine);
+          invariant.recompute(engine->currentTimestamp());
           const Int o = engine->value(engine->currentTimestamp(), outputId);
           if (o < engine->lowerBound(outputId) ||
               engine->upperBound(outputId) < o) {
@@ -84,7 +84,7 @@ TEST_F(TimesTest, Recompute) {
   const VarId y = engine->makeIntVar(yUb, yLb, yUb);
   const VarId outputId =
       engine->makeIntVar(0, 0, std::max(xUb - yLb, yUb - xLb));
-  Times& invariant = engine->makeInvariant<Times>(outputId, x, y);
+  Times& invariant = engine->makeInvariant<Times>(*engine, outputId, x, y);
   engine->close();
 
   for (Int xVal = xLb; xVal <= xUb; ++xVal) {
@@ -93,7 +93,7 @@ TEST_F(TimesTest, Recompute) {
       engine->setValue(engine->currentTimestamp(), y, yVal);
 
       const Int expectedOutput = computeOutput(xVal, yVal);
-      invariant.recompute(engine->currentTimestamp(), *engine);
+      invariant.recompute(engine->currentTimestamp());
       EXPECT_EQ(expectedOutput,
                 engine->value(engine->currentTimestamp(), outputId));
     }
@@ -109,8 +109,8 @@ TEST_F(TimesTest, NotifyInputChanged) {
   std::array<VarId, 2> inputs{engine->makeIntVar(ub, lb, ub),
                               engine->makeIntVar(ub, lb, ub)};
   VarId outputId = engine->makeIntVar(0, 0, ub - lb);
-  Times& invariant =
-      engine->makeInvariant<Times>(outputId, inputs.at(0), inputs.at(1));
+  Times& invariant = engine->makeInvariant<Times>(*engine, outputId,
+                                                  inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Int val = lb; val <= ub; ++val) {
@@ -119,8 +119,7 @@ TEST_F(TimesTest, NotifyInputChanged) {
       const Int expectedOutput =
           computeOutput(engine->currentTimestamp(), inputs);
 
-      invariant.notifyInputChanged(engine->currentTimestamp(), *engine,
-                                   LocalId(i));
+      invariant.notifyInputChanged(engine->currentTimestamp(), LocalId(i));
       EXPECT_EQ(expectedOutput,
                 engine->value(engine->currentTimestamp(), outputId));
     }
@@ -138,22 +137,22 @@ TEST_F(TimesTest, NextInput) {
   const VarId outputId = engine->makeIntVar(0, 0, 2);
   const VarId minVarId = *std::min_element(inputs.begin(), inputs.end());
   const VarId maxVarId = *std::max_element(inputs.begin(), inputs.end());
-  Times& invariant =
-      engine->makeInvariant<Times>(outputId, inputs.at(0), inputs.at(1));
+  Times& invariant = engine->makeInvariant<Times>(*engine, outputId,
+                                                  inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     std::vector<bool> notified(maxVarId + 1, false);
     for (size_t i = 0; i < inputs.size(); ++i) {
-      const VarId varId = invariant.nextInput(ts, *engine);
+      const VarId varId = invariant.nextInput(ts);
       EXPECT_NE(varId, NULL_ID);
       EXPECT_TRUE(minVarId <= varId);
       EXPECT_TRUE(varId <= maxVarId);
       EXPECT_FALSE(notified.at(varId));
       notified[varId] = true;
     }
-    EXPECT_EQ(invariant.nextInput(ts, *engine), NULL_ID);
+    EXPECT_EQ(invariant.nextInput(ts), NULL_ID);
     for (size_t varId = minVarId; varId <= maxVarId; ++varId) {
       EXPECT_TRUE(notified.at(varId));
     }
@@ -171,19 +170,19 @@ TEST_F(TimesTest, NotifyCurrentInputChanged) {
       engine->makeIntVar(valueDist(gen), lb, ub),
       engine->makeIntVar(valueDist(gen), lb, ub)};
   const VarId outputId = engine->makeIntVar(0, 0, ub - lb);
-  Times& invariant =
-      engine->makeInvariant<Times>(outputId, inputs.at(0), inputs.at(1));
+  Times& invariant = engine->makeInvariant<Times>(*engine, outputId,
+                                                  inputs.at(0), inputs.at(1));
   engine->close();
 
   for (Timestamp ts = engine->currentTimestamp() + 1;
        ts < engine->currentTimestamp() + 4; ++ts) {
     for (const VarId varId : inputs) {
-      EXPECT_EQ(invariant.nextInput(ts, *engine), varId);
+      EXPECT_EQ(invariant.nextInput(ts), varId);
       const Int oldVal = engine->value(ts, varId);
       do {
         engine->setValue(ts, varId, valueDist(gen));
       } while (engine->value(ts, varId) == oldVal);
-      invariant.notifyCurrentInputChanged(ts, *engine);
+      invariant.notifyCurrentInputChanged(ts);
       EXPECT_EQ(engine->value(ts, outputId), computeOutput(ts, inputs));
     }
   }
@@ -204,8 +203,8 @@ TEST_F(TimesTest, Commit) {
   std::shuffle(indices.begin(), indices.end(), rng);
 
   VarId outputId = engine->makeIntVar(0, 0, 2);
-  Times& invariant =
-      engine->makeInvariant<Times>(outputId, inputs.at(0), inputs.at(1));
+  Times& invariant = engine->makeInvariant<Times>(*engine, outputId,
+                                                  inputs.at(0), inputs.at(1));
   engine->close();
 
   EXPECT_EQ(engine->value(engine->currentTimestamp(), outputId),
@@ -224,11 +223,11 @@ TEST_F(TimesTest, Commit) {
     } while (oldVal == engine->value(ts, inputs.at(i)));
 
     // notify changes
-    invariant.notifyInputChanged(ts, *engine, LocalId(i));
+    invariant.notifyInputChanged(ts, LocalId(i));
 
     // incremental value
     const Int notifiedOutput = engine->value(ts, outputId);
-    invariant.recompute(ts, *engine);
+    invariant.recompute(ts);
 
     ASSERT_EQ(notifiedOutput, engine->value(ts, outputId));
 
@@ -236,8 +235,8 @@ TEST_F(TimesTest, Commit) {
     committedValues.at(i) = engine->value(ts, inputs.at(i));
     engine->commitIf(ts, outputId);
 
-    invariant.commit(ts, *engine);
-    invariant.recompute(ts + 1, *engine);
+    invariant.commit(ts);
+    invariant.recompute(ts + 1);
     ASSERT_EQ(notifiedOutput, engine->value(ts + 1, outputId));
   }
 }
@@ -245,39 +244,35 @@ TEST_F(TimesTest, Commit) {
 class MockTimes : public Times {
  public:
   bool registered = false;
-  void registerVars(Engine& engine) override {
+  void registerVars() override {
     registered = true;
-    Times::registerVars(engine);
+    Times::registerVars();
   }
-  explicit MockTimes(VarId output, VarId x, VarId y) : Times(output, x, y) {
-    ON_CALL(*this, recompute)
-        .WillByDefault([this](Timestamp timestamp, Engine& engine) {
-          return Times::recompute(timestamp, engine);
-        });
-    ON_CALL(*this, nextInput)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          return Times::nextInput(t, engine);
-        });
+  explicit MockTimes(Engine& engine, VarId output, VarId x, VarId y)
+      : Times(engine, output, x, y) {
+    ON_CALL(*this, recompute).WillByDefault([this](Timestamp timestamp) {
+      return Times::recompute(timestamp);
+    });
+    ON_CALL(*this, nextInput).WillByDefault([this](Timestamp timestamp) {
+      return Times::nextInput(timestamp);
+    });
     ON_CALL(*this, notifyCurrentInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine) {
-          Times::notifyCurrentInputChanged(t, engine);
+        .WillByDefault([this](Timestamp timestamp) {
+          Times::notifyCurrentInputChanged(timestamp);
         });
     ON_CALL(*this, notifyInputChanged)
-        .WillByDefault([this](Timestamp t, Engine& engine, LocalId id) {
-          Times::notifyInputChanged(t, engine, id);
+        .WillByDefault([this](Timestamp timestamp, LocalId id) {
+          Times::notifyInputChanged(timestamp, id);
         });
-    ON_CALL(*this, commit).WillByDefault([this](Timestamp t, Engine& engine) {
-      Times::commit(t, engine);
+    ON_CALL(*this, commit).WillByDefault([this](Timestamp timestamp) {
+      Times::commit(timestamp);
     });
   }
-  MOCK_METHOD(void, recompute, (Timestamp timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(VarId, nextInput, (Timestamp, Engine&), (override));
-  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp, Engine& engine),
-              (override));
-  MOCK_METHOD(void, notifyInputChanged,
-              (Timestamp t, Engine& engine, LocalId id), (override));
-  MOCK_METHOD(void, commit, (Timestamp timestamp, Engine& engine), (override));
+  MOCK_METHOD(void, recompute, (Timestamp), (override));
+  MOCK_METHOD(VarId, nextInput, (Timestamp), (override));
+  MOCK_METHOD(void, notifyCurrentInputChanged, (Timestamp), (override));
+  MOCK_METHOD(void, notifyInputChanged, (Timestamp, LocalId), (override));
+  MOCK_METHOD(void, commit, (Timestamp), (override));
 };
 TEST_F(TimesTest, EngineIntegration) {
   for (const auto& [propMode, markingMode] : propMarkModes) {
@@ -288,8 +283,8 @@ TEST_F(TimesTest, EngineIntegration) {
     const VarId y = engine->makeIntVar(10, -100, 100);
     const VarId output = engine->makeIntVar(0, 0, 200);
     testNotifications<MockTimes>(
-        &engine->makeInvariant<MockTimes>(output, x, y), propMode, markingMode,
-        3, x, 0, output);
+        &engine->makeInvariant<MockTimes>(*engine, output, x, y), propMode,
+        markingMode, 3, x, 0, output);
   }
 }
 

--- a/test/search/tAssignment.cpp
+++ b/test/search/tAssignment.cpp
@@ -28,8 +28,8 @@ class AssignmentTest : public testing::Test {
     d = engine.makeIntVar(3, 3, 3);
     violation = engine.makeIntVar(0, 0, 10);
 
-    engine.makeInvariant<Linear>(c, std::vector<VarId>{a, b});
-    engine.makeConstraint<Equal>(violation, c, d);
+    engine.makeInvariant<Linear>(engine, c, std::vector<VarId>{a, b});
+    engine.makeConstraint<Equal>(engine, violation, c, d);
     engine.close();
   }
 };

--- a/test/testHelper.hpp
+++ b/test/testHelper.hpp
@@ -74,9 +74,8 @@ class InvariantTest : public ::testing::Test {
                          const size_t numNextInputCalls,
                          const VarId modifiedVarId, const Int modifiedVal,
                          const VarId queryVarId) {
-    EXPECT_CALL(*invariant, recompute(testing::_, testing::_))
-        .Times(AtLeast(1));
-    EXPECT_CALL(*invariant, commit(testing::_, testing::_)).Times(AtLeast(1));
+    EXPECT_CALL(*invariant, recompute(testing::_)).Times(AtLeast(1));
+    EXPECT_CALL(*invariant, commit(testing::_)).Times(AtLeast(1));
 
     if (!engine->isOpen()) {
       engine->open();
@@ -86,20 +85,16 @@ class InvariantTest : public ::testing::Test {
     engine->close();
 
     if (engine->propagationMode() == PropagationMode::INPUT_TO_OUTPUT) {
-      EXPECT_CALL(*invariant, nextInput(testing::_, testing::_)).Times(0);
-      EXPECT_CALL(*invariant, notifyCurrentInputChanged(testing::_, testing::_))
+      EXPECT_CALL(*invariant, nextInput(testing::_)).Times(0);
+      EXPECT_CALL(*invariant, notifyCurrentInputChanged(testing::_))
           .Times(AtMost(1));
-      EXPECT_CALL(*invariant,
-                  notifyInputChanged(testing::_, testing::_, testing::_))
+      EXPECT_CALL(*invariant, notifyInputChanged(testing::_, testing::_))
           .Times(1);
     } else {
-      EXPECT_CALL(*invariant, nextInput(testing::_, testing::_))
-          .Times(numNextInputCalls);
-      EXPECT_CALL(*invariant, notifyCurrentInputChanged(testing::_, testing::_))
-          .Times(1);
+      EXPECT_CALL(*invariant, nextInput(testing::_)).Times(numNextInputCalls);
+      EXPECT_CALL(*invariant, notifyCurrentInputChanged(testing::_)).Times(1);
 
-      EXPECT_CALL(*invariant,
-                  notifyInputChanged(testing::_, testing::_, testing::_))
+      EXPECT_CALL(*invariant, notifyInputChanged(testing::_, testing::_))
           .Times(AtMost(1));
     }
 

--- a/test/views/tBool2IntView.cpp
+++ b/test/views/tBool2IntView.cpp
@@ -16,7 +16,7 @@ TEST(Bool2IntViewTest, simple) {
   PropagationEngine engine;
   engine.open();
   const VarId varId = engine.makeIntVar(0, 0, 1);
-  const VarId viewId = engine.makeIntView<Bool2IntView>(varId);
+  const VarId viewId = engine.makeIntView<Bool2IntView>(engine, varId);
   const std::array<Int, 5> values{0, 0, 1, 1, 0};
   engine.close();
 

--- a/test/views/tBoolView.cpp
+++ b/test/views/tBoolView.cpp
@@ -20,8 +20,8 @@ TEST_F(BoolViewTest, CreateBoolView) {
   engine->open();
 
   const VarId var = engine->makeIntVar(10, 0, 10);
-  auto viewOfVar = engine->makeIntView<Violation2BoolView>(var);
-  auto viewOfView = engine->makeIntView<Violation2BoolView>(viewOfVar);
+  auto viewOfVar = engine->makeIntView<Violation2BoolView>(*engine, var);
+  auto viewOfView = engine->makeIntView<Violation2BoolView>(*engine, viewOfVar);
 
   EXPECT_EQ(engine->committedValue(viewOfVar), Int(1));
   EXPECT_EQ(engine->committedValue(viewOfView), Int(1));
@@ -33,7 +33,7 @@ TEST_F(BoolViewTest, ComputeBounds) {
   engine->open();
   auto a = engine->makeIntVar(20, -100, 100);
 
-  auto va = engine->makeIntView<Violation2BoolView>(a);
+  auto va = engine->makeIntView<Violation2BoolView>(*engine, a);
 
   EXPECT_EQ(engine->lowerBound(va), Int(0));
   EXPECT_EQ(engine->upperBound(va), Int(1));
@@ -48,7 +48,7 @@ TEST_F(BoolViewTest, RecomputeBoolView) {
   engine->open();
   auto a = engine->makeIntVar(20, -100, 100);
 
-  auto viewOfVarId = engine->makeIntView<Violation2BoolView>(a);
+  auto viewOfVarId = engine->makeIntView<Violation2BoolView>(*engine, a);
 
   EXPECT_EQ(engine->currentValue(viewOfVarId), Int(1));
 

--- a/test/views/tElementConst.cpp
+++ b/test/views/tElementConst.cpp
@@ -64,7 +64,8 @@ TEST_F(ElementConstTest, Bounds) {
 
   engine->open();
   const VarId index = engine->makeIntVar(indexDist(gen), indexLb, indexUb);
-  const VarId outputId = engine->makeIntView<ElementConst>(index, values);
+  const VarId outputId =
+      engine->makeIntView<ElementConst>(*engine, index, values);
   engine->close();
 
   const Int ub = 100;
@@ -90,7 +91,8 @@ TEST_F(ElementConstTest, Value) {
 
   engine->open();
   const VarId index = engine->makeIntVar(indexDist(gen), indexLb, indexUb);
-  const VarId outputId = engine->makeIntView<ElementConst>(index, values);
+  const VarId outputId =
+      engine->makeIntView<ElementConst>(*engine, index, values);
   engine->close();
 
   for (Int val = indexLb; val <= indexUb; ++val) {
@@ -113,7 +115,8 @@ TEST_F(ElementConstTest, CommittedValue) {
 
   engine->open();
   const VarId index = engine->makeIntVar(indexDist(gen), indexLb, indexUb);
-  const VarId outputId = engine->makeIntView<ElementConst>(index, values);
+  const VarId outputId =
+      engine->makeIntView<ElementConst>(*engine, index, values);
   engine->close();
 
   Int committedValue = engine->committedValue(index);

--- a/test/views/tEqualConst.cpp
+++ b/test/views/tEqualConst.cpp
@@ -24,7 +24,7 @@ RC_GTEST_FIXTURE_PROP(EqualViewConst, simple, (int a, int b)) {
     engine->open();
   }
   const VarId varId = engine->makeIntVar(a, a, a);
-  const VarId violationId = engine->makeIntView<EqualConst>(varId, b);
+  const VarId violationId = engine->makeIntView<EqualConst>(*engine, varId, b);
   RC_ASSERT(engine->committedValue(violationId) == std::abs(Int(a) - Int(b)));
 }
 
@@ -33,7 +33,7 @@ RC_GTEST_FIXTURE_PROP(EqualViewConst, singleton, (int a, int b)) {
     engine->open();
   }
   const VarId varId = engine->makeIntVar(a, a, a);
-  const VarId violationId = engine->makeIntView<EqualConst>(varId, b);
+  const VarId violationId = engine->makeIntView<EqualConst>(*engine, varId, b);
   RC_ASSERT(engine->committedValue(violationId) == std::abs(Int(a) - Int(b)));
   RC_ASSERT(engine->lowerBound(violationId) ==
             engine->committedValue(violationId));
@@ -48,7 +48,7 @@ RC_GTEST_FIXTURE_PROP(EqualViewConst, interval, (int a, int b)) {
 
   engine->open();
   const VarId varId = engine->makeIntVar(ub, lb, ub);
-  const VarId violationId = engine->makeIntView<EqualConst>(varId, b);
+  const VarId violationId = engine->makeIntView<EqualConst>(*engine, varId, b);
   engine->close();
 
   const Int violLb = engine->lowerBound(violationId);

--- a/test/views/tGreaterEqualConst.cpp
+++ b/test/views/tGreaterEqualConst.cpp
@@ -26,7 +26,8 @@ RC_GTEST_FIXTURE_PROP(GreaterEqualViewConst, simple, (int a, int b)) {
     engine->open();
   }
   const VarId varId = engine->makeIntVar(a, a, a);
-  const VarId violationId = engine->makeIntView<GreaterEqualConst>(varId, b);
+  const VarId violationId =
+      engine->makeIntView<GreaterEqualConst>(*engine, varId, b);
   RC_ASSERT(engine->committedValue(violationId) == computeViolation(a, b));
 }
 
@@ -35,7 +36,8 @@ RC_GTEST_FIXTURE_PROP(GreaterEqualViewConst, singleton, (int a, int b)) {
     engine->open();
   }
   const VarId varId = engine->makeIntVar(a, a, a);
-  const VarId violationId = engine->makeIntView<GreaterEqualConst>(varId, b);
+  const VarId violationId =
+      engine->makeIntView<GreaterEqualConst>(*engine, varId, b);
   RC_ASSERT(engine->committedValue(violationId) == computeViolation(a, b));
   RC_ASSERT(engine->lowerBound(violationId) ==
             engine->committedValue(violationId));
@@ -50,7 +52,8 @@ RC_GTEST_FIXTURE_PROP(GreaterEqualViewConst, interval, (int a, int b)) {
 
   engine->open();
   const VarId varId = engine->makeIntVar(ub, lb, ub);
-  const VarId violationId = engine->makeIntView<GreaterEqualConst>(varId, b);
+  const VarId violationId =
+      engine->makeIntView<GreaterEqualConst>(*engine, varId, b);
   engine->close();
 
   const Int violLb = engine->lowerBound(violationId);

--- a/test/views/tInDomain.cpp
+++ b/test/views/tInDomain.cpp
@@ -65,8 +65,8 @@ TEST_F(InDomainTest, Bounds) {
         engine->open();
       }
       engine->updateBounds(x, xLb, xUb, false);
-      const VarId violationId =
-          engine->makeIntView<InDomain>(x, std::vector<DomainEntry>(dom));
+      const VarId violationId = engine->makeIntView<InDomain>(
+          *engine, x, std::vector<DomainEntry>(dom));
       engine->close();
 
       std::vector<Int> violations;
@@ -97,8 +97,8 @@ TEST_F(InDomainTest, Value) {
     const Int lb = domainVec.front().lowerBound - margin;
     const Int ub = domainVec.back().upperBound + margin;
     const VarId x = engine->makeIntVar(lb, lb, ub);
-    const VarId violationId =
-        engine->makeIntView<InDomain>(x, std::vector<DomainEntry>(dom));
+    const VarId violationId = engine->makeIntView<InDomain>(
+        *engine, x, std::vector<DomainEntry>(dom));
     engine->close();
     for (Int val = lb; val <= ub; ++val) {
       engine->setValue(engine->currentTimestamp(), x, val);
@@ -130,8 +130,8 @@ TEST_F(InDomainTest, CommittedValue) {
     std::shuffle(values.begin(), values.end(), rng);
 
     const VarId x = engine->makeIntVar(lb, lb, ub);
-    const VarId violationId =
-        engine->makeIntView<InDomain>(x, std::vector<DomainEntry>(dom));
+    const VarId violationId = engine->makeIntView<InDomain>(
+        *engine, x, std::vector<DomainEntry>(dom));
     engine->close();
 
     Int committedValue = engine->committedValue(x);

--- a/test/views/tInSparseDomain.cpp
+++ b/test/views/tInSparseDomain.cpp
@@ -65,8 +65,8 @@ TEST_F(InSparseDomainTest, Bounds) {
         engine->open();
       }
       engine->updateBounds(x, xLb, xUb, false);
-      const VarId violationId =
-          engine->makeIntView<InSparseDomain>(x, std::vector<DomainEntry>(dom));
+      const VarId violationId = engine->makeIntView<InSparseDomain>(
+          *engine, x, std::vector<DomainEntry>(dom));
       engine->close();
 
       std::vector<Int> violations;
@@ -97,8 +97,8 @@ TEST_F(InSparseDomainTest, Value) {
     const Int lb = domainVec.front().lowerBound - margin;
     const Int ub = domainVec.back().upperBound + margin;
     const VarId x = engine->makeIntVar(lb, lb, ub);
-    const VarId violationId =
-        engine->makeIntView<InSparseDomain>(x, std::vector<DomainEntry>(dom));
+    const VarId violationId = engine->makeIntView<InSparseDomain>(
+        *engine, x, std::vector<DomainEntry>(dom));
     engine->close();
     for (Int val = lb; val <= ub; ++val) {
       engine->setValue(engine->currentTimestamp(), x, val);
@@ -130,8 +130,8 @@ TEST_F(InSparseDomainTest, CommittedValue) {
     std::shuffle(values.begin(), values.end(), rng);
 
     const VarId x = engine->makeIntVar(lb, lb, ub);
-    const VarId violationId =
-        engine->makeIntView<InSparseDomain>(x, std::vector<DomainEntry>(dom));
+    const VarId violationId = engine->makeIntView<InSparseDomain>(
+        *engine, x, std::vector<DomainEntry>(dom));
     engine->close();
 
     Int committedValue = engine->committedValue(x);

--- a/test/views/tLessEqualConst.cpp
+++ b/test/views/tLessEqualConst.cpp
@@ -26,7 +26,8 @@ RC_GTEST_FIXTURE_PROP(LessEqualViewConst, simple, (int a, int b)) {
     engine->open();
   }
   const VarId varId = engine->makeIntVar(a, a, a);
-  const VarId violationId = engine->makeIntView<LessEqualConst>(varId, b);
+  const VarId violationId =
+      engine->makeIntView<LessEqualConst>(*engine, varId, b);
   RC_ASSERT(engine->committedValue(violationId) == computeViolation(a, b));
 }
 
@@ -35,7 +36,8 @@ RC_GTEST_FIXTURE_PROP(LessEqualViewConst, singleton, (int a, int b)) {
     engine->open();
   }
   const VarId varId = engine->makeIntVar(a, a, a);
-  const VarId violationId = engine->makeIntView<LessEqualConst>(varId, b);
+  const VarId violationId =
+      engine->makeIntView<LessEqualConst>(*engine, varId, b);
   RC_ASSERT(engine->committedValue(violationId) == computeViolation(a, b));
   RC_ASSERT(engine->lowerBound(violationId) ==
             engine->committedValue(violationId));
@@ -50,7 +52,8 @@ RC_GTEST_FIXTURE_PROP(LessEqualViewConst, interval, (int a, int b)) {
 
   engine->open();
   const VarId varId = engine->makeIntVar(ub, lb, ub);
-  const VarId violationId = engine->makeIntView<LessEqualConst>(varId, b);
+  const VarId violationId =
+      engine->makeIntView<LessEqualConst>(*engine, varId, b);
   engine->close();
 
   const Int violLb = engine->lowerBound(violationId);

--- a/test/views/tNotEqualConst.cpp
+++ b/test/views/tNotEqualConst.cpp
@@ -24,7 +24,8 @@ RC_GTEST_FIXTURE_PROP(notEqualViewConst, simple, (Int a, Int b)) {
     engine->open();
   }
   const VarId varId = engine->makeIntVar(a, a, a);
-  const VarId violationId = engine->makeIntView<NotEqualConst>(varId, b);
+  const VarId violationId =
+      engine->makeIntView<NotEqualConst>(*engine, varId, b);
   RC_ASSERT(engine->committedValue(violationId) == static_cast<Int>(a == b));
 }
 
@@ -33,7 +34,8 @@ RC_GTEST_FIXTURE_PROP(notEqualViewConst, singleton, (Int a, Int b)) {
     engine->open();
   }
   const VarId varId = engine->makeIntVar(a, a, a);
-  const VarId violationId = engine->makeIntView<NotEqualConst>(varId, b);
+  const VarId violationId =
+      engine->makeIntView<NotEqualConst>(*engine, varId, b);
   RC_ASSERT(engine->committedValue(violationId) == static_cast<Int>(a == b));
   RC_ASSERT(engine->lowerBound(violationId) ==
             engine->committedValue(violationId));
@@ -59,7 +61,8 @@ RC_GTEST_FIXTURE_PROP(notEqualViewConst, interval, (Int a)) {
 
   engine->open();
   const VarId varId = engine->makeIntVar(ub, lb, ub);
-  const VarId violationId = engine->makeIntView<NotEqualConst>(varId, b);
+  const VarId violationId =
+      engine->makeIntView<NotEqualConst>(*engine, varId, b);
   engine->close();
 
   const Int violLb = engine->lowerBound(violationId);

--- a/test/views/tScalarView.cpp
+++ b/test/views/tScalarView.cpp
@@ -14,7 +14,7 @@ class ScalarViewTest : public ::testing::Test {
 RC_GTEST_FIXTURE_PROP(ScalarViewTest, simple, (Int a, Int b)) {
   engine->open();
   auto varId = engine->makeIntVar(a, a, a);
-  auto viewId = engine->makeIntView<ScalarView>(varId, b);
+  auto viewId = engine->makeIntView<ScalarView>(*engine, varId, b);
   engine->close();
 
   RC_ASSERT(engine->committedValue(viewId) == a * b);


### PR DESCRIPTION
Updated constructors and the creation of these classes.
With topological ordering, each invariant is only called once for each input variable during each commit/probe.
This can be exploited by removing the storage of values in the invariant and only using the variables committed and current values