### PR TITLE
Add Dockerfile to create a Docker image for the MiniZinc Challenge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update -y && \
 # Clone the Atlantis git repository.
 RUN ssh-keyscan github.com > /etc/ssh/ssh_known_hosts
 RUN --mount=type=ssh \
-    git clone git@github.com:astra-uu-se/cbls.git /src
+    git clone git@github.com:astra-uu-se/atlantis.git /src
 
 # Change directory to /src.
 WORKDIR /src


### PR DESCRIPTION
This PR adds a Dockerfile according to the MiniZinc Challenge instructions: https://www.minizinc.org/challenge/2024/docker/

Note that because Atlantis (and its parser dependency) is still closed source, you need to build with the `--ssh default` flag, exposing your SSH configuration.

I use the following build command: 
```sh
docker build --ssh default -t atlantis:latest .
```

Although the build succeeds correctly, the test command fails. Seemingly the following FlatZinc cannot be solved correctly:
```mzn
var 2..3: x:: output_var;
solve :: int_search([x],input_order,indomain_min,complete) maximize x;
```
Just returning `=====ERROR=====`, locally this seems to give a segmentation fault