### PR TITLE
Break static cycles

### DIFF
--- a/include/atlantis/invariantgraph/varNode.hpp
+++ b/include/atlantis/invariantgraph/varNode.hpp
@@ -33,11 +33,22 @@ class VarNode {
   std::vector<InvariantNodeId> _dynamicInputTo;
   std::unordered_set<InvariantNodeId, InvariantNodeIdHash> _outputOf;
   bool _isViolationVar{false};
+  std::optional<std::string> _identifier;
 
  public:
   explicit VarNode(VarNodeId, bool isIntVar,
                    DomainType = DomainType::DOM_RANGE);
+
   explicit VarNode(VarNodeId, bool isIntVar,
+                   const std::shared_ptr<SearchDomain>& domain,
+                   DomainType = DomainType::DOM_DOMAIN);
+
+  explicit VarNode(const std::string& identifier,
+                    VarNodeId, bool isIntVar,
+                   DomainType = DomainType::DOM_RANGE);
+
+  explicit VarNode(const std::string& identifier,
+  VarNodeId, bool isIntVar,
                    const std::shared_ptr<SearchDomain>& domain,
                    DomainType = DomainType::DOM_DOMAIN);
 

--- a/src/invariantgraph/fzn/bool_not.cpp
+++ b/src/invariantgraph/fzn/bool_not.cpp
@@ -25,9 +25,16 @@ bool bool_not(FznInvariantGraph& graph,
   FZN_CONSTRAINT_TYPE_CHECK(constraint, 0, fznparser::BoolArg, true)
   FZN_CONSTRAINT_TYPE_CHECK(constraint, 1, fznparser::BoolArg, true)
 
-  return bool_not(graph,
-                  std::get<fznparser::BoolArg>(constraint.arguments().at(0)),
-                  std::get<fznparser::BoolArg>(constraint.arguments().at(1)));
+  const auto& b = std::get<fznparser::BoolArg>(constraint.arguments().at(0));
+  const auto& bNeg = std::get<fznparser::BoolArg>(constraint.arguments().at(1));
+
+  if (constraint.definedVar().has_value() &&
+    std::holds_alternative<std::shared_ptr<fznparser::BoolVar>>(constraint.definedVar().value()) &&
+    std::get<std::shared_ptr<fznparser::BoolVar>>(constraint.definedVar().value()) == std::get<std::shared_ptr<const fznparser::BoolVar>>(b) ) {
+      return bool_not(graph, bNeg, b);
+  }
+
+  return bool_not(graph,b, bNeg);
 }
 
 }  // namespace atlantis::invariantgraph::fzn

--- a/src/invariantgraph/invariantGraph.cpp
+++ b/src/invariantgraph/invariantGraph.cpp
@@ -46,7 +46,7 @@ static void SCCUtil(const InvariantGraph& graph, VarNodeId inputId,
                   components);
           lowTime[inputId] = std::min(lowTime[outputId], lowTime[inputId]);
         } else if (onStack[outputId]) {
-          lowTime[inputId] = std::min(lowTime[outputId], discoverTime[inputId]);
+          lowTime[inputId] = std::min(discoverTime[outputId], lowTime[inputId]);
         }
       }
     }
@@ -100,12 +100,13 @@ static std::vector<std::vector<VarNodeId>> SCC(const InvariantGraph& graph) {
   return components;
 }
 
-static std::vector<VarNodeId> findStaticCycle(
+static std::vector<VarNodeId> findCycle(
     const InvariantGraph& graph, const std::vector<VarNodeId>& component,
-    const size_t componentIndex, const std::vector<size_t>& componentOfVar) {
+    const size_t componentIndex, const std::vector<size_t>& componentOfVar,
+    bool findDynCycles) {
   std::vector<VarNodeId> stack;
   std::vector<Int> discoverTime(componentOfVar.size(), -1);
-  std::vector<VarNodeId> parent(componentOfVar.size(), NULL_NODE_ID);
+  std::vector<VarNodeId> outputOf(componentOfVar.size(), NULL_NODE_ID);
   stack.reserve(component.size());
   Int time = 0;
   for (const VarNodeId orig : component) {
@@ -120,7 +121,7 @@ static std::vector<VarNodeId> findStaticCycle(
       const VarNodeId outputId = stack.back();
       stack.pop_back();
       if (outputId >= componentOfVar.size()) {
-        // This var has been when breaking a cycle and cannot be in another
+        // This var has been added when breaking a cycle and cannot be in another
         // cycle.
         continue;
       }
@@ -132,87 +133,24 @@ static std::vector<VarNodeId> findStaticCycle(
       const auto defInv = *graph.varNodeConst(outputId).definingNodes().begin();
       assert(defInv != NULL_NODE_ID);
       const auto& invNode = graph.invariantNodeConst(defInv);
-      for (const VarNodeId inputId : invNode.staticInputVarNodeIds()) {
-        if (inputId >= componentOfVar.size() ||
-            componentOfVar[inputId] != componentIndex ||
-            parent[inputId] != NULL_NODE_ID) {
-          // This var either: (i) was added when breaking a cycle or (ii) is not
-          // in the current component.
-          continue;
-        }
-        // what if outputId != NULL_NODE_ID
-        parent[inputId] = outputId;
-        if (discoverTime[inputId] == discoverTime[orig]) {
-          std::vector<VarNodeId> cycle;
-          cycle.reserve(component.size());
-          cycle.emplace_back(inputId);
-          for (VarNodeId vId = outputId; vId != inputId; vId = parent[vId]) {
-            assert(vId != NULL_NODE_ID);
-            assert(vId < componentOfVar.size());
-            assert(discoverTime.at(vId) == discoverTime.at(orig));
-            assert(componentOfVar.at(vId) == componentOfVar.at(orig));
-            cycle.emplace_back(vId);
-          }
-          return cycle;
-        }
-        if (discoverTime[inputId] < 0) {
-          stack.emplace_back(inputId);
-        }
-      }
-    }
-  }
-  return {};
-}
-
-static std::vector<VarNodeId> findDynamicCycle(
-    const InvariantGraph& graph, const std::vector<VarNodeId>& component,
-    const size_t componentIndex, const std::vector<size_t>& componentOfVar) {
-  std::vector<VarNodeId> stack;
-  std::vector<Int> discoverTime(componentOfVar.size(), -1);
-  std::vector<VarNodeId> parent(componentOfVar.size(), NULL_NODE_ID);
-  stack.reserve(component.size());
-  Int time = 0;
-  for (const VarNodeId orig : component) {
-    if (discoverTime[orig] < 0) {
-      continue;
-    }
-    discoverTime[orig] = time;
-    ++time;
-    stack.emplace_back(orig);
-
-    while (!stack.empty()) {
-      const VarNodeId outputId = stack.back();
-      stack.pop_back();
-      if (outputId >= componentOfVar.size()) {
-        // This var has been when breaking a cycle and cannot be in another
-        // cycle.
-        continue;
-      }
-      discoverTime[outputId] = discoverTime[orig];
-      assert(graph.varNodeConst(outputId).definingNodes().size() <= 1);
-      if (graph.varNodeConst(outputId).definingNodes().empty()) {
-        continue;
-      }
-      const auto defInv = *graph.varNodeConst(outputId).definingNodes().begin();
-      assert(defInv != NULL_NODE_ID);
-      const auto& invNode = graph.invariantNodeConst(defInv);
-      for (size_t i = 0; i < 2; ++i) {
-        for (const VarNodeId inputId : i == 0
-                                           ? invNode.staticInputVarNodeIds()
-                                           : invNode.dynamicInputVarNodeIds()) {
+      for (unsigned int i = 0; i < (findDynCycles ? 2 : 1); ++i) {
+        for (const VarNodeId inputId : (i == 0 ? invNode.staticInputVarNodeIds() : invNode.dynamicInputVarNodeIds())) {
           if (inputId >= componentOfVar.size() ||
               componentOfVar[inputId] != componentIndex) {
-            // This var either: (i) was added when breaking a cycle or (ii) is
-            // not in the current component.
+            // This var either: (i) was added when breaking a cycle or (ii) is not
+            // in the current component.
             continue;
           }
-          parent[inputId] = outputId;
+          // what if outputId != NULL_NODE_ID
+          outputOf[inputId] = outputId;
           if (discoverTime[inputId] == discoverTime[orig]) {
             std::vector<VarNodeId> cycle;
             cycle.reserve(component.size());
             cycle.emplace_back(inputId);
-            for (VarNodeId vId = outputId; vId != inputId; vId = parent[vId]) {
-              assert(vId != NULL_NODE_ID);
+            for (VarNodeId vId = outputId; vId != inputId && vId != NULL_NODE_ID; vId = outputOf[vId]) {
+              assert(vId < componentOfVar.size());
+              assert(discoverTime.at(vId) == discoverTime.at(orig));
+              assert(componentOfVar.at(vId) == componentOfVar.at(orig));
               cycle.emplace_back(vId);
             }
             return cycle;
@@ -225,6 +163,18 @@ static std::vector<VarNodeId> findDynamicCycle(
     }
   }
   return {};
+}
+
+static std::vector<VarNodeId> findStaticCycle(
+    const InvariantGraph& graph, const std::vector<VarNodeId>& component,
+    const size_t componentIndex, const std::vector<size_t>& componentOfVar) {
+  return findCycle(graph, component, componentIndex, componentOfVar, false);
+}
+
+static std::vector<VarNodeId> findDynamicCycle(
+    const InvariantGraph& graph, const std::vector<VarNodeId>& component,
+    const size_t componentIndex, const std::vector<size_t>& componentOfVar) {
+  return findCycle(graph, component, componentIndex, componentOfVar, true);
 }
 
 static std::pair<VarNodeId, InvariantNodeId> findPivotInCycle(
@@ -323,7 +273,7 @@ VarNodeId InvariantGraph::retrieveBoolVarNode(bool b) {
 VarNodeId InvariantGraph::retrieveBoolVarNode(const std::string& identifier,
                                               DomainType domainType) {
   if (!containsVarNode(identifier)) {
-    const VarNodeId nId = retrieveBoolVarNode(domainType);
+    const VarNodeId nId = _varNodes.emplace_back(identifier, nextVarNodeId(), false, domainType).varNodeId();
     _namedVarNodeIndices.emplace(identifier, nId);
     return nId;
   }
@@ -432,7 +382,11 @@ VarNodeId InvariantGraph::retrieveIntVarNode(
     }
     return node.varNodeId();
   }
-  const VarNodeId nId = retrieveIntVarNode(domain, domainType);
+
+  VarNodeId nId = domain->isFixed() ?
+    retrieveIntVarNode(domain->lowerBound())
+      : _varNodes.emplace_back(identifier, nextVarNodeId(), true, domain, domainType)
+      .varNodeId();
 
   assert(!containsVarNode(identifier));
   _namedVarNodeIndices.emplace(identifier, nId);
@@ -962,8 +916,8 @@ void createVarsUtil(
   }
   onStack.emplace(invNodeId);
   for (const VarNodeId inputId : invNode.staticInputVarNodeIds()) {
-    for (const InvariantNodeId defInv :
-         graph.varNodeConst(inputId).definingNodes()) {
+    const auto inputVar = graph.varNodeConst(inputId);
+    for (const InvariantNodeId defInv : inputVar.definingNodes()) {
       assert(!onStack.contains(defInv));
       if (!visitedInvNodes.contains(defInv)) {
         createVarsUtil(graph, defInv, visitedInvNodes, onStack);

--- a/src/invariantgraph/varNode.cpp
+++ b/src/invariantgraph/varNode.cpp
@@ -17,21 +17,46 @@
 
 namespace atlantis::invariantgraph {
 
-VarNode::VarNode(VarNodeId varNodeId, bool isIntVar, DomainType domainType)
+std::string toString(VarNodeId varNodeId) {
+  return "ATLANTIS_INTRODUCED_" + std::to_string(varNodeId);
+}
+
+VarNode::VarNode(const std::string& identifier, VarNodeId varNodeId, bool isIntVar,
+                 const std::shared_ptr<SearchDomain>& domain,
+                 DomainType domainType)
     : _varNodeId(varNodeId),
       _isIntVar(isIntVar),
       _domainType(domainType),
-      _domain(std::make_shared<SearchDomain>(0, 1)) {
+      _domain(domain),
+      _identifier(identifier)
+{}
+
+VarNode::VarNode(const std::string& identifier, VarNodeId varNodeId, bool isIntVar, DomainType domainType)
+    : _varNodeId(varNodeId),
+      _isIntVar(isIntVar),
+      _domainType(domainType),
+      _domain(std::make_shared<SearchDomain>(0, 1)),
+      _identifier(identifier) {
+  assert(!isIntVar);
+}
+
+VarNode::VarNode(VarNodeId varNodeId, bool isIntVar, DomainType domainType)
+: _varNodeId(varNodeId),
+  _isIntVar(isIntVar),
+  _domainType(domainType),
+  _domain(std::make_shared<SearchDomain>(0, 1)),
+  _identifier(std::nullopt) {
   assert(!isIntVar);
 }
 
 VarNode::VarNode(VarNodeId varNodeId, bool isIntVar,
                  const std::shared_ptr<SearchDomain>& domain,
                  DomainType domainType)
-    : _varNodeId(varNodeId),
-      _isIntVar(isIntVar),
-      _domainType(domainType),
-      _domain(domain) {}
+: _varNodeId(varNodeId),
+  _isIntVar(isIntVar),
+  _domainType(domainType),
+  _domain(domain),
+  _identifier(std::nullopt) {}
 
 VarNodeId VarNode::varNodeId() const noexcept { return _varNodeId; }
 

--- a/test/challenges/tMznChallenge.cpp
+++ b/test/challenges/tMznChallenge.cpp
@@ -12,6 +12,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "atlantis/exceptions/exceptions.hpp"
 #include "atlantis/fznBackend.hpp"
 #include "atlantis/logging/logger.hpp"
 #include "atlantis/search/searchStatistics.hpp"
@@ -59,12 +60,9 @@ class MznChallenge : public ::testing::Test {
   std::unordered_set<std::string> timeout{};
 
   std::unordered_set<std::string> unbrokenCycles{
-      std::string(FZN_CHALLENGE_DIR) + std::string{"/mqueens"},
-      std::string(FZN_CHALLENGE_DIR) + std::string{"/pattern-set-mining"},
-      std::string(FZN_CHALLENGE_DIR) + std::string{"/project-planning"},
-      std::string(FZN_CHALLENGE_DIR) + std::string{"/tdtsp"}};
+      std::string(FZN_CHALLENGE_DIR) + std::string{"/project-planning"}};
 
-  std::unordered_set<std::string> unsatAllEqual{std::string(FZN_CHALLENGE_DIR) +
+  std::unordered_set<std::string> expectedUnsat{std::string(FZN_CHALLENGE_DIR) +
                                                 std::string{"/still_life"}};
 
   std::unordered_set<std::string> failing{};
@@ -78,7 +76,7 @@ class MznChallenge : public ::testing::Test {
   std::vector<std::string> mallocFznModels;
   std::vector<std::string> timeoutFznModels;
   std::vector<std::string> unbrokenCycleFznModels;
-  std::vector<std::string> unsatAllEqualFznModels;
+  std::vector<std::string> expectedUnsatFznModels;
   std::vector<std::string> failingFznModels;
   std::vector<std::string> unboundedFznModels;
 
@@ -127,7 +125,7 @@ class MznChallenge : public ::testing::Test {
     EXPECT_EQ(dirs.size(), fznModelsByDir.size());
     EXPECT_GE(fznModelsByDir.size(),
               malloc.size() + timeout.size() + unbrokenCycles.size() +
-                  unsatAllEqual.size() + failing.size() + unbounded.size());
+                  expectedUnsat.size() + failing.size() + unbounded.size());
 
     std::ranges::sort(dirs.begin(), dirs.end());
 
@@ -137,13 +135,13 @@ class MznChallenge : public ::testing::Test {
     mallocFznModels.reserve(malloc.size());
     timeoutFznModels.reserve(timeout.size());
     unbrokenCycleFznModels.reserve(unbrokenCycles.size());
-    unsatAllEqualFznModels.reserve(unsatAllEqual.size());
+    expectedUnsatFznModels.reserve(expectedUnsat.size());
     unboundedFznModels.reserve(unbounded.size());
     failingFznModels.reserve(failing.size());
 
     passingFznModels.reserve(fznModelsByDir.size() - malloc.size() -
                              timeout.size() - unbrokenCycles.size() -
-                             unsatAllEqual.size() - failing.size() -
+                             expectedUnsat.size() - failing.size() -
                              unbounded.size());
 
     for (const auto& dirPath : dirs) {
@@ -157,8 +155,8 @@ class MznChallenge : public ::testing::Test {
           timeoutFznModels.emplace_back(fznModel);
         } else if (unbrokenCycles.contains(dirPath)) {
           unbrokenCycleFznModels.emplace_back(fznModel);
-        } else if (unsatAllEqual.contains(dirPath)) {
-          unsatAllEqualFznModels.emplace_back(fznModel);
+        } else if (expectedUnsat.contains(dirPath)) {
+          expectedUnsatFznModels.emplace_back(fznModel);
         } else if (failing.contains(dirPath)) {
           failingFznModels.emplace_back(fznModel);
         } else if (unbounded.contains(dirPath)) {
@@ -204,11 +202,11 @@ TEST_F(MznChallenge, DISABLED_unbrokenCycle) {
     testChallenge(unbrokenCycleFznModels.at(i));
   }
 }
-TEST_F(MznChallenge, DISABLED_unsatAllEqual) {
-  for (size_t i = 0; i < unsatAllEqualFznModels.size(); ++i) {
-    logModelName(unsatAllEqualFznModels.at(i), false, i,
-                 unsatAllEqualFznModels.size());
-    testChallenge(unsatAllEqualFznModels.at(i));
+TEST_F(MznChallenge, DISABLED_expectedUnsat) {
+  for (size_t i = 0; i < expectedUnsatFznModels.size(); ++i) {
+    logModelName(expectedUnsatFznModels.at(i), false, i,
+                 expectedUnsatFznModels.size());
+    EXPECT_THROW(testChallenge(expectedUnsatFznModels.at(i)), InconsistencyException);
   }
 }
 TEST_F(MznChallenge, DISABLED_failing) {


### PR DESCRIPTION
There was a bug in the SCC finding in the InvariantGraph class when breaking static cycles.


Additonally, updated variable to have an identifier. Fixed SCC finding in the InvariantGraph class