### PR TITLE
Add IntView for exponentiation with a constant

### DIFF
--- a/include/atlantis/propagation/views/expView.hpp
+++ b/include/atlantis/propagation/views/expView.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <stdexcept>
+
+#include "atlantis/propagation/solver.hpp"
+#include "atlantis/propagation/views/intView.hpp"
+
+namespace atlantis::propagation {
+
+class ExpView : public IntView {
+ private:
+  Int _power;
+
+ protected:
+  static inline Int pow(Int base, Int power) {
+    if (power == 0) {
+      return 1;
+    }
+    if (power == 1) {
+      return base;
+    }
+    if (power < 0) {
+      if (base == 0) {
+        throw std::runtime_error("negative power of zero");
+      }
+      if (base == 1) {
+        return 1;
+      }
+      if (base == -1) {
+        return power % 2 == 0 ? 1 : -1;
+      }
+      return 0;
+    }
+    Int result = 1;
+    for (int i = 0; i < power; i++) {
+      result *= base;
+    }
+    return result;
+  }
+
+ public:
+  explicit ExpView(SolverBase& solver, VarId parentId, Int power)
+      : IntView(solver, parentId), _power(power) {}
+
+  [[nodiscard]] Int value(Timestamp) override;
+  [[nodiscard]] Int committedValue() override;
+  [[nodiscard]] Int lowerBound() const override;
+  [[nodiscard]] Int upperBound() const override;
+};
+
+}  // namespace atlantis::propagation

--- a/src/propagation/views/expView.cpp
+++ b/src/propagation/views/expView.cpp
@@ -1,0 +1,26 @@
+#include "atlantis/propagation/views/expView.hpp"
+
+#include <initializer_list>
+
+namespace atlantis::propagation {
+
+Int ExpView::value(Timestamp ts) {
+  return pow(_solver.value(ts, _parentId), _power);
+}
+
+Int ExpView::committedValue() {
+  return pow(_solver.committedValue(_parentId), _power);
+}
+
+Int ExpView::lowerBound() const {
+  return std::min(
+      std::initializer_list<Int>{0, pow(_power, _solver.lowerBound(_parentId)),
+                                 pow(_power, _solver.upperBound(_parentId))});
+}
+
+Int ExpView::upperBound() const {
+  return std::max(pow(_power, _solver.lowerBound(_parentId)),
+                  pow(_power, _solver.upperBound(_parentId)));
+}
+
+}  // namespace atlantis::propagation


### PR DESCRIPTION
This PR adds an additional view that allows exponentiation. The exponentiation might seems a little simplistic, but this avoids rounding of the standard library function that would use floating point operations. (This is similar how the MiniZinc built-in function operates).