### PR TITLE
Fixed an issue with creating output variables using the invariant graph

### DIFF
--- a/include/atlantis/invariantgraph/invariantGraph.hpp
+++ b/include/atlantis/invariantgraph/invariantGraph.hpp
@@ -9,6 +9,7 @@
 #include "atlantis/invariantgraph/invariantGraph.hpp"
 #include "atlantis/invariantgraph/types.hpp"
 #include "atlantis/propagation/types.hpp"
+#include "implicitConstraintNode.hpp"
 
 namespace atlantis {
 class SearchDomain;
@@ -40,6 +41,14 @@ class InvariantGraph {
   bool _breakDynamicCycles;
 
   void populateRootNode();
+
+  void breakSelfCycles();
+
+  void createVars();
+  void createImplicitConstraints();
+  void createInvariants();
+  propagation::VarViewId createViolations();
+  void sanity(bool);
 
  protected:
   propagation::VarViewId _totalViolationVarId{propagation::NULL_ID};
@@ -117,6 +126,11 @@ class InvariantGraph {
 
   [[nodiscard]] const VarNode& varNodeConst(VarNodeId id) const;
 
+  [[nodiscard]] const InvariantNode& invariantNodeConst(InvariantNodeId) const;
+
+  [[nodiscard]] const std::vector<std::shared_ptr<ImplicitConstraintNode>>&
+  implicitConstraintNodes() const;
+
   [[nodiscard]] VarNodeId varNodeId(bool val) const;
 
   [[nodiscard]] VarNodeId varNodeId(Int val) const;
@@ -175,30 +189,6 @@ class InvariantGraph {
       const;
 
   void writeDotFile(std::ostream&) const;
-
- private:
-  std::unordered_set<VarNodeId> dynamicVarNodeFrontier(
-      VarNodeId node, const std::unordered_set<VarNodeId>& visitedGlobal);
-
-  VarNodeId findCycleUtil(
-      VarNodeId varNodeId, const std::unordered_set<VarNodeId>& visitedGlobal,
-      std::unordered_set<VarNodeId>& visitedLocal,
-      std::unordered_map<VarNodeId, InvariantGraphEdge>& path);
-
-  InvariantGraphEdge findPivotInCycle(
-      const std::vector<InvariantGraphEdge>& cycle);
-
-  void breakSelfCycles();
-
-  std::vector<VarNodeId> breakCycles(
-      VarNodeId node, std::unordered_set<VarNodeId>& visitedGlobal);
-  VarNodeId breakCycle(const std::vector<InvariantGraphEdge>& cycle);
-
-  void createVars();
-  void createImplicitConstraints();
-  void createInvariants();
-  propagation::VarViewId createViolations();
-  void sanity(bool);
 };
 
 }  // namespace atlantis::invariantgraph

--- a/include/atlantis/propagation/propagation/propagationGraph.hpp
+++ b/include/atlantis/propagation/propagation/propagationGraph.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stack>
+
 #include "atlantis/propagation/propagation/propagationQueue.hpp"
 #include "atlantis/propagation/store/store.hpp"
 
@@ -7,6 +9,10 @@ namespace atlantis::propagation {
 
 class PropagationGraph {
  public:
+  struct LayerIndex {
+    size_t layer;
+    size_t index;
+  };
   struct ListeningInvariantData {
     InvariantId invariantId;
     LocalId localId;
@@ -59,46 +65,27 @@ class PropagationGraph {
   std::vector<std::vector<ListeningInvariantData>> _listeningInvariantData;
 
   std::vector<std::vector<VarId>> _varsInLayer;
-  struct LayerIndex {
-    size_t layer;
-    size_t index;
-  };
   std::vector<LayerIndex> _varLayerIndex;
-  std::vector<size_t> _varPosition;
-  std::vector<size_t> _layerPositionOffset{};
+  std::vector<size_t> _topologicalNumber;
   std::vector<bool> _layerHasDynamicCycle{};
+  std::vector<size_t> _topologicalNumberOffset;
   bool _hasDynamicCycle{false};
   size_t _numInvariants{0};
   size_t _numVars{0};
 
-  bool containsStaticCycle(std::vector<bool>& visited,
-                           std::vector<bool>& inFrontier, VarId varId);
-  bool containsStaticCycle();
-  void partitionIntoLayers(std::vector<bool>& visited, VarId varId);
   void partitionIntoLayers();
-  bool containsDynamicCycle(std::vector<bool>& visited, VarId originVarId);
-  bool containsDynamicCycle(size_t layer);
-  void mergeLayersWithoutDynamicCycles();
-  void computeLayerOffsets();
-  void topologicallyOrder(Timestamp ts, std::vector<bool>& inFrontier,
-                          VarId varId);
   void topologicallyOrder(Timestamp ts, size_t layer, bool updatePriorityQueue);
   void topologicallyOrder(Timestamp ts);
 
   struct PriorityCmp {
     PropagationGraph& graph;
     explicit PriorityCmp(PropagationGraph& g) : graph(g) {}
-    bool operator()(VarId left, VarId right) {
+    bool operator()(VarId left, VarId right) const {
       return graph.varPosition(left) > graph.varPosition(right);
     }
   };
 
   PropagationQueue _propagationQueue;
-
-  [[nodiscard]] VarId dynamicInputVar(Timestamp ts,
-                                      InvariantId invariantId) const noexcept {
-    return _store.dynamicInputVar(ts, invariantId);
-  }
 
  public:
   explicit PropagationGraph(const Store& store, size_t expectedSize = 1000u);
@@ -155,12 +142,12 @@ class PropagationGraph {
     return _numInvariants;  // this ignores null invariant
   }
 
-  bool isEvaluationVar(VarId id) {
+  [[nodiscard]] bool isEvaluationVar(VarId id) const {
     assert(size_t(id) < _isEvaluationVar.size());
     return _isEvaluationVar[size_t(id)];
   }
 
-  bool isSearchVar(VarId id) {
+  [[nodiscard]] bool isSearchVar(VarId id) const {
     assert(size_t(id) < _isSearchVar.size());
     return _isSearchVar.at(size_t(id));
   }
@@ -190,6 +177,11 @@ class PropagationGraph {
     return _inputVars.at(invariantId);
   }
 
+  [[nodiscard]] VarId dynamicInputVar(Timestamp ts,
+                                      InvariantId invariantId) const noexcept {
+    return _store.dynamicInputVar(ts, invariantId);
+  }
+
   [[nodiscard]] const std::vector<VarId>& searchVars() const {
     return _searchVars;
   }
@@ -204,7 +196,7 @@ class PropagationGraph {
     }
   }
 
-  [[nodiscard]] bool propagationQueueEmpty() {
+  [[nodiscard]] bool propagationQueueEmpty() const {
     return _propagationQueue.empty();
   }
 
@@ -237,22 +229,23 @@ class PropagationGraph {
     return _varsInLayer[layer];
   }
 
-  [[nodiscard]] size_t varLayer(VarId id) {
+  [[nodiscard]] size_t varLayer(VarId id) const {
     return _varLayerIndex.at(id).layer;
   }
 
-  [[nodiscard]] size_t invariantLayer(InvariantId invariantId) {
+  [[nodiscard]] size_t invariantLayer(InvariantId invariantId) const {
     assert(!varsDefinedBy(invariantId).empty());
     return _varLayerIndex.at(varsDefinedBy(invariantId).front()).layer;
   }
 
-  [[nodiscard]] size_t varPosition(VarId id) {
-    return _varPosition[size_t(id)];
+  [[nodiscard]] size_t varPosition(VarId id) const {
+    return _topologicalNumber[size_t(id)];
   }
 
-  size_t invariantPosition(InvariantId invariantId) {
+  [[nodiscard]] size_t invariantPosition(InvariantId invariantId) const {
     assert(!_varsDefinedByInvariant.at(invariantId).empty());
-    return _varPosition.at(_varsDefinedByInvariant.at(invariantId).front());
+    return _topologicalNumber.at(
+        _varsDefinedByInvariant.at(invariantId).front());
   }
 
   void enqueuePropagationQueue(VarId id) { _propagationQueue.push(id); }

--- a/src/invariantgraph/invariantGraph.cpp
+++ b/src/invariantgraph/invariantGraph.cpp
@@ -20,6 +20,241 @@
 
 namespace atlantis::invariantgraph {
 
+static void SCCUtil(const InvariantGraph& graph, VarNodeId inputId,
+                    std::vector<Int>& discoverTime, std::vector<Int>& lowTime,
+                    std::vector<VarNodeId>& stack, std::vector<bool>& onStack,
+                    Int& time,
+                    std::vector<std::vector<VarNodeId>>& components) {
+  assert(inputId < discoverTime.size());
+  assert(discoverTime.size() == lowTime.size());
+  assert(discoverTime.size() == onStack.size());
+  assert(!onStack[inputId]);
+  discoverTime[inputId] = lowTime[inputId] = time;
+  ++time;
+  stack.emplace_back(inputId);
+  onStack[inputId] = true;
+
+  assert(graph.varNodeConst(inputId).definingNodes().size() <= 1);
+  for (size_t i = 0; i < 2; ++i) {
+    for (const InvariantNodeId invId :
+         i == 0 ? graph.varNodeConst(inputId).staticInputTo()
+                : graph.varNodeConst(inputId).dynamicInputTo()) {
+      for (const VarNodeId outputId :
+           graph.invariantNodeConst(invId).outputVarNodeIds()) {
+        if (discoverTime[outputId] < 0) {
+          SCCUtil(graph, outputId, discoverTime, lowTime, stack, onStack, time,
+                  components);
+          lowTime[inputId] = std::min(lowTime[outputId], lowTime[inputId]);
+        } else if (onStack[outputId]) {
+          lowTime[inputId] = std::min(lowTime[outputId], discoverTime[inputId]);
+        }
+      }
+    }
+  }
+  if (lowTime[inputId] == discoverTime[inputId]) {
+    const bool inSCC = stack.back() != inputId;
+    if (inSCC) {
+      components.emplace_back();
+      while (stack.back() != inputId) {
+        onStack[stack.back()] = false;
+        components.back().emplace_back(stack.back());
+        stack.pop_back();
+      }
+    }
+    onStack[inputId] = false;
+    assert(stack.back() == inputId);
+    if (inSCC) {
+      components.back().emplace_back(inputId);
+    }
+    stack.pop_back();
+  }
+}
+
+static std::vector<std::vector<VarNodeId>> SCC(const InvariantGraph& graph) {
+  std::vector<Int> discoverTime(graph.nextVarNodeId(), -1);
+  std::vector<Int> lowTime(graph.nextVarNodeId(), -1);
+  std::vector<VarNodeId> stack;
+  stack.reserve(graph.nextVarNodeId());
+  std::vector<bool> onStack(graph.nextVarNodeId(), false);
+  std::vector<std::vector<VarNodeId>> components;
+  components.reserve(graph.nextVarNodeId());
+  Int time = 0;
+  for (const std::shared_ptr<ImplicitConstraintNode>& invNode :
+       graph.implicitConstraintNodes()) {
+    for (const VarNodeId searchVar : invNode->outputVarNodeIds()) {
+      if (discoverTime[searchVar] < 0) {
+        SCCUtil(graph, searchVar, discoverTime, lowTime, stack, onStack, time,
+                components);
+      }
+    }
+  }
+  for (VarNodeId varId = 0; varId < graph.nextVarNodeId(); ++varId) {
+    if (graph.varNodeConst(varId).definingNodes().empty() && discoverTime[varId] < 0) {
+      SCCUtil(graph, varId, discoverTime, lowTime, stack, onStack, time,
+                components);
+    }
+  }
+  assert(std::ranges::none_of(onStack, [&](const bool b) { return b; }));
+  assert(
+      std::ranges::all_of(discoverTime, [&](const Int t) { return t >= 0; }));
+  return components;
+}
+
+static std::vector<VarNodeId> findStaticCycle(
+    const InvariantGraph& graph, const std::vector<VarNodeId>& component,
+    const size_t componentIndex, const std::vector<size_t>& componentOfVar) {
+  std::vector<VarNodeId> stack;
+  std::vector<Int> discoverTime(componentOfVar.size(), -1);
+  std::vector<VarNodeId> parent(componentOfVar.size(), NULL_NODE_ID);
+  stack.reserve(component.size());
+  Int time = 0;
+  for (const VarNodeId orig : component) {
+    if (discoverTime[orig] >= 0) {
+      continue;
+    }
+    discoverTime[orig] = time;
+    ++time;
+    stack.emplace_back(orig);
+
+    while (!stack.empty()) {
+      const VarNodeId outputId = stack.back();
+      stack.pop_back();
+      discoverTime[outputId] = discoverTime[orig];
+      assert(graph.varNodeConst(outputId).definingNodes().size() <= 1);
+      if (graph.varNodeConst(outputId).definingNodes().empty()) {
+        continue;
+      }
+      const auto defInv = *graph.varNodeConst(outputId).definingNodes().begin();
+      assert(defInv != NULL_NODE_ID);
+      const auto& invNode = graph.invariantNodeConst(defInv);
+      for (const VarNodeId inputId : invNode.staticInputVarNodeIds()) {
+        if (componentOfVar[inputId] != componentIndex) {
+          continue;
+        }
+        parent[inputId] = outputId;
+        if (discoverTime[inputId] == discoverTime[orig]) {
+          std::vector<VarNodeId> cycle;
+          cycle.reserve(component.size());
+          cycle.emplace_back(inputId);
+          for (VarNodeId vId = outputId; vId != inputId; vId = parent[vId]) {
+            assert(vId != NULL_NODE_ID);
+            cycle.emplace_back(vId);
+          }
+          return cycle;
+        }
+        if (discoverTime[inputId] < 0) {
+          stack.emplace_back(inputId);
+        }
+      }
+    }
+  }
+  return {};
+}
+
+static std::vector<VarNodeId> findDynamicCycle(
+    const InvariantGraph& graph, const std::vector<VarNodeId>& component,
+    const size_t componentIndex, const std::vector<size_t>& componentOfVar) {
+  std::vector<VarNodeId> stack;
+  std::vector<Int> discoverTime(componentOfVar.size(), -1);
+  std::vector<VarNodeId> parent(componentOfVar.size(), NULL_NODE_ID);
+  stack.reserve(component.size());
+  Int time = 0;
+  for (const VarNodeId orig : component) {
+    if (discoverTime[orig] < 0) {
+      continue;
+    }
+    discoverTime[orig] = time;
+    ++time;
+    stack.emplace_back(orig);
+
+    while (!stack.empty()) {
+      const VarNodeId outputId = stack.back();
+      stack.pop_back();
+      discoverTime[outputId] = discoverTime[orig];
+      assert(graph.varNodeConst(outputId).definingNodes().size() <= 1);
+      if (graph.varNodeConst(outputId).definingNodes().empty()) {
+        continue;
+      }
+      const auto defInv = *graph.varNodeConst(outputId).definingNodes().begin();
+      assert(defInv != NULL_NODE_ID);
+      const auto& invNode = graph.invariantNodeConst(defInv);
+      for (size_t i = 0; i < 2; ++i) {
+        for (const VarNodeId inputId : i == 0
+                                           ? invNode.staticInputVarNodeIds()
+                                           : invNode.dynamicInputVarNodeIds()) {
+          if (componentOfVar[inputId] != componentIndex) {
+            continue;
+          }
+          parent[inputId] = outputId;
+          if (discoverTime[inputId] == discoverTime[orig]) {
+            std::vector<VarNodeId> cycle;
+            cycle.reserve(component.size());
+            cycle.emplace_back(inputId);
+            for (VarNodeId vId = outputId; vId != inputId; vId = parent[vId]) {
+              assert(vId != NULL_NODE_ID);
+              cycle.emplace_back(vId);
+            }
+            return cycle;
+          }
+          if (discoverTime[inputId] < 0) {
+            stack.emplace_back(inputId);
+          }
+        }
+      }
+    }
+  }
+  return {};
+}
+
+static std::pair<VarNodeId, InvariantNodeId> findPivotInCycle(
+    const InvariantGraph& graph, const std::vector<VarNodeId>& cycle) {
+  assert(cycle.size() > 1);
+  size_t index = 0;
+  size_t domSize = graph.varNodeConst(cycle.front()).constDomain()->size();
+  for (size_t i = 1; i < cycle.size(); ++i) {
+    const size_t ds = graph.varNodeConst(cycle[i]).constDomain()->size();
+    if (ds < domSize) {
+      domSize = ds;
+      index = i;
+    }
+  }
+  assert(index < cycle.size());
+  assert(domSize > 1);
+
+  const VarNodeId pivot = cycle[index];
+
+  assert(!graph.varNodeConst(pivot).isFixed());
+
+  assert(std::ranges::all_of(cycle, [&](const VarNodeId vId) {
+    return graph.varNodeConst(vId).definingNodes().size() == 1;
+  }));
+
+  const size_t outputIndex = (index + 1) % cycle.size();
+  const auto& outputNode = graph.varNodeConst(cycle[outputIndex]);
+
+  assert(outputNode.definingNodes().size() == 1);
+  const InvariantNodeId invId = *outputNode.definingNodes().begin();
+
+  assert(std::ranges::any_of(
+      graph.invariantNodeConst(invId).outputVarNodeIds(),
+      [&](const VarNodeId vId) { return vId == outputNode.varNodeId(); }));
+
+  assert(std::ranges::any_of(
+             graph.invariantNodeConst(invId).staticInputVarNodeIds(),
+             [&](const VarNodeId vId) { return vId == pivot; }) ||
+         std::ranges::any_of(
+             graph.invariantNodeConst(invId).dynamicInputVarNodeIds(),
+             [&](const VarNodeId vId) { return vId == pivot; }));
+
+  assert(pivot != NULL_NODE_ID);
+
+  // Dont create a VarNode& reference to pivot, since the _varNodes vector is
+  // modified, this reference could be invalidated!
+  assert(!graph.varNodeConst(pivot).isFixed());
+
+  return {pivot, invId};
+}
+
 InvariantGraphRoot& InvariantGraph::root() const {
   return dynamic_cast<InvariantGraphRoot&>(*_implicitConstraintNodes.front());
 }
@@ -217,11 +452,15 @@ void InvariantGraph::replaceInvariantNodes() {
         invNode.deactivate();
       } else {
         if (invNode.canBeReplaced()) {
-          if (invNode.replace()) {
+          const bool wasReplaced =invNode.replace();
+          assert(wasReplaced);
+          if (wasReplaced) {
             invNode.deactivate();
           }
         } else if (invNode.canBeMadeImplicit()) {
-          if (invNode.makeImplicit()) {
+          const bool isImplicit = invNode.makeImplicit();
+          assert(isImplicit);
+          if (isImplicit) {
             invNode.deactivate();
           }
         }
@@ -280,6 +519,22 @@ const VarNode& InvariantGraph::varNodeConst(
 const VarNode& InvariantGraph::varNodeConst(VarNodeId id) const {
   assert(size_t(id) < _varNodes.size());
   return _varNodes.at(size_t(id));
+}
+
+const InvariantNode& InvariantGraph::invariantNodeConst(
+    InvariantNodeId id) const {
+  if (id.isInvariant()) {
+    assert(size_t(id) < _invariantNodes.size());
+    return *_invariantNodes.at(size_t(id));
+  }
+  assert(size_t(id) < _implicitConstraintNodes.size());
+  return static_cast<const InvariantNode&>(
+      *_implicitConstraintNodes.at(size_t(id)));
+}
+
+const std::vector<std::shared_ptr<ImplicitConstraintNode>>&
+InvariantGraph::implicitConstraintNodes() const {
+  return _implicitConstraintNodes;
 }
 
 VarNodeId InvariantGraph::varNodeId(const std::string& identifier) const {
@@ -564,241 +819,6 @@ void InvariantGraph::splitMultiDefinedVars() {
   assert(_varNodes.size() == newSize);
 }
 
-InvariantGraphEdge InvariantGraph::findPivotInCycle(
-    const std::vector<InvariantGraphEdge>& cycle) {
-  // Each edge (i, v) is from invariant i to variable v that i defines
-  // For each subsequent edges (i1, v1), (i2, v2) in the cycle (wrapped around)
-  // v1 is a static input to i2
-  assert(cycle.size() > 1);
-#ifndef NDEBUG
-  for (size_t i = 0; i < cycle.size(); ++i) {
-    const size_t inputIndex = (i + cycle.size() - 1) % cycle.size();
-    const VarNode& input = varNode(cycle.at(inputIndex).varNodeId);
-    InvariantNode& invNode = invariantNode(cycle.at(i).invariantNodeId);
-    const VarNode& output = varNode(cycle.at(i).varNodeId);
-
-    assert(std::ranges::any_of(
-               invNode.staticInputVarNodeIds().begin(),
-               invNode.staticInputVarNodeIds().end(),
-               [&](const VarNodeId vId) { return vId == input.varNodeId(); }) ||
-           std::ranges::any_of(
-               invNode.dynamicInputVarNodeIds().begin(),
-               invNode.dynamicInputVarNodeIds().end(),
-               [&](const VarNodeId vId) { return vId == input.varNodeId(); }));
-
-    assert(std::ranges::any_of(input.staticInputTo().begin(),
-                               input.staticInputTo().end(),
-                               [&](const InvariantNodeId& invId) {
-                                 return invId == invNode.id();
-                               }) ||
-           std::ranges::any_of(input.dynamicInputTo().begin(),
-                               input.dynamicInputTo().end(),
-                               [&](const InvariantNodeId& invId) {
-                                 return invId == invNode.id();
-                               }));
-
-    assert(std::ranges::any_of(
-        output.definingNodes().begin(), output.definingNodes().end(),
-        [&](const InvariantNodeId& invId) { return invId == invNode.id(); }));
-
-    assert(std::ranges::any_of(
-        invNode.outputVarNodeIds().begin(), invNode.outputVarNodeIds().end(),
-        [&](const VarNodeId vId) { return vId == output.varNodeId(); }));
-  }
-#endif
-  VarNodeId pivot = cycle[0].varNodeId;
-  InvariantNodeId listeningInvNodeId = cycle[1].invariantNodeId;
-
-  assert(std::ranges::any_of(
-             invariantNode(listeningInvNodeId).staticInputVarNodeIds().begin(),
-             invariantNode(listeningInvNodeId).staticInputVarNodeIds().end(),
-             [&](VarNodeId input) { return input == pivot; }) ||
-         std::ranges::any_of(
-             invariantNode(listeningInvNodeId).dynamicInputVarNodeIds().begin(),
-             invariantNode(listeningInvNodeId).dynamicInputVarNodeIds().end(),
-             [&](VarNodeId input) { return input == pivot; }));
-
-  assert(std::ranges::any_of(
-             varNodeConst(pivot).staticInputTo().begin(),
-             varNodeConst(pivot).staticInputTo().end(),
-             [&](InvariantNodeId inv) { return inv == listeningInvNodeId; }) ||
-         std::ranges::any_of(
-             varNodeConst(pivot).dynamicInputTo().begin(),
-             varNodeConst(pivot).dynamicInputTo().end(),
-             [&](InvariantNodeId inv) { return inv == listeningInvNodeId; }));
-
-  size_t minDomainSize = varNodeConst(pivot).isIntVar()
-                             ? varNodeConst(pivot).constDomain()->size()
-                             : 2;
-
-  for (size_t i = 1; i < cycle.size() && minDomainSize > 2; ++i) {
-    const VarNode& vNode = varNodeConst(cycle[i].varNodeId);
-    if (!vNode.isIntVar() || vNode.constDomain()->size() < minDomainSize) {
-      minDomainSize = !vNode.isIntVar() ? 2 : vNode.constDomain()->size();
-      pivot = vNode.varNodeId();
-      const size_t listeningInvIndex = i + 1 % cycle.size();
-      listeningInvNodeId = cycle[listeningInvIndex].invariantNodeId;
-      assert(
-          std::ranges::any_of(
-              invariantNode(listeningInvNodeId).staticInputVarNodeIds().begin(),
-              invariantNode(listeningInvNodeId).staticInputVarNodeIds().end(),
-              [&](const VarNodeId input) { return input == pivot; }) ||
-          std::ranges::any_of(
-              invariantNode(listeningInvNodeId)
-                  .dynamicInputVarNodeIds()
-                  .begin(),
-              invariantNode(listeningInvNodeId).dynamicInputVarNodeIds().end(),
-              [&](const VarNodeId input) { return input == pivot; }));
-    }
-  }
-  assert(pivot != NULL_NODE_ID);
-  assert(minDomainSize > 0);
-  return InvariantGraphEdge{listeningInvNodeId, pivot};
-}
-
-VarNodeId InvariantGraph::breakCycle(
-    const std::vector<InvariantGraphEdge>& cycle) {
-  // Each edge (v, i) is from a variable v to an invariant that v is a static
-  // input variable to
-  const auto [listeningInvariant, pivot] = findPivotInCycle(cycle);
-
-  assert(pivot != NULL_NODE_ID);
-  assert(listeningInvariant != NULL_NODE_ID);
-
-  // Dont create a VarNode& reference to pivot, since the _varNodes vector is
-  // modified, this reference could be invalidated!
-  assert(!varNodeConst(pivot).isFixed());
-
-  const VarNode& newInputNode = _varNodes.emplace_back(
-      nextVarNodeId(), varNodeConst(pivot).isIntVar(),
-      std::make_shared<SearchDomain>(varNodeConst(pivot).lowerBound(),
-                                     varNodeConst(pivot).upperBound()),
-      DomainType::DOM_NONE);
-
-  invariantNode(listeningInvariant)
-      .replaceStaticInputVarNode(pivot, newInputNode.varNodeId());
-  if (varNodeConst(pivot).isIntVar()) {
-    addInvariantNode(std::make_shared<IntAllEqualNode>(
-        *this, pivot, newInputNode.varNodeId(), true, true));
-  } else {
-    addInvariantNode(std::make_shared<BoolAllEqualNode>(
-        *this, pivot, newInputNode.varNodeId(), true, true));
-  }
-  root().addSearchVarNode(newInputNode.varNodeId());
-  return newInputNode.varNodeId();
-}
-
-std::unordered_set<VarNodeId> InvariantGraph::dynamicVarNodeFrontier(
-    const VarNodeId node, const std::unordered_set<VarNodeId>& visitedGlobal) {
-  std::unordered_set<VarNodeId> visitedLocal;
-  std::unordered_set<VarNodeId> visitedDynamic;
-  std::queue<VarNodeId> q;
-  q.push(node);
-  visitedLocal.emplace(node);
-  while (!q.empty()) {
-    const auto cur = q.front();
-    q.pop();
-    // Add unvisited dynamic neighbors to set of visited dynamic variable
-    // nodes:
-    for (const auto& dynamicInvNodeId : varNode(cur).dynamicInputTo()) {
-      for (const auto& outputVarId :
-           invariantNode(dynamicInvNodeId).outputVarNodeIds()) {
-        if (!visitedGlobal.contains(outputVarId) &&
-            !visitedDynamic.contains(outputVarId)) {
-          visitedDynamic.emplace(outputVarId);
-        }
-      }
-    }
-    // add unvisited static neighbors to queue:
-    for (const auto& staticInvNodeId : varNode(cur).staticInputTo()) {
-      for (const auto& outputVarId :
-           invariantNode(staticInvNodeId).outputVarNodeIds()) {
-        if (!visitedLocal.contains(outputVarId)) {
-          visitedLocal.emplace(outputVarId);
-          q.push(outputVarId);
-        }
-      }
-    }
-  }
-  return visitedDynamic;
-}
-
-VarNodeId InvariantGraph::findCycleUtil(
-    const VarNodeId varNodeId,
-    const std::unordered_set<VarNodeId>& visitedGlobal,
-    std::unordered_set<VarNodeId>& visitedLocal,
-    std::unordered_map<VarNodeId, InvariantGraphEdge>& path) {
-  assert(!path.contains(varNodeId));
-  // The path here is a map (x, (i, y)), where the variable x is a static input
-  // to invariant i and y is an output variable of i.
-  // Note therefore that each InvariantGraphEdge is from an invariant i to a
-  // variable y that i defines.
-  if (visitedGlobal.contains(varNodeId)) {
-    assert(!path.contains(varNodeId));
-    return VarNodeId{NULL_NODE_ID};
-  }
-
-  if (visitedLocal.contains(varNodeId)) {
-    // this variable is part of a cycle, return the root node of the cycle:
-    assert(path.contains(varNodeId));
-    return path.at(varNodeId).varNodeId;
-  }
-
-  visitedLocal.emplace(varNodeId);
-  // iterate over all invariants that the variable is a static input to:
-  // TODO: we now also break dynamic cycles. this should be fixed by having a
-  // better implicit constraint/neighborhood initialisation process when
-  // closing the propagation _solver.
-  for (size_t i = 0; i < (_breakDynamicCycles ? 2 : 1); ++i) {
-    for (const InvariantNodeId& listeningInvNodeId :
-         i == 0 ? varNode(varNodeId).staticInputTo()
-                : varNode(varNodeId).dynamicInputTo()) {
-      // iterate over all variables that the invariant defines:
-      for (const VarNodeId definedVarId :
-           invariantNode(listeningInvNodeId).outputVarNodeIds()) {
-        if (path.contains(definedVarId)) {
-          assert(visitedLocal.contains(definedVarId));
-          // this is the first variable that is in the cycle
-          // add the last edge to the path (each edge is from a defining
-          // invariant i to a variable i defines):
-          auto iter = path.find(varNodeId);
-          if (iter == path.end()) {
-            path.emplace(varNodeId,
-                         InvariantGraphEdge{listeningInvNodeId, definedVarId});
-          } else {
-            iter->second.invariantNodeId = listeningInvNodeId;
-            iter->second.varNodeId = definedVarId;
-          }
-          // return the root node of the cycle:
-          return definedVarId;
-        }
-        if (!visitedGlobal.contains(definedVarId) &&
-            !visitedLocal.contains(definedVarId)) {
-          // we have not visited this variable yet, add it to the path:
-          // each edge is from a defining invariant i to a variable i defines:
-          auto iter = path.find(varNodeId);
-          if (iter == path.end()) {
-            path.emplace(varNodeId,
-                         InvariantGraphEdge{listeningInvNodeId, definedVarId});
-          } else {
-            iter->second.invariantNodeId = listeningInvNodeId;
-            iter->second.varNodeId = definedVarId;
-          }
-          const VarNodeId cycleRoot =
-              findCycleUtil(definedVarId, visitedGlobal, visitedLocal, path);
-          if (cycleRoot != NULL_NODE_ID) {
-            return cycleRoot;
-          }
-        }
-      }
-    }
-  }
-  // this variable is not part of a cycle, remove it from the path and return
-  // null:
-  path.erase(varNodeId);
-  return VarNodeId{NULL_NODE_ID};
-}
-
 void InvariantGraph::breakSelfCycles() {
   for (const auto& invNode : _invariantNodes) {
     std::unordered_set<VarNodeId> visitedOutputs;
@@ -848,152 +868,83 @@ void InvariantGraph::breakSelfCycles() {
   }
 }
 
-std::vector<VarNodeId> InvariantGraph::breakCycles(
-    VarNodeId node, std::unordered_set<VarNodeId>& visitedGlobal) {
-  std::unordered_map<VarNodeId, InvariantGraphEdge> path;
-  // The path here is a map (x, (i, y)), where the variable x is a static input
-  // to invariant i and y is an output variable of i.
-  // Note therefore that each InvariantGraphEdge is from an invariant i to a
-  // variable y that i defines.
-  std::unordered_set<VarNodeId> visitedLocal;
-  VarNodeId cycleRoot;
-  std::vector<VarNodeId> newSearchNodes;
-  do {
-    path.clear();
-    visitedLocal.clear();
-    cycleRoot = findCycleUtil(node, visitedGlobal, visitedLocal, path);
-    assert(std::ranges::all_of(path.begin(), path.end(), [&](const auto& pair) {
-      const VarNode& inputVar = varNodeConst(pair.first);
-      const InvariantNode& inv = invariantNode(pair.second.invariantNodeId);
-      const VarNode& outputVar = varNodeConst(pair.second.varNodeId);
-
-      const bool isStaticInput = std::ranges::any_of(
-          inputVar.staticInputTo().begin(), inputVar.staticInputTo().end(),
-          [&](const InvariantNodeId& invNodeId) {
-            return invNodeId == inv.id();
-          });
-      const bool isDynamicInput =
-          _breakDynamicCycles &&
-          std::ranges::any_of(inputVar.dynamicInputTo().begin(),
-                              inputVar.dynamicInputTo().end(),
-                              [&](const InvariantNodeId& invNodeId) {
-                                return invNodeId == inv.id();
-                              });
-      const bool isOutput = std::ranges::any_of(
-          outputVar.definingNodes().begin(), outputVar.definingNodes().end(),
-          [&](const InvariantNodeId& invNodeId) {
-            return invNodeId == inv.id();
-          });
-      const bool hasStaticInput = std::ranges::any_of(
-          inv.staticInputVarNodeIds().begin(),
-          inv.staticInputVarNodeIds().end(), [&](const VarNodeId varNodeId) {
-            return varNodeId == inputVar.varNodeId();
-          });
-      const bool hasDynamicInput =
-          _breakDynamicCycles &&
-          std::ranges::any_of(inv.dynamicInputVarNodeIds().begin(),
-                              inv.dynamicInputVarNodeIds().end(),
-                              [&](const VarNodeId varNodeId) {
-                                return varNodeId == inputVar.varNodeId();
-                              });
-      const bool hasOutput = std::ranges::any_of(
-          inv.outputVarNodeIds().begin(), inv.outputVarNodeIds().end(),
-          [&](const VarNodeId varNodeId) {
-            return varNodeId == outputVar.varNodeId();
-          });
-      assert(isStaticInput || isDynamicInput);
-      assert(isOutput);
-      assert(hasStaticInput || hasDynamicInput);
-      assert(hasOutput);
-
-      assert(isStaticInput == hasStaticInput);
-      assert(isDynamicInput == hasDynamicInput);
-
-      return (isStaticInput || isDynamicInput) && isOutput &&
-             (hasStaticInput || hasDynamicInput) && hasOutput;
-    }));
-
-    if (cycleRoot != NULL_NODE_ID) {
-      // Each edge (i, v) in cycle is from a defining invariant i to the
-      // variable v that i defines:
-      std::vector<InvariantGraphEdge> cycle;
-      VarNodeId cur = cycleRoot;
-      while (cycle.empty() || cur != cycleRoot) {
-        assert(path.contains(cur));
-        cycle.emplace_back(path.at(cur));
-        cur = path.at(cur).varNodeId;
-      }
-      assert(path.contains(cur));
-      newSearchNodes.emplace_back(breakCycle(cycle));
-      assert(newSearchNodes.back() != NULL_NODE_ID);
-    }
-  } while (cycleRoot != NULL_NODE_ID);
-
-  // add the visited nodes to the global set of visited nodes
-  for (const auto& visitedNodeId : visitedLocal) {
-    assert(!visitedGlobal.contains(visitedNodeId));
-    visitedGlobal.emplace(visitedNodeId);
+void InvariantGraph::breakCycles() {
+  std::vector<std::vector<VarNodeId>> components = SCC(*this);
+  if (components.empty()) {
+    return;
   }
-  return newSearchNodes;
+
+  std::vector<size_t> componentOfVar(_varNodes.size(), components.size());
+  for (size_t c = 0; c < components.size(); ++c) {
+    for (const VarNodeId vId : components[c]) {
+      componentOfVar[size_t(vId)] = c;
+    }
+  }
+
+  for (size_t c = 0; c < components.size(); ++c) {
+    for (size_t i = 0; i < (_breakDynamicCycles ? 2 : 1); ++i) {
+      while (true) {
+        std::vector<VarNodeId> cycle =
+            i == 0 ? findStaticCycle(*this, components[c], c, componentOfVar)
+                   : findDynamicCycle(*this, components[c], c, componentOfVar);
+        if (cycle.empty()) {
+          break;
+        }
+        const auto [pivotId, invId] = findPivotInCycle(*this, cycle);
+        assert(pivotId != NULL_NODE_ID);
+        auto& invNode = invariantNode(invId);
+        const VarNodeId newDefinedVar =
+            _varNodes
+                .emplace_back(nextVarNodeId(), varNodeConst(pivotId).isIntVar(),
+                              std::make_shared<SearchDomain>(
+                                  varNodeConst(pivotId).lowerBound(),
+                                  varNodeConst(pivotId).upperBound()),
+                              DomainType::DOM_NONE)
+                .varNodeId();
+        invNode.replaceStaticInputVarNode(pivotId, newDefinedVar);
+        invNode.replaceDynamicInputVarNode(pivotId, newDefinedVar);
+        if (varNodeConst(pivotId).isIntVar()) {
+          addInvariantNode(std::make_shared<IntAllEqualNode>(
+              *this, pivotId, newDefinedVar, true, true));
+        } else {
+          addInvariantNode(std::make_shared<BoolAllEqualNode>(
+              *this, pivotId, newDefinedVar, true, true));
+        }
+        assert(varNodeConst(newDefinedVar).definingNodes().empty());
+        root().addSearchVarNode(newDefinedVar);
+      }
+    }
+  }
 }
 
-void InvariantGraph::breakCycles() {
-  std::unordered_set<VarNodeId> visitedGlobal;
-  std::queue<VarNodeId> searchNodeIds;
-
-  for (auto const& implicitConstraint : _implicitConstraintNodes) {
-    for (const auto& searchVarId : implicitConstraint->outputVarNodeIds()) {
-      searchNodeIds.emplace(searchVarId);
-    }
+void createVarsUtil(InvariantGraph& graph, InvariantNodeId invNodeId, std::unordered_set<InvariantNodeId, InvariantNodeIdHash>& visitedInvNodes, std::unordered_set<InvariantNodeId, InvariantNodeIdHash>& onStack) {
+  if (visitedInvNodes.contains(invNodeId)) {
+    return;
   }
-
-  for (const VarNode& vNode : _varNodes) {
-    if (vNode.definingNodes().empty() &&
-        (!vNode.staticInputTo().empty() || !vNode.dynamicInputTo().empty())) {
-      assert(vNode.isFixed());
-      assert((vNode.isIntVar() &&
-              varNodeId(vNode.lowerBound()) == vNode.varNodeId()) ||
-             (!vNode.isIntVar() &&
-              varNodeId(vNode.inDomain(bool{true})) == vNode.varNodeId()));
-      searchNodeIds.emplace(vNode.varNodeId());
-    }
+  visitedInvNodes.emplace(invNodeId);
+  InvariantNode& invNode = graph.invariantNode(invNodeId);
+  if (invNode.state() != InvariantNodeState::ACTIVE) {
+    return;
   }
-
-  while (!searchNodeIds.empty()) {
-    std::vector<VarNodeId> visitedSearchNodes;
-    while (!searchNodeIds.empty()) {
-      VarNodeId searchNodeId = searchNodeIds.front();
-      searchNodeIds.pop();
-      visitedSearchNodes.emplace_back(searchNodeId);
-      for (auto newSearchNodeId : breakCycles(searchNodeId, visitedGlobal)) {
-        searchNodeIds.emplace(newSearchNodeId);
-        assert(varNode(newSearchNodeId).outputOf() == root().id());
-      }
-    }
-    // If some part of the invariant graph is unreachable if not traversing
-    // dynamic inputs of dynamic invariants, then add those dynamic inputs to
-    // the set of search nodes:
-    std::unordered_set<VarNodeId> dynamicSearchNodeIds;
-    for (const auto searchNodeId : visitedSearchNodes) {
-      for (auto dynamicVarNodeId :
-           dynamicVarNodeFrontier(searchNodeId, visitedGlobal)) {
-        assert(!visitedGlobal.contains(dynamicVarNodeId));
-        if (!dynamicSearchNodeIds.contains(dynamicVarNodeId)) {
-          searchNodeIds.emplace(dynamicVarNodeId);
-          dynamicSearchNodeIds.emplace(dynamicVarNodeId);
-        }
+  onStack.emplace(invNodeId);
+  for (const VarNodeId inputId : invNode.staticInputVarNodeIds() ) {
+    for (const InvariantNodeId defInv : graph.varNodeConst(inputId).definingNodes()) {
+      assert(!onStack.contains(defInv));
+      if (!visitedInvNodes.contains(defInv)) {
+        createVarsUtil(graph, defInv, visitedInvNodes, onStack);
       }
     }
   }
+  assert(std::ranges::none_of(invNode.staticInputVarNodeIds(), [&](const VarNodeId inputId) { return inputId == propagation::NULL_ID; }));
+  invNode.registerOutputVars();
+  onStack.erase(invNodeId);
 }
 
 void InvariantGraph::createVars() {
-  std::unordered_set<InvariantNodeId, InvariantNodeIdHash> visitedInvNodes;
-  std::queue<InvariantNodeId> unregisteredInvNodes;
-
   // create a _solver var for each fixed boolean:
   for (const auto& varNodeId : _boolVarNodeIndices) {
     VarNode& vNode = varNode(varNodeId);
+    assert(vNode.definingNodes().empty());
     if (vNode.staticInputTo().empty() && vNode.dynamicInputTo().empty()) {
       continue;
     }
@@ -1002,20 +953,12 @@ void InvariantGraph::createVars() {
       const Int constant = *vNode.constantValue();
       vNode.setVarId(_solver.makeIntVar(constant, constant, constant));
     }
-    for (int i = 0; i < 2; ++i) {
-      for (const auto& listeningInvNode :
-           i == 0 ? vNode.staticInputTo() : vNode.dynamicInputTo()) {
-        if (!visitedInvNodes.contains(listeningInvNode)) {
-          visitedInvNodes.emplace(listeningInvNode);
-          unregisteredInvNodes.emplace(listeningInvNode);
-        }
-      }
-    }
   }
 
   // create a _solver var for each fixed integer var
   for (const auto& [constant, varNodeId] : _intVarNodeIndices) {
     VarNode& vNode = varNode(varNodeId);
+    assert(vNode.definingNodes().empty());
     if (vNode.staticInputTo().empty() && vNode.dynamicInputTo().empty()) {
       continue;
     }
@@ -1023,15 +966,6 @@ void InvariantGraph::createVars() {
       assert(vNode.constantValue().has_value() &&
              vNode.constantValue().value() == constant);
       vNode.setVarId(_solver.makeIntVar(constant, constant, constant));
-    }
-    for (int i = 0; i < 2; ++i) {
-      for (const auto& listeningInvNode :
-           i == 0 ? vNode.staticInputTo() : vNode.dynamicInputTo()) {
-        if (!visitedInvNodes.contains(listeningInvNode)) {
-          visitedInvNodes.emplace(listeningInvNode);
-          unregisteredInvNodes.emplace(listeningInvNode);
-        }
-      }
     }
   }
 
@@ -1046,73 +980,22 @@ void InvariantGraph::createVars() {
       vNode.setVarId(_solver.makeIntVar(vNode.lowerBound(), vNode.upperBound(),
                                         vNode.lowerBound()));
     }
-    for (int i = 0; i < 2; ++i) {
-      for (const auto& listeningInvNode :
-           i == 0 ? vNode.staticInputTo() : vNode.dynamicInputTo()) {
-        if (!visitedInvNodes.contains(listeningInvNode)) {
-          visitedInvNodes.emplace(listeningInvNode);
-          unregisteredInvNodes.emplace(listeningInvNode);
-        }
-      }
+  }
+
+  std::unordered_set<InvariantNodeId, InvariantNodeIdHash> visitedInvNodes;
+  std::unordered_set<InvariantNodeId, InvariantNodeIdHash> onStack;
+  visitedInvNodes.reserve(_invariantNodes.size() + _implicitConstraintNodes.size());
+  onStack.reserve(_invariantNodes.size() + _implicitConstraintNodes.size());
+
+  for (const auto& implNode : _implicitConstraintNodes) {
+    if (implNode->state() == InvariantNodeState::ACTIVE) {
+      createVarsUtil(*this, implNode->id(), visitedInvNodes, onStack);
     }
   }
 
-  // enqueue each implicit constraint:
-  for (auto const& implicitConstraint : _implicitConstraintNodes) {
-    if (implicitConstraint->state() == InvariantNodeState::ACTIVE) {
-      visitedInvNodes.emplace(implicitConstraint->id());
-      unregisteredInvNodes.emplace(implicitConstraint->id());
-    }
-  }
-
-  while (!unregisteredInvNodes.empty()) {
-    const auto invNodeId = unregisteredInvNodes.front();
-    unregisteredInvNodes.pop();
-    assert(visitedInvNodes.contains(invNodeId));
-    auto& invNode = invariantNode(invNodeId);
-    // If the invNodeId only defines a single variable, then it is a view:
-    assert(!invNode.dynamicInputVarNodeIds().empty() ||
-           invNode.staticInputVarNodeIds().size() != 1 ||
-           varId(invNode.staticInputVarNodeIds().front()) !=
-               propagation::NULL_ID);
-
-    // The output variables have not been created in the _solver yet:
-    assert(std::ranges::all_of(
-        invNode.outputVarNodeIds().begin(), invNode.outputVarNodeIds().end(),
-        [&](VarNodeId outputVarNodeId) {
-          return varId(outputVarNodeId) == propagation::NULL_ID;
-        }));
-    if (invNode.state() != InvariantNodeState::ACTIVE) {
-      continue;
-    }
-
-    invNode.registerOutputVars();
-    for (const auto& outputVarNodeId : invNode.outputVarNodeIds()) {
-      assert(outputVarNodeId != NULL_NODE_ID);
-      const auto& vn = varNode(outputVarNodeId);
-      assert(std::ranges::any_of(
-          vn.definingNodes().begin(), vn.definingNodes().end(),
-          [&](InvariantNodeId defNodeId) { return defNodeId == invNodeId; }));
-
-      assert(vn.varId() != propagation::NULL_ID);
-      for (int i = 0; i < 2; ++i) {
-        for (const auto& nextVarDefNode :
-             i == 0 ? vn.staticInputTo() : vn.dynamicInputTo()) {
-          if (!visitedInvNodes.contains(nextVarDefNode)) {
-            visitedInvNodes.emplace(nextVarDefNode);
-            unregisteredInvNodes.emplace(nextVarDefNode);
-          }
-        }
-      }
-    }
-  }
-
-  // Each invariant that is not reachable from a search variable is deactivated:
   for (const auto& invNode : _invariantNodes) {
-    if (invNode->state() == InvariantNodeState::ACTIVE &&
-        !visitedInvNodes.contains(invNode->id())) {
-      invNode->deactivate();
-      assert(invNode->state() == InvariantNodeState::SUBSUMED);
+    if (invNode->state() == InvariantNodeState::ACTIVE) {
+      createVarsUtil(*this, invNode->id(), visitedInvNodes, onStack);
     }
   }
 }

--- a/src/invariantgraph/invariantNode.cpp
+++ b/src/invariantgraph/invariantNode.cpp
@@ -164,25 +164,39 @@ void InvariantNode::removeOutputVarNode(VarNodeId outputVarNodeId) {
 void InvariantNode::replaceStaticInputVarNode(VarNodeId oldInputVarNodeId,
                                               VarNodeId newInputVarNodeId) {
   // Replace all occurrences:
+  bool wasInput = false;
   for (auto& sVarId : _staticInputVarNodeIds) {
     if (sVarId == oldInputVarNodeId) {
       sVarId = newInputVarNodeId;
+      wasInput = true;
     }
   }
-  _invariantGraph.varNode(oldInputVarNodeId).unmarkAsInputFor(_id, true);
-  _invariantGraph.varNode(newInputVarNodeId).markAsInputFor(_id, true);
+  assert(wasInput == std::ranges::any_of(_invariantGraph.varNode(oldInputVarNodeId).staticInputTo(), [&](InvariantNodeId invId) {
+    return invId == _id;
+  }));
+  if (wasInput) {
+    _invariantGraph.varNode(oldInputVarNodeId).unmarkAsInputFor(_id, true);
+    _invariantGraph.varNode(newInputVarNodeId).markAsInputFor(_id, true);
+  }
 }
 
 void InvariantNode::replaceDynamicInputVarNode(VarNodeId oldInputVarNodeId,
                                                VarNodeId newInputVarNodeId) {
   // Replace all occurrences:
+  bool wasInput = false;
   for (auto& dVarId : _dynamicInputVarNodeIds) {
     if (dVarId == oldInputVarNodeId) {
       dVarId = newInputVarNodeId;
+      wasInput = true;
     }
   }
-  _invariantGraph.varNode(oldInputVarNodeId).unmarkAsInputFor(_id, false);
-  _invariantGraph.varNode(newInputVarNodeId).markAsInputFor(_id, false);
+  assert(wasInput == std::ranges::any_of(_invariantGraph.varNode(oldInputVarNodeId).dynamicInputTo(), [&](InvariantNodeId invId) {
+    return invId == _id;
+  }));
+  if (wasInput) {
+    _invariantGraph.varNode(oldInputVarNodeId).unmarkAsInputFor(_id, false);
+    _invariantGraph.varNode(newInputVarNodeId).markAsInputFor(_id, false);
+  }
 }
 
 std::ostream& InvariantNode::dotLangEntry(std::ostream& o) const {

--- a/src/propagation/propagation/propagationGraph.cpp
+++ b/src/propagation/propagation/propagationGraph.cpp
@@ -7,6 +7,7 @@
 #include <ranges>
 
 #include "atlantis/exceptions/exceptions.hpp"
+#include "atlantis/propagation/invariants/invariant.hpp"
 #include "atlantis/propagation/store/store.hpp"
 
 namespace atlantis::propagation {
@@ -20,6 +21,378 @@ inline bool all_in_range(size_t start, size_t stop,
   return std::ranges::all_of(vec.begin(), vec.end(), std::move(predicate));
 }
 
+static void SCCUtil(const PropagationGraph& graph, VarId inputId,
+                    std::vector<Int>& discoverTime, std::vector<Int>& lowTime,
+                    std::vector<VarId>& stack, std::vector<bool>& onStack,
+                    Int& time, std::vector<std::vector<VarId>>& components) {
+  assert(inputId < discoverTime.size());
+  assert(discoverTime.size() == lowTime.size());
+  assert(discoverTime.size() == onStack.size());
+  assert(!onStack[inputId]);
+  discoverTime[inputId] = lowTime[inputId] = time;
+  ++time;
+  stack.emplace_back(inputId);
+  onStack[inputId] = true;
+
+  for (const auto& data : graph.listeningInvariantData(inputId)) {
+    for (const VarId outputId : graph.varsDefinedBy(data.invariantId)) {
+      if (discoverTime[outputId] < 0) {
+        SCCUtil(graph, outputId, discoverTime, lowTime, stack, onStack, time,
+                components);
+        lowTime[inputId] = std::min(lowTime[outputId], lowTime[inputId]);
+      } else if (onStack[outputId]) {
+        lowTime[inputId] = std::min(lowTime[outputId], discoverTime[inputId]);
+      }
+    }
+  }
+  if (lowTime[inputId] == discoverTime[inputId]) {
+    const bool inSCC = stack.back() != inputId;
+    if (inSCC) {
+      components.emplace_back();
+      while (stack.back() != inputId) {
+        onStack[stack.back()] = false;
+        components.back().emplace_back(stack.back());
+        stack.pop_back();
+      }
+    }
+    onStack[inputId] = false;
+    assert(stack.back() == inputId);
+    if (inSCC) {
+      components.back().emplace_back(inputId);
+    }
+    stack.pop_back();
+  }
+}
+
+static std::vector<std::vector<VarId>> SCC(const PropagationGraph& graph) {
+  std::vector<Int> discoverTime(graph.numVars(), -1);
+  std::vector<Int> lowTime(graph.numVars(), -1);
+  std::vector<VarId> stack;
+  stack.reserve(graph.numVars());
+  std::vector<bool> onStack(graph.numVars(), false);
+  std::vector<std::vector<VarId>> components;
+  components.reserve(graph.numVars());
+  Int time = 0;
+  for (const VarId searchVar : graph.searchVars()) {
+    if (discoverTime[searchVar] < 0) {
+      SCCUtil(graph, searchVar, discoverTime, lowTime, stack, onStack, time,
+              components);
+    }
+  }
+  assert(std::ranges::all_of(discoverTime, [&](Int i) { return i >= 0; }));
+  return components;
+}
+
+static void partitionIntoLayersUtil(
+    const PropagationGraph& graph,
+    const std::vector<std::vector<VarId>>& components, VarId varId,
+    const std::vector<size_t>& componentOfVar, std::vector<bool>& visited,
+    std::vector<VarId>& layerOfVar, std::vector<bool>& layerHasSCC) {
+  visited[varId] = true;
+  const InvariantId defInv = graph.definingInvariant(varId);
+  if (defInv == NULL_ID) {
+    // varId is a search variable, put into layer 0:
+    assert(componentOfVar[varId] >= components.size());
+    layerOfVar[varId] = 0;
+    if (layerHasSCC.empty()) {
+      layerHasSCC.emplace_back(false);
+    }
+    assert(!layerHasSCC[0]);
+    return;
+  }
+
+  if (componentOfVar[varId] >= components.size()) {
+    // varId is not in an SCC:
+    for (const VarId inputId : std::views::keys(graph.inputVars(defInv))) {
+      if (!visited[inputId]) {
+        visited[inputId] = true;
+        partitionIntoLayersUtil(graph, components, inputId, componentOfVar,
+                                visited, layerOfVar, layerHasSCC);
+      }
+      assert(layerOfVar[inputId] < layerHasSCC.size());
+      layerOfVar[varId] = std::max(
+          layerOfVar[varId],
+          layerOfVar[inputId] + (layerHasSCC[layerOfVar[inputId]] ? 1 : 0));
+    }
+    if (layerOfVar[varId] >= layerHasSCC.size()) {
+      // varId is in a new layer, create that layer:
+      assert(layerOfVar[varId] == layerHasSCC.size());
+      layerHasSCC.emplace_back(false);
+    } else {
+      // Find the layer that (i) has no SCC and (ii) has an index that equals or
+      // is greater to that of varId, creating the layer if it does not exist:
+      while (layerHasSCC[layerOfVar[varId]]) {
+        ++layerOfVar[varId];
+        if (layerOfVar[varId] == layerHasSCC.size()) {
+          layerHasSCC.emplace_back(false);
+        }
+      }
+    }
+  } else {
+    // varId is in an SCC:
+    const size_t comp = componentOfVar[varId];
+    for (const VarId cVarId : components[comp]) {
+      visited[cVarId] = true;
+      const InvariantId cDefInv = graph.definingInvariant(cVarId);
+      assert(cDefInv != NULL_ID);
+      for (const VarId inputId : std::views::keys(graph.inputVars(defInv))) {
+        if (componentOfVar[inputId] != comp) {
+          if (!visited[inputId]) {
+            visited[inputId] = true;
+            partitionIntoLayersUtil(graph, components, inputId, componentOfVar,
+                                    visited, layerOfVar, layerHasSCC);
+          }
+          assert(layerOfVar[inputId] < layerHasSCC.size());
+          // update layer of varId. The layer of the component will be updated
+          // below.
+          layerOfVar[varId] =
+              std::max(layerOfVar[varId], layerOfVar[inputId] + 1);
+        }
+      }
+    }
+    if (layerOfVar[varId] >= layerHasSCC.size()) {
+      // varId is in a new layer, create that layer:
+      assert(layerOfVar[varId] == layerHasSCC.size());
+      layerHasSCC.emplace_back(true);
+    } else {
+      // Find the layer that has (i) an SCC and (ii) an index that equals or is
+      // greater to that of varId, creating the layer if it does not exist:
+      while (!layerHasSCC[layerOfVar[varId]]) {
+        ++layerOfVar[varId];
+        if (layerOfVar[varId] == layerHasSCC.size()) {
+          layerHasSCC.emplace_back(true);
+        }
+      }
+    }
+    // update the layer of the remaining variables in the SCC:
+    for (const VarId cVarId : components[comp]) {
+      layerOfVar[cVarId] = layerOfVar[varId];
+    }
+  }
+}
+
+static std::vector<bool> partitionIntoLayersUsingSCC(
+    const PropagationGraph& graph,
+    const std::vector<std::vector<VarId>>& components,
+    std::vector<size_t>& layerOfVar) {
+  assert(layerOfVar.size() == graph.numVars());
+  assert(std::ranges::all_of(layerOfVar,
+                             [&](const size_t layer) { return layer == 0; }));
+
+  std::vector<size_t> componentOfVar(graph.numVars(), components.size());
+  for (size_t c = 0; c < components.size(); ++c) {
+    for (const VarId varId : components[c]) {
+      componentOfVar[varId] = c;
+    }
+  }
+  std::vector<bool> visited(graph.numVars(), false);
+  std::vector<bool> layerHasSCC;
+  layerHasSCC.reserve(components.size() * 2);
+
+  for (const VarId evalVarId : graph.evaluationVars()) {
+    partitionIntoLayersUtil(graph, components, evalVarId, componentOfVar,
+                            visited, layerOfVar, layerHasSCC);
+  }
+  for (Int c = static_cast<Int>(components.size()) - 1; c >= 0; --c) {
+    for (const VarId varId : components[c]) {
+      if (!visited[varId]) {
+        partitionIntoLayersUtil(graph, components, varId, componentOfVar, visited, layerOfVar, layerHasSCC);
+      }
+    }
+  }
+  return layerHasSCC;
+}
+
+static bool hasStaticCycle(const PropagationGraph& graph,
+                           const std::vector<VarId>& component,
+                           size_t componentIndex,
+                           const std::vector<size_t>& componentOfVar) {
+  std::vector<VarId> stack;
+  std::vector<Int> discoverTime(graph.numVars(), -1);
+  stack.reserve(component.size());
+  Int time = 0;
+  for (const VarId orig : component) {
+    if (discoverTime[orig] < 0) {
+      continue;
+    }
+    discoverTime[orig] = time;
+    ++time;
+    stack.emplace_back(orig);
+
+    while (!stack.empty()) {
+      const VarId outputId = stack.back();
+      stack.pop_back();
+      discoverTime[outputId] = discoverTime[orig];
+      const auto defInv = graph.definingInvariant(outputId);
+      if (defInv == NULL_ID) {
+        continue;
+      }
+      for (const auto& [inputId, isDynInput] : graph.inputVars(defInv)) {
+        if (componentOfVar[inputId] != componentIndex || isDynInput) {
+          continue;
+        }
+        if (discoverTime[inputId] == discoverTime[orig]) {
+          return true;
+        }
+        if (discoverTime[inputId] < 0) {
+          stack.emplace_back(inputId);
+        }
+      }
+    }
+  }
+  return false;
+}
+
+static bool hasUndeterminableDynamicCycle(
+    const PropagationGraph& graph, const std::vector<VarId>& component,
+    size_t componentIndex, const std::vector<size_t>& componentOfVar) {
+  for (const VarId outputId : component) {
+    const auto defInv = graph.definingInvariant(outputId);
+    if (defInv == NULL_ID || !graph.isDynamicInvariant(defInv)) {
+      continue;
+    }
+    bool hasStaticInLayer = false;
+    bool hasDynamicInLayer = false;
+    // If defInf only has static input in layer, then it is a static invariant
+    // in layer.
+    //.Else, if defInv only has dynamic input in layer, then it is a dynamic
+    // invariant in layer.
+    // Otherwise, defInv has a mix of static and dynamic inputs in layer, and
+    // creates an undeterminable dynamic cycle.
+    for (const auto& [inputId, isDynInput] : graph.inputVars(defInv)) {
+      if (componentOfVar[inputId] == componentIndex) {
+        hasStaticInLayer = hasStaticInLayer || !isDynInput;
+        hasDynamicInLayer = hasDynamicInLayer || isDynInput;
+        if (hasStaticInLayer && hasDynamicInLayer) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+void topologicallyOrderUtil(
+    const PropagationGraph& graph, const Timestamp ts,
+    std::vector<bool>& inFrontier, const VarId varId,
+    const std::vector<PropagationGraph::LayerIndex>& varLayerIndex,
+    const size_t layerOffset, std::vector<size_t>& topologicalNumber) {
+  assert(varId < varLayerIndex.size());
+  assert(varLayerIndex.at(varId).layer < graph.numLayers());
+  const auto& [layer, index] = varLayerIndex.at(varId);
+
+  // sanity:
+  assert(varLayerIndex.at(varId).index < graph.varsInLayer(layer).size());
+  assert(layer < graph.numLayers());
+  assert(index < graph.varsInLayer(layer).size());
+  assert(index < inFrontier.size());
+  assert(varId == graph.varsInLayer(layer).at(index));
+
+  if (inFrontier[index]) {
+    throw TopologicalOrderError();
+  }
+  assert(topologicalNumber.at(varId) == graph.numVars());
+  if (topologicalNumber[varId] != graph.numVars()) {
+    // already visited:
+    return;
+  }
+
+  // Get defining invariant:
+  const InvariantId defInv = graph.definingInvariant(varId);
+
+  // reset the topological number:
+  topologicalNumber[varId] = layerOffset;
+
+  if (defInv == NULL_ID) {
+    // The current variable is a search variable:
+    assert(topologicalNumber[varId] == 0);
+    return;
+  }
+
+  // add the current variable to the frontier:
+  inFrontier[index] = true;
+
+  const bool isDynInv =
+      graph.hasDynamicCycle(layer) && graph.isDynamicInvariant(defInv);
+
+  // For any invariant in a layer without an SCC, each input is in the same or a
+  // previous layer:
+  assert(isDynInv ||
+         std::ranges::all_of(std::views::keys(graph.inputVars(defInv)),
+                             [&](const VarId inputId) {
+                               if (inputId == NULL_ID) {
+                                 return false;
+                               }
+                               return varLayerIndex[inputId].layer <= layer;
+                             }));
+
+  // For any dynamic invariant in a layer with an SCC: either (i) all dynamic
+  // inputs are in a previous level or (ii) all static inputs are in a previous
+  // level
+  assert(!isDynInv ||
+         std::ranges::all_of(graph.inputVars(defInv),
+                             [&](const std::pair<VarId, bool>& p) {
+                               if (p.first == NULL_ID) {
+                                 return false;
+                               }
+                               if (p.second) {
+                                 return varLayerIndex[p.first].layer < layer;
+                               }
+                               return true;
+                             }) ||
+         std::ranges::all_of(graph.inputVars(defInv),
+                             [&](const std::pair<VarId, bool>& p) {
+                               if (p.first == NULL_ID) {
+                                 return false;
+                               }
+                               if (!p.second) {
+                                 return varLayerIndex[p.first].layer < layer;
+                               }
+                               return true;
+                             }));
+
+  const VarId dynInput =
+      isDynInv ? graph.dynamicInputVar(ts, defInv) : NULL_ID;
+  const size_t numVars = graph.numVars();
+  for (const auto& [inputId, isDynamicInput] : graph.inputVars(defInv)) {
+    if (isDynInv && isDynamicInput && dynInput != inputId) {
+      continue;
+    }
+    assert(inputId < varLayerIndex.size());
+    const size_t inputLayer = varLayerIndex[inputId].layer;
+    const size_t tn = topologicalNumber[inputId];
+    if (inputLayer == layer && tn == numVars) {
+      assert(!inFrontier.at(varLayerIndex.at(inputId).index));
+      topologicallyOrderUtil(graph, ts, inFrontier, inputId, varLayerIndex,
+                             layerOffset, topologicalNumber);
+      assert(topologicalNumber[inputId] != graph.numVars());
+    }
+    assert(topologicalNumber[inputId] != graph.numVars());
+    topologicalNumber[varId] =
+        std::max(topologicalNumber[varId], topologicalNumber[inputId] + 1);
+  }
+  assert(!isDynInv || dynInput == graph.dynamicInputVar(ts, defInv));
+  assert(std::ranges::all_of(
+      graph.inputVars(defInv), [&](const std::pair<VarId, bool>& p) {
+        if (p.first == NULL_ID) {
+          return false;
+        }
+        if (isDynInv && p.second) {
+          if (dynInput == p.first &&
+              topologicalNumber[p.first] >= topologicalNumber[varId]) {
+            return false;
+          }
+          return true;
+        }
+        if (topologicalNumber[p.first] >= topologicalNumber[varId]) {
+          return false;
+        }
+        return true;
+      }));
+
+  inFrontier[index] = false;
+}
+
 PropagationGraph::PropagationGraph(const Store& store, size_t expectedSize)
     : _store(store) {
   _definingInvariant.reserve(expectedSize);
@@ -28,7 +401,7 @@ PropagationGraph::PropagationGraph(const Store& store, size_t expectedSize)
   _isDynamicInvariant.reserve(expectedSize);
   _listeningInvariantData.reserve(expectedSize);
   _varLayerIndex.reserve(expectedSize);
-  _varPosition.reserve(expectedSize);
+  _topologicalNumber.reserve(expectedSize);
 }
 
 void PropagationGraph::registerInvariant(
@@ -48,12 +421,12 @@ void PropagationGraph::registerVar([[maybe_unused]] VarId id) {
   assert(id == _definingInvariant.size());
   assert(id == _listeningInvariantData.size());
   assert(id == _varLayerIndex.size());
-  assert(id == _varPosition.size());
+  assert(id == _topologicalNumber.size());
 
   _definingInvariant.emplace_back(NULL_ID);
   _listeningInvariantData.emplace_back();
   _varLayerIndex.emplace_back();
-  _varPosition.emplace_back();
+  _topologicalNumber.emplace_back();
   ++_numVars;
 }
 
@@ -121,91 +494,13 @@ void PropagationGraph::close(Timestamp ts) {
   }
 
   partitionIntoLayers();
-  mergeLayersWithoutDynamicCycles();
-  computeLayerOffsets();
   topologicallyOrder(ts);
   // Reset propagation queue data structure.
-  // TODO: Be sure that this does not cause a memeory leak...
-  // _propagationQueue = PropagationQueue();
+
   _propagationQueue.init(numVars(), numLayers());
   for (VarId vId = 0; vId < numVars(); ++vId) {
     _propagationQueue.initVar(vId, varPosition(vId));
   }
-}
-
-bool PropagationGraph::containsStaticCycle(std::vector<bool>& visited,
-                                           std::vector<bool>& inFrontier,
-                                           VarId varId) {
-  // Mark current output variable
-  assert(varId < visited.size());
-  assert(varId < inFrontier.size());
-  if (inFrontier[varId]) {
-    return true;
-  }
-  visited[varId] = true;
-  inFrontier[varId] = true;
-  // get the defining invariant:
-  const InvariantId defInv = definingInvariant(varId);
-  if (defInv != NULL_ID) {
-    for (const auto& [inputId, isDynamicInput] : inputVars(defInv)) {
-      if (!isDynamicInput &&
-          containsStaticCycle(visited, inFrontier, inputId)) {
-        return true;
-      }
-    }
-  }
-  inFrontier[varId] = false;
-  return false;
-}
-
-bool PropagationGraph::containsStaticCycle() {
-  std::vector<bool> visited(numVars(), false);
-  std::vector<bool> inFrontier(numVars(), false);
-  // Check for static cycles starting from the output variables:
-  for (VarId varId = 0; varId < numVars(); ++varId) {
-    assert(all_in_range(0, numVars(),
-                        [&](const size_t i) { return !inFrontier.at(i); }));
-    if (listeningInvariantData(varId).empty()) {
-      if (containsStaticCycle(visited, inFrontier, VarId(varId))) {
-        return true;
-      }
-    }
-  }
-  assert(all_in_range(0, numVars(),
-                      [&](const size_t varId) { return visited.at(varId); }));
-  return false;
-}
-
-void PropagationGraph::partitionIntoLayers(std::vector<bool>& visited,
-                                           VarId varId) {
-  assert(varId < _varLayerIndex.size());
-  assert(varId < visited.size());
-  // Mark current output variable
-  visited[varId] = true;
-  // get the defining invariant:
-  const InvariantId defInv = definingInvariant(varId);
-  size_t layer = 0;
-  if (defInv != NULL_ID) {
-    // we are at a defined variable.
-    // for each input variable:
-    for (const auto& [inputId, isDynamicInput] : inputVars(defInv)) {
-      // visit the input if unvisited:
-      if (!visited[inputId]) {
-        partitionIntoLayers(visited, inputId);
-      }
-      // update layer for varId:
-      layer =
-          std::max(layer, _varLayerIndex[inputId].layer +
-                              static_cast<size_t>(isDynamicInvariant(defInv) &&
-                                                  !isDynamicInput));
-    }
-  }
-  _varLayerIndex[varId].layer = layer;
-  for (size_t i = _varsInLayer.size(); i <= layer; ++i) {
-    _varsInLayer.emplace_back();
-  }
-  _varLayerIndex[varId].index = _varsInLayer[layer].size();
-  _varsInLayer[layer].emplace_back(varId);
 }
 
 /**
@@ -220,245 +515,125 @@ void PropagationGraph::partitionIntoLayers(std::vector<bool>& visited,
  * share key-value.
  */
 void PropagationGraph::partitionIntoLayers() {
-  std::vector<bool> visited(numVars(), false);
-  _layerHasDynamicCycle.assign(1, false);
-  _varsInLayer.assign(1, std::vector<VarId>{});
-  assert(_varLayerIndex.size() == numVars());
-  // Call visit on all output variables
-  for (const VarId evalVar : _evaluationVars) {
-    partitionIntoLayers(visited, evalVar);
-  }
-  // Visit any unvisited nodes (this should not happen):
-  for (VarId varId = 0; varId < numVars(); ++varId) {
-    if (!visited[varId]) {
-      partitionIntoLayers(visited, VarId(varId));
+  // Step 1: find all SCCs:
+  auto components = SCC(*this);
+  // Step 2: check for undeterminable cycles in the SCCs:
+  // For any SCC, an undeterminable cycle contains:
+  // * a fully static cycle or
+  // * a dynamic invariant with both a static and dynamic input also in the SCC
+  std::vector<size_t> componentOfVar(numVars(), components.size());
+  for (size_t c = 0; c < components.size(); ++c) {
+    for (const VarId varId : components[c]) {
+      assert(componentOfVar[varId] == components.size());
+      componentOfVar[varId] = c;
     }
   }
+  for (size_t c = 0; c < components.size(); ++c) {
+    if (hasStaticCycle(*this, components[c], c, componentOfVar)) {
+      throw PropagationGraphHasCycles(
+          "PropagationGraph has one or more static cycles");
+    }
+    if (hasUndeterminableDynamicCycle(*this, components[c], c,
+                                      componentOfVar)) {
+      throw PropagationGraphHasCycles(
+          "PropagationGraph has one or more bad dynamic cycles");
+    }
+  }
+  componentOfVar.clear();
+
+  // Step 3: using the SCCs, partition into layers:
+  std::vector<size_t> layerOfVar(numVars(), 0);
+  _layerHasDynamicCycle =
+      partitionIntoLayersUsingSCC(*this, components, layerOfVar);
+  components.clear();
+
+  assert(layerOfVar.size() == numVars());
+
+  _varLayerIndex.resize(numVars());
+  _varsInLayer.assign(_layerHasDynamicCycle.size(), std::vector<VarId>());
+
+  for (VarId varId = 0; varId < numVars(); ++varId) {
+    const size_t layer = layerOfVar[varId];
+    assert(layer < _varsInLayer.size());
+    const size_t index = _varsInLayer[layer].size();
+    _varsInLayer[layer].emplace_back(varId);
+    _varLayerIndex[varId].layer = layer;
+    _varLayerIndex[varId].index = index;
+  }
+
+  for (const InvariantId invId : _definingInvariant) {
+    if (invId == NULL_ID) {
+      continue;
+    }
+    assert(_store.constInvariant(invId).primaryDefinedVar() != NULL_ID);
+
+    const size_t layer =
+        _varLayerIndex.at(_store.constInvariant(invId).primaryDefinedVar())
+            .layer;
+    assert(std::ranges::all_of(varsDefinedBy(invId), [&](const VarId varId) {
+      return _varLayerIndex.at(varId).layer == layer;
+    }));
+    const bool isDyn =
+        _layerHasDynamicCycle.at(layer) && isDynamicInvariant(invId);
+    if (!isDyn) {
+      assert(std::ranges::all_of(
+          std::views::keys(inputVars(invId)), [&](const VarId inputId) {
+            return _varLayerIndex.at(inputId).layer <= layer;
+          }));
+    } else {
+      bool allStaticInPrevLayer = true;
+      bool allDynInPrevLayer = true;
+      for (const auto& [inputId, isDynInput] : inputVars(invId)) {
+        const size_t inputLayer = _varLayerIndex.at(inputId).layer;
+        assert(inputLayer <= layer);
+        if (isDynInput) {
+          allDynInPrevLayer = allDynInPrevLayer && inputLayer < layer;
+        } else {
+          allStaticInPrevLayer = allStaticInPrevLayer && inputLayer < layer;
+        }
+      }
+      assert(allStaticInPrevLayer || allDynInPrevLayer);
+    }
+  }
+
+  // Step 4: compute layer offsets for topological numbers
+  _topologicalNumberOffset.resize(_varsInLayer.size());
+  _topologicalNumberOffset[0] = 0;
+  for (size_t layer = 1; layer < _varsInLayer.size(); ++layer) {
+    _topologicalNumberOffset[layer] =
+        _topologicalNumberOffset[layer - 1] + _varsInLayer[layer - 1].size();
+  }
+
+  assert(numVars() == _varLayerIndex.size());
+
   assert(all_in_range(0, numVars(), [&](const VarId varId) {
     const size_t layer = _varLayerIndex.at(varId).layer;
     const size_t index = _varLayerIndex.at(varId).index;
-    return varId < _varLayerIndex.size() && layer < _varsInLayer.size() &&
-           index < _varsInLayer.at(layer).size() &&
-           varId == _varsInLayer.at(layer).at(index);
-  }));
-}
 
-bool PropagationGraph::containsDynamicCycle(std::vector<bool>& visited,
-                                            VarId originVarId) {
-  assert(originVarId < _varLayerIndex.size());
-  const size_t layer = _varLayerIndex[originVarId].layer;
-  assert(layer < numLayers());
-
-  std::vector<bool> onStack(visited.size(), false);
-  std::vector<VarId> stack;
-  stack.reserve(visited.size());
-  stack.emplace_back(originVarId);
-  size_t stackPtr = 0;
-
-  while (stackPtr < stack.size()) {
-    const VarId varId = stack[stackPtr];
-    ++stackPtr;
-    assert(varId != NULL_ID);
-    const size_t index = _varLayerIndex[varId].index;
-    assert(index < _varsInLayer.at(layer).size());
-    assert(varId == _varsInLayer.at(layer).at(index));
-    assert(index < visited.size());
-    assert(index < onStack.size());
-
-    if (visited[index]) {
-      // this node has been visited during a previous origin var
-      continue;
-    }
-    if (onStack[index]) {
-      // this node has been pushed onto the stack, there is a cycle
-      return true;
-    }
-    onStack[index] = true;
-    const InvariantId defInv = definingInvariant(varId);
-    if (defInv == NULL_ID) {
-      // we are at a search variable.
+    if (index >= _varsInLayer.at(layer).size()) {
       return false;
     }
-    // mark as in frontier:
-    onStack[index] = true;
-    // get the defining invariant:
-    for (const auto& inputId : std::views::keys(inputVars(defInv))) {
-      assert(_varLayerIndex[inputId].layer <= layer);
-      if (_varLayerIndex[inputId].layer == layer) {
-        stack.emplace_back(inputId);
+    if (varId != _varsInLayer.at(layer).at(index)) {
+      return false;
+    }
+
+    const auto defInv = definingInvariant(varId);
+
+    if (defInv == NULL_ID) {
+      if (layer != 0) {
+        return false;
       }
+      return layer == 0;
     }
-  }
-  for (const VarId varId : stack) {
-    // add all nodes that have been visited during this call to visited
-    visited[_varLayerIndex[varId].index] = true;
-  }
-  return false;
-}
 
-bool PropagationGraph::containsDynamicCycle(size_t layer) {
-  assert(layer < numLayers());
-  std::vector<bool> visited(_varsInLayer[layer].size(), false);
-  // Check for dynamic cycles starting from the output variables:
-  for (const VarId varId : _varsInLayer[layer]) {
-    if (!visited[varId] && definingInvariant(varId) != NULL_ID &&
-        isDynamicInvariant(definingInvariant(varId)) &&
-        containsDynamicCycle(visited, varId)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-void PropagationGraph::mergeLayersWithoutDynamicCycles() {
-  // combine subsequent layers without dynamic cycles:
-  assert(!containsDynamicCycle(0));
-  _layerHasDynamicCycle.assign(numLayers(), false);
-  size_t layer = 1;
-  while (layer < numLayers()) {
-    _layerHasDynamicCycle[layer] = containsDynamicCycle(layer);
-    if (_layerHasDynamicCycle[layer - 1] || _layerHasDynamicCycle[layer]) {
-      // the previous layer had one or more dynamic cycles: continue
-      ++layer;
-      continue;
-    }
-    // The previous layer contained no cycles: merge the layers.
-    // merge layers layer - 1 and layer:
-    const size_t oldSize = _varsInLayer[layer - 1].size();
-    // concat layer to layer - 1:
-    _varsInLayer[layer - 1].insert(_varsInLayer[layer - 1].end(),
-                                   _varsInLayer[layer].begin(),
-                                   _varsInLayer[layer].end());
-    // Update the vars:
-    for (size_t i = oldSize; i < _varsInLayer[layer - 1].size(); ++i) {
-      const VarId varId = _varsInLayer[layer - 1][i];
-      // sanity:
-      assert(_varLayerIndex.at(varId).layer == layer);
-      assert(_varsInLayer[layer][_varLayerIndex.at(varId).index] == varId);
-      // change layer
-      _varLayerIndex[varId].layer = layer - 1;
-      _varLayerIndex[varId].index = i;
-      // sanity
-      assert(varId == _varsInLayer[_varLayerIndex[varId].layer]
-                                  [_varLayerIndex[varId].index]);
-    }
-    assert(std::ranges::all_of(
-        _varsInLayer[layer - 1].begin(), _varsInLayer[layer - 1].end(),
-        [&](const VarId varId) {
-          return _varLayerIndex[varId].layer == layer - 1;
-        }));
-
-    assert(!containsDynamicCycle(layer - 1));
-    // shift the rest of the layers:
-    for (size_t l = layer + 1; l < numLayers(); ++l) {
-      for (const VarId varId : _varsInLayer[l]) {
-        _varLayerIndex[varId].layer = l - 1;
-      }
-    }
-    // remove the layer
-    _varsInLayer.erase(_varsInLayer.begin() + static_cast<Int>(layer));
-    _layerHasDynamicCycle.erase(_layerHasDynamicCycle.begin() +
-                                static_cast<Int>(layer));
-  }
-}
-
-void PropagationGraph::computeLayerOffsets() {
-  _layerPositionOffset.assign(numLayers(), 0);
-  for (size_t layer = 1; layer < numLayers(); ++layer) {
-    _layerPositionOffset[layer] =
-        _layerPositionOffset[layer - 1] + _varsInLayer[layer - 1].size();
-  }
-  assert(_layerPositionOffset.back() + _varsInLayer.back().size() == numVars());
-}
-
-void PropagationGraph::topologicallyOrder(const Timestamp ts,
-                                          std::vector<bool>& inFrontier,
-                                          const VarId varId) {
-  assert(varId < _varLayerIndex.size());
-  assert(_varLayerIndex.at(varId).layer < numLayers());
-  const auto& [layer, index] = _varLayerIndex.at(varId);
-
-  // sanity:
-  assert(_varLayerIndex.at(varId).index < _varsInLayer[layer].size());
-  assert(layer < _varsInLayer.size());
-  assert(index < _varsInLayer.at(layer).size());
-  assert(index < inFrontier.size());
-  assert(varId == _varsInLayer.at(layer).at(index));
-
-  if (inFrontier[index]) {
-    throw TopologicalOrderError();
-  }
-  assert(_varPosition[varId] == numVars());
-  if (_varPosition[varId] != numVars()) {
-    // already visited:
-    return;
-  }
-
-  // Get defining invariant:
-  const InvariantId defInv = definingInvariant(varId);
-
-  // reset the topological number:
-  _varPosition[varId] = 0;
-
-  if (defInv == NULL_ID) {
-    // The current variable is a search variable:
-    return;
-  }
-
-  // add the current variable to the frontier:
-  inFrontier[index] = true;
-
-  const bool isDynInv =
-      _layerHasDynamicCycle[layer] && isDynamicInvariant(defInv);
-
-  assert(std::ranges::all_of(inputVars(defInv).begin(), inputVars(defInv).end(),
-                             [&](const std::pair<VarId, bool>& p) {
-                               if (p.first == NULL_ID) {
-                                 return false;
-                               }
-                               if (isDynInv && !p.second) {
-                                 return _varLayerIndex[p.first].layer < layer;
-                               }
-                               return _varLayerIndex[p.first].layer <= layer;
-                             }));
-
-  for (const auto& [inputId, isDynamicInput] : _inputVars[defInv]) {
-    if (!isDynInv || !isDynamicInput) {
-      if (_varLayerIndex[inputId].layer == layer &&
-          _varPosition[inputId] == numVars()) {
-        topologicallyOrder(ts, inFrontier, inputId);
-      }
-
-      _varPosition[varId] =
-          std::max(_varPosition[varId], _varPosition[inputId] + 1);
-    }
-  }
-  if (isDynInv) {
-    const VarId dynamicInputId = dynamicInputVar(ts, defInv);
-    assert(dynamicInputId != NULL_ID);
-    // we should have no dependencies to subsequent layers:
-    assert(_varLayerIndex[dynamicInputId].layer <= layer);
-    if (_varLayerIndex[dynamicInputId].layer == layer &&
-        _varPosition[dynamicInputId] == numVars()) {
-      topologicallyOrder(ts, inFrontier, dynamicInputId);
-    }
-    _varPosition[varId] =
-        std::max(_varPosition[varId], _varPosition[dynamicInputId] + 1);
-  }
-  assert(std::ranges::all_of(
-      inputVars(defInv).begin(), inputVars(defInv).end(),
-      [&](const std::pair<VarId, bool>& p) {
-        if (p.first == NULL_ID) {
-          return false;
-        }
-        if (isDynInv && p.second) {
-          return _store.dynamicInputVar(ts, defInv) != p.first ||
-                 _varPosition[p.first] < _varPosition[varId];
-        }
-        return _varPosition[p.first] < _varPosition[varId];
-      }));
-
-  inFrontier[index] = false;
+    return std::ranges::all_of(std::views::keys(inputVars(defInv)),
+                               [&](const VarId inputId) {
+                                 if (_varLayerIndex.at(inputId).layer > layer) {
+                                   return false;
+                                 }
+                                 return true;
+                               });
+  }));
 }
 
 /**
@@ -475,33 +650,34 @@ void PropagationGraph::topologicallyOrder(const Timestamp ts,
 void PropagationGraph::topologicallyOrder(Timestamp ts, size_t layer,
                                           bool updatePriorityQueue) {
   assert(layer < numLayers());
-  assert(_layerPositionOffset.size() == numLayers());
   for (const VarId varId : _varsInLayer[layer]) {
-    _varPosition[varId] = numVars();
+    _topologicalNumber[varId] = numVars();
   }
   std::vector<bool> inFrontier(_varsInLayer[layer].size(), false);
   for (const VarId varId : _varsInLayer[layer]) {
-    if (_varPosition[varId] == numVars()) {
-      topologicallyOrder(ts, inFrontier, varId);
+    if (_topologicalNumber[varId] == numVars()) {
+      topologicallyOrderUtil(*this, ts, inFrontier, varId, _varLayerIndex,
+                             _topologicalNumberOffset[layer],
+                             _topologicalNumber);
     }
-    assert(_varPosition[varId] < numVars());
+    assert(_topologicalNumber[varId] < numVars());
   }
-  assert(all_in_range(0u, inFrontier.size(), [&](const size_t index) {
-    return !inFrontier.at(index);
-  }));
-  for (const VarId varId : _varsInLayer.at(layer)) {
-    const InvariantId defInv = definingInvariant(varId);
+  assert(std::ranges::none_of(inFrontier, [&](const bool b) { return b; }));
+  for (const VarId outputId : _varsInLayer[layer]) {
+    const InvariantId defInv = definingInvariant(outputId);
     if (defInv == NULL_ID) {
-      assert(_varPosition[varId] == 0);
+      assert(_topologicalNumber[outputId] == 0);
       continue;
     }
     const bool isDynInv =
         _layerHasDynamicCycle.at(layer) && isDynamicInvariant(defInv);
 
+    const VarId dynInput = isDynInv ? dynamicInputVar(ts, defInv) : NULL_ID;
     for (const auto& [inputId, isDynamicInput] : inputVars(defInv)) {
-      if ((!isDynInv || !isDynamicInput ||
-           dynamicInputVar(ts, defInv) == inputId) &&
-          _varPosition[inputId] >= _varPosition[varId]) {
+      if (isDynInv && isDynamicInput && dynInput != inputId) {
+        continue;
+      }
+      if (_topologicalNumber[inputId] >= _topologicalNumber[outputId]) {
         throw TopologicalOrderError();
       }
     }
@@ -509,7 +685,7 @@ void PropagationGraph::topologicallyOrder(Timestamp ts, size_t layer,
 
   if (updatePriorityQueue) {
     for (const VarId varId : _varsInLayer[layer]) {
-      _propagationQueue.updatePriority(varId, _varPosition.at(varId));
+      _propagationQueue.updatePriority(varId, _topologicalNumber[varId]);
     }
   }
 }


### PR DESCRIPTION
For any invariant node, all static input variables must have a var id before its output var ids can be created

Refactored how cycles are detected:
1. All strongly Connected Components are found using Tarjan's algorithms
2. each static cycle is broken
3. each bad dynamic cycle is broken
4. if dynamic cycles aren't allowed, then they are also broken

Topological ordering now only orders the strongly connected components, making layers smaller