### PR TITLE
fixed bug in gcc when multiple outputs were fixed to the same value

### DIFF
--- a/include/atlantis/invariantgraph/invariantGraph.hpp
+++ b/include/atlantis/invariantgraph/invariantGraph.hpp
@@ -88,6 +88,8 @@ class InvariantGraph {
 
   virtual VarNodeId retrieveBoolVarNode(bool);
 
+  virtual VarNodeId retrieveBoolVarNode(bool, bool forceNewVar);
+
   virtual VarNodeId retrieveBoolVarNode(bool, const std::string&);
 
   virtual VarNodeId retrieveBoolVarNode(const std::shared_ptr<SearchDomain>&,
@@ -101,6 +103,8 @@ class InvariantGraph {
   virtual VarNodeId retrieveIntVarNode(const std::string&);
 
   virtual VarNodeId retrieveIntVarNode(Int);
+
+  virtual VarNodeId retrieveIntVarNode(Int, bool forceNewVar);
 
   virtual VarNodeId retrieveIntVarNode(Int, const std::string&);
 

--- a/src/invariantgraph/invariantGraph.cpp
+++ b/src/invariantgraph/invariantGraph.cpp
@@ -273,6 +273,18 @@ VarNodeId InvariantGraph::retrieveBoolVarNode(bool b) {
   return _boolVarNodeIndices.at(b ? 1 : 0);
 }
 
+VarNodeId InvariantGraph::retrieveBoolVarNode(bool value, bool forceNew) {
+  if (!forceNew) {
+    return retrieveBoolVarNode(value);
+  }
+  return _varNodes
+      .emplace_back(
+          nextVarNodeId(), false,
+          std::make_shared<SearchDomain>(std::vector<Int>{value ? 0 : 1}),
+          DomainType::DOM_FIXED)
+      .varNodeId();
+}
+
 VarNodeId InvariantGraph::retrieveBoolVarNode(const std::string& identifier,
                                               DomainType domainType) {
   if (!containsVarNode(identifier)) {
@@ -340,6 +352,22 @@ VarNodeId InvariantGraph::retrieveIntVarNode(Int value) {
                                 " is not fixed to " + std::to_string(value));
   }
   return _intVarNodeIndices.at(value);
+}
+
+VarNodeId InvariantGraph::retrieveIntVarNode(Int value, bool forceNew) {
+  if (!forceNew) {
+    retrieveIntVarNode(value);
+  }
+  const VarNodeId nodeId =
+      _varNodes
+          .emplace_back(nextVarNodeId(), true,
+                        std::make_shared<SearchDomain>(std::vector<Int>{value}),
+                        DomainType::DOM_FIXED)
+          .varNodeId();
+  if (!containsVarNode(value)) {
+    _intVarNodeIndices.emplace(value, nodeId);
+  }
+  return nodeId;
 }
 
 VarNodeId InvariantGraph::retrieveIntVarNode(const std::string& identifier) {
@@ -742,7 +770,7 @@ void InvariantGraph::populateRootNode() {
 }
 
 void InvariantGraph::splitMultiDefinedVars() {
-  // DO NOT empace to _varNodes while doing this kind of iteration!
+  // DO NOT emplace to _varNodes while doing this kind of iteration!
 
   size_t newSize = 0;
   for (const auto& vNode : _varNodes) {

--- a/src/invariantgraph/invariantNode.cpp
+++ b/src/invariantgraph/invariantNode.cpp
@@ -262,21 +262,27 @@ InvariantNode::splitOutputVarNodes() {
   std::vector<std::pair<VarNodeId, VarNodeId>> replaced;
   replaced.reserve(_outputVarNodeIds.size());
   for (size_t i = 0; i < _outputVarNodeIds.size(); ++i) {
-    VarNode& iNode = _invariantGraph.varNode(_outputVarNodeIds[i]);
-    if (iNode.isFixed()) {
-      continue;
-    }
+    VarNode& varNode = _invariantGraph.varNode(_outputVarNodeIds[i]);
     for (size_t j = i + 1; j < _outputVarNodeIds.size(); ++j) {
-      const VarNode& jNode = _invariantGraph.varNodeConst(_outputVarNodeIds[j]);
-      if (jNode.isFixed()) {
+      if (_outputVarNodeIds[i] != _outputVarNodeIds[j]) {
         continue;
       }
-      if (_outputVarNodeIds[i] == _outputVarNodeIds[j]) {
+      if (varNode.isFixed()) {
+        if (varNode.isIntVar()) {
+          _outputVarNodeIds[j] =
+              _invariantGraph.retrieveIntVarNode(varNode.lowerBound(), true);
+        } else {
+          _outputVarNodeIds[j] = _invariantGraph.retrieveBoolVarNode(
+              varNode.inDomain(bool{true}), true);
+        }
+      } else if (varNode.isIntVar()) {
         _outputVarNodeIds[j] = _invariantGraph.retrieveIntVarNode(
-            iNode.domain(), iNode.domainType());
-        _invariantGraph.varNode(_outputVarNodeIds[j]).markOutputTo(_id);
-        replaced.emplace_back(_outputVarNodeIds[i], _outputVarNodeIds[j]);
+            varNode.domain(), varNode.domainType());
+      } else {
+        _outputVarNodeIds[j] = _invariantGraph.retrieveBoolVarNode();
       }
+      _invariantGraph.varNode(_outputVarNodeIds[j]).markOutputTo(_id);
+      replaced.emplace_back(_outputVarNodeIds[i], _outputVarNodeIds[j]);
     }
   }
   return replaced;

--- a/src/invariantgraph/invariantNodes/globalCardinalityNode.cpp
+++ b/src/invariantgraph/invariantNodes/globalCardinalityNode.cpp
@@ -51,7 +51,9 @@ void GlobalCardinalityNode::updateState() {
   // that are defined multiple times:
   std::vector<std::pair<VarNodeId, VarNodeId>> replacedOutputs =
       splitOutputVarNodes();
-  for (const auto& [oldVarNodeId, newVarNodeId] : replacedOutputs) {
+  while (!replacedOutputs.empty()) {
+    const auto [oldVarNodeId, newVarNodeId] = replacedOutputs.front();
+    assert(oldVarNodeId != newVarNodeId);
     assert(invariantGraph()
                .varNodeConst(oldVarNodeId)
                .definingNodes()
@@ -60,8 +62,24 @@ void GlobalCardinalityNode::updateState() {
                .varNodeConst(newVarNodeId)
                .definingNodes()
                .contains(id()));
-    invariantGraph().addInvariantNode(std::make_shared<IntAllEqualNode>(
-        invariantGraph(), oldVarNodeId, newVarNodeId, true, true));
+    std::vector<VarNodeId> duplicates;
+    duplicates.reserve(2 * replacedOutputs.size());
+    duplicates.emplace_back(oldVarNodeId);
+    duplicates.emplace_back(newVarNodeId);
+    for (size_t i = replacedOutputs.size() - 1; i > 0; i--) {
+      if (replacedOutputs[i].first != oldVarNodeId) {
+        continue;
+      }
+      duplicates.emplace_back(replacedOutputs[i].second);
+      std::swap(replacedOutputs[i], replacedOutputs.back());
+      replacedOutputs.pop_back();
+    }
+    std::swap(replacedOutputs.front(), replacedOutputs.back());
+    replacedOutputs.pop_back();
+    if (!invariantGraphConst().varNodeConst(oldVarNodeId).isFixed()) {
+      invariantGraph().addInvariantNode(std::make_shared<IntAllEqualNode>(
+          invariantGraph(), std::move(duplicates), true, true));
+    }
   }
   for (Int i = 0; i < static_cast<Int>(_cover.size()); i++) {
     for (Int j = static_cast<Int>(_cover.size()) - 1; j > i; --j) {
@@ -197,27 +215,12 @@ bool GlobalCardinalityNode::replace() {
 
 void GlobalCardinalityNode::registerOutputVars() {
   for (size_t i = 0; i < _cover.size(); ++i) {
-    const bool isDuplicate = std::ranges::any_of(
+    assert(std::ranges::none_of(
         outputVarNodeIds().begin(),
         outputVarNodeIds().begin() + static_cast<Int>(i),
-        [&](const VarNodeId vId) { return vId == outputVarNodeIds().at(i); });
+        [&](const VarNodeId vId) { return vId == outputVarNodeIds().at(i); }));
 
-    assert(
-        !isDuplicate ||
-        invariantGraphConst().varNodeConst(outputVarNodeIds().at(i)).isFixed());
-
-    if (isDuplicate) {
-      assert(invariantGraphConst()
-                 .varNodeConst(outputVarNodeIds().at(i))
-                 .varId() != propagation::NULL_ID);
-      _intermediate.at(i) = solver().makeIntVar(0, 0, 0);
-      solver().makeIntView<propagation::EqualConst>(
-          solver(), _intermediate.at(i),
-          invariantGraphConst()
-                  .varNodeConst(outputVarNodeIds().at(i))
-                  .lowerBound() -
-              _countOffsets[i]);
-    } else if (_countOffsets[i] == 0) {
+    if (_countOffsets[i] == 0) {
       assert(invariantGraphConst()
                  .varNodeConst(outputVarNodeIds().at(i))
                  .varId() == propagation::NULL_ID);

--- a/src/propagation/invariants/globalCardinalityOpen.cpp
+++ b/src/propagation/invariants/globalCardinalityOpen.cpp
@@ -126,8 +126,8 @@ void GlobalCardinalityOpen::notifyCurrentInputChanged(Timestamp timestamp) {
 void GlobalCardinalityOpen::commit(Timestamp timestamp) {
   Invariant::commit(timestamp);
 
-  for (CommittableInt& CommittableInt : _counts) {
-    CommittableInt.commitIf(timestamp);
+  for (CommittableInt& count : _counts) {
+    count.commitIf(timestamp);
   }
 }
 }  // namespace atlantis::propagation


### PR DESCRIPTION
For any invariant with multiple output variables (only GCC for now), each output variable requires a unique variable node in the invariant graph, even if they are fixed.

For this bug, if _n_ fixed output variables of GCC take the same value, then there are no domain constraints posted for _n -1_ of them.