### PR TITLE
Fix/revert topo ordering

### DIFF
--- a/include/atlantis/propagation/propagation/propagationGraph.hpp
+++ b/include/atlantis/propagation/propagation/propagationGraph.hpp
@@ -16,20 +16,13 @@ class PropagationGraph {
   struct ListeningInvariantData {
     InvariantId invariantId;
     LocalId localId;
-    // Dynamic/static status for this listening edge. localId values are not
-    // unique across an invariant's registered inputs.
-    bool isDynamicInput;
     ListeningInvariantData(const ListeningInvariantData& other) = default;
     ListeningInvariantData(const InvariantId t_invariantId,
-                           const LocalId t_localId,
-                           bool t_isDynamicInput)
-        : invariantId(t_invariantId),
-          localId(t_localId),
-          isDynamicInput(t_isDynamicInput) {}
+                           const LocalId t_localId)
+        : invariantId(t_invariantId), localId(t_localId) {}
     ListeningInvariantData& operator=(ListeningInvariantData&& other) noexcept {
       invariantId = other.invariantId;
       localId = other.localId;
-      isDynamicInput = other.isDynamicInput;
       return *this;
     }
   };
@@ -254,12 +247,6 @@ class PropagationGraph {
     return _topologicalNumber.at(
         _varsDefinedByInvariant.at(invariantId).front());
   }
-
-  // Returns true for a currently inactive same-layer input in a dynamic SCC.
-  [[nodiscard]] bool shouldIgnoreInputForOrdering(Timestamp ts,
-                                                  InvariantId invariantId,
-                                                  VarId inputId,
-                                                  bool isDynamicInput) const;
 
   void enqueuePropagationQueue(VarId id) { _propagationQueue.push(id); }
 };

--- a/src/propagation/invariants/linear.cpp
+++ b/src/propagation/invariants/linear.cpp
@@ -72,7 +72,12 @@ void Linear::recompute(Timestamp ts) {
 
 void Linear::notifyInputChanged(Timestamp ts, LocalId id) {
   assert(id < _varArray.size());
-  recompute(ts);
+  const Int committedValue = _solver.committedValue(_varArray[id]);
+  const Int newValue = _solver.value(ts, _varArray[id]);
+  if (newValue == committedValue) {
+    return;
+  }
+  incValue(ts, _output, _coeffs[id] * (newValue - committedValue));
 }
 
 VarViewId Linear::nextInput(Timestamp ts) {

--- a/src/propagation/invariants/linear.cpp
+++ b/src/propagation/invariants/linear.cpp
@@ -77,6 +77,24 @@ void Linear::notifyInputChanged(Timestamp ts, LocalId id) {
   if (newValue == committedValue) {
     return;
   }
+  assert([&]() {
+    Int diff;
+    return !overflow::subOverflow(newValue, committedValue, &diff);
+  }());
+
+  assert([&]() {
+    const Int diff = overflow::saturatingSub(newValue, committedValue);
+    Int prod;
+    return !overflow::mulOverflow(_coeffs.at(id), diff, &prod);
+  }());
+
+  assert([&]() {
+    const Int diff = overflow::saturatingSub(newValue, committedValue);
+    const Int prod = overflow::saturatingMul(_coeffs.at(id), diff);
+    Int sum;
+    return !overflow::addOverflow(_solver.value(ts, _output), prod, &sum);
+  }());
+
   incValue(ts, _output, _coeffs[id] * (newValue - committedValue));
 }
 

--- a/src/propagation/propagation/propagationGraph.cpp
+++ b/src/propagation/propagation/propagationGraph.cpp
@@ -87,13 +87,9 @@ static std::vector<std::vector<VarId>> SCC(const PropagationGraph& graph) {
 static void partitionIntoLayersUtil(
     const PropagationGraph& graph,
     const std::vector<std::vector<VarId>>& components, VarId varId,
-    const std::vector<size_t>& componentOfVar, std::vector<bool>& visiting,
-    std::vector<bool>& assigned, std::vector<VarId>& layerOfVar,
-    std::vector<bool>& layerHasSCC) {
-  if (assigned[varId]) {
-    return;
-  }
-  visiting[varId] = true;
+    const std::vector<size_t>& componentOfVar, std::vector<bool>& visited,
+    std::vector<VarId>& layerOfVar, std::vector<bool>& layerHasSCC) {
+  visited[varId] = true;
   const InvariantId defInv = graph.definingInvariant(varId);
   if (defInv == NULL_ID) {
     // varId is a search variable, put into layer 0:
@@ -103,18 +99,16 @@ static void partitionIntoLayersUtil(
       layerHasSCC.emplace_back(false);
     }
     assert(!layerHasSCC[0]);
-    assigned[varId] = true;
-    visiting[varId] = false;
     return;
   }
 
   if (componentOfVar[varId] >= components.size()) {
     // varId is not in an SCC:
     for (const VarId inputId : std::views::keys(graph.inputVars(defInv))) {
-      assert(!visiting[inputId]);
-      if (!assigned[inputId]) {
+      if (!visited[inputId]) {
+        visited[inputId] = true;
         partitionIntoLayersUtil(graph, components, inputId, componentOfVar,
-                                visiting, assigned, layerOfVar, layerHasSCC);
+                                visited, layerOfVar, layerHasSCC);
       }
       assert(layerOfVar[inputId] < layerHasSCC.size());
       layerOfVar[varId] = std::max(
@@ -135,22 +129,18 @@ static void partitionIntoLayersUtil(
         }
       }
     }
-    assigned[varId] = true;
-    visiting[varId] = false;
   } else {
     // varId is in an SCC:
     const size_t comp = componentOfVar[varId];
     for (const VarId cVarId : components[comp]) {
-      visiting[cVarId] = true;
-      const InvariantId cDefInv = graph.definingInvariant(cVarId);
-      assert(cDefInv != NULL_ID);
-      for (const VarId inputId : std::views::keys(graph.inputVars(cDefInv))) {
+      visited[cVarId] = true;
+      assert(graph.definingInvariant(cVarId) != NULL_ID);
+      for (const VarId inputId : std::views::keys(graph.inputVars(defInv))) {
         if (componentOfVar[inputId] != comp) {
-          assert(!visiting[inputId]);
-          if (!assigned[inputId]) {
+          if (!visited[inputId]) {
+            visited[inputId] = true;
             partitionIntoLayersUtil(graph, components, inputId, componentOfVar,
-                                    visiting, assigned, layerOfVar,
-                                    layerHasSCC);
+                                    visited, layerOfVar, layerHasSCC);
           }
           assert(layerOfVar[inputId] < layerHasSCC.size());
           // update layer of varId. The layer of the component will be updated
@@ -177,8 +167,6 @@ static void partitionIntoLayersUtil(
     // update the layer of the remaining variables in the SCC:
     for (const VarId cVarId : components[comp]) {
       layerOfVar[cVarId] = layerOfVar[varId];
-      assigned[cVarId] = true;
-      visiting[cVarId] = false;
     }
   }
 }
@@ -197,20 +185,19 @@ static std::vector<bool> partitionIntoLayersUsingSCC(
       componentOfVar[varId] = c;
     }
   }
-  std::vector<bool> visiting(graph.numVars(), false);
-  std::vector<bool> assigned(graph.numVars(), false);
+  std::vector<bool> visited(graph.numVars(), false);
   std::vector<bool> layerHasSCC;
   layerHasSCC.reserve(components.size() * 2);
 
   for (const VarId evalVarId : graph.evaluationVars()) {
     partitionIntoLayersUtil(graph, components, evalVarId, componentOfVar,
-                            visiting, assigned, layerOfVar, layerHasSCC);
+                            visited, layerOfVar, layerHasSCC);
   }
   for (Int c = static_cast<Int>(components.size()) - 1; c >= 0; --c) {
     for (const VarId varId : components[c]) {
-      if (!assigned[varId]) {
+      if (!visited[varId]) {
         partitionIntoLayersUtil(graph, components, varId, componentOfVar,
-                                visiting, assigned, layerOfVar, layerHasSCC);
+                                visited, layerOfVar, layerHasSCC);
       }
     }
   }
@@ -282,46 +269,6 @@ static bool hasUndeterminableDynamicCycle(
         }
       }
     }
-  }
-  return false;
-}
-
-bool PropagationGraph::shouldIgnoreInputForOrdering(
-    Timestamp ts, InvariantId invariantId, VarId inputId,
-    bool isDynamicInput) const {
-  // Same-layer inactive inputs in a dynamic SCC are excluded from both
-  // topological ordering and propagation.
-  if (inputId == NULL_ID) {
-    return false;
-  }
-  const size_t layer = invariantLayer(invariantId);
-  const bool isDynInv = hasDynamicCycle(layer) && isDynamicInvariant(invariantId);
-  if (!isDynInv || _varLayerIndex[inputId].layer != layer) {
-    return false;
-  }
-
-  const VarId dynInput = dynamicInputVar(ts, invariantId);
-  if (isDynamicInput && dynInput != inputId) {
-    return true;
-  }
-
-  const bool staticInputsPrevious =
-      std::ranges::all_of(inputVars(invariantId),
-                          [&](const std::pair<VarId, bool>& p) {
-                            return p.first != NULL_ID &&
-                                   (p.second || _varLayerIndex[p.first].layer < layer);
-                          });
-  const bool dynamicInputsPrevious =
-      std::ranges::all_of(inputVars(invariantId),
-                          [&](const std::pair<VarId, bool>& p) {
-                            return p.first != NULL_ID &&
-                                   (!p.second || _varLayerIndex[p.first].layer < layer);
-                          });
-  if (staticInputsPrevious) {
-    return isDynamicInput && dynInput == inputId;
-  }
-  if (dynamicInputsPrevious) {
-    return !isDynamicInput;
   }
   return false;
 }
@@ -408,8 +355,7 @@ void topologicallyOrderUtil(
   const VarId dynInput = isDynInv ? graph.dynamicInputVar(ts, defInv) : NULL_ID;
   const size_t numVars = graph.numVars();
   for (const auto& [inputId, isDynamicInput] : graph.inputVars(defInv)) {
-    if (graph.shouldIgnoreInputForOrdering(ts, defInv, inputId,
-                                           isDynamicInput)) {
+    if (isDynInv && isDynamicInput && dynInput != inputId) {
       continue;
     }
     assert(inputId < varLayerIndex.size());
@@ -426,6 +372,23 @@ void topologicallyOrderUtil(
         std::max(topologicalNumber[varId], topologicalNumber[inputId] + 1);
   }
   assert(!isDynInv || dynInput == graph.dynamicInputVar(ts, defInv));
+  assert(std::ranges::all_of(
+      graph.inputVars(defInv), [&](const std::pair<VarId, bool>& p) {
+        if (p.first == NULL_ID) {
+          return false;
+        }
+        if (isDynInv && p.second) {
+          if (dynInput == p.first &&
+              topologicalNumber[p.first] >= topologicalNumber[varId]) {
+            return false;
+          }
+          return true;
+        }
+        if (topologicalNumber[p.first] >= topologicalNumber[varId]) {
+          return false;
+        }
+        return true;
+      }));
 
   inFrontier[index] = false;
 }
@@ -480,10 +443,7 @@ void PropagationGraph::registerInvariantInput(InvariantId invariantId,
       _isDynamicInvariant[invariantId] || isDynamicInput;
 
   assert(inputVarId < _listeningInvariantData.size());
-  // listeningInvariantData is keyed by input variable, so the listening edge
-  // stores its own dynamic/static status.
-  _listeningInvariantData[inputVarId].emplace_back(invariantId, localId,
-                                                   isDynamicInput);
+  _listeningInvariantData[inputVarId].emplace_back(invariantId, localId);
 
   assert(invariantId < _inputVars.size());
   _inputVars[invariantId].emplace_back(inputVarId, isDynamicInput);
@@ -709,8 +669,12 @@ void PropagationGraph::topologicallyOrder(Timestamp ts, size_t layer,
       assert(_topologicalNumber[outputId] == 0);
       continue;
     }
+    const bool isDynInv =
+        _layerHasDynamicCycle.at(layer) && isDynamicInvariant(defInv);
+
+    const VarId dynInput = isDynInv ? dynamicInputVar(ts, defInv) : NULL_ID;
     for (const auto& [inputId, isDynamicInput] : inputVars(defInv)) {
-      if (shouldIgnoreInputForOrdering(ts, defInv, inputId, isDynamicInput)) {
+      if (isDynInv && isDynamicInput && dynInput != inputId) {
         continue;
       }
       if (_topologicalNumber[inputId] >= _topologicalNumber[outputId]) {

--- a/src/propagation/solver.cpp
+++ b/src/propagation/solver.cpp
@@ -350,9 +350,9 @@ void Solver::propagate() {
         } else {
           if (_propGraph.varPosition(queuedVar) >
               _propGraph.varPosition(primaryDefinedVar)) {
-            assert(_propGraph.shouldIgnoreInputForOrdering(
-                _currentTimestamp, toNotify.invariantId, queuedVar,
-                toNotify.isDynamicInput));
+            assert(_propGraph.isDynamicInvariant(toNotify.invariantId) &&
+                   _store.dynamicInputVar(_currentTimestamp,
+                                          toNotify.invariantId) != queuedVar);
             continue;
           }
         }

--- a/test/propagation/invariants/tLinear.cpp
+++ b/test/propagation/invariants/tLinear.cpp
@@ -58,14 +58,27 @@ class LinearTest : public InvariantTest {
       }
     }
 
-    std::vector<Int> bounds{
-        std::numeric_limits<Int>::min() / (numInputVars * coeffLb),
-        std::numeric_limits<Int>::min() / (numInputVars * coeffUb),
-        std::numeric_limits<Int>::max() / (numInputVars * coeffLb),
-        std::numeric_limits<Int>::max() / (numInputVars * coeffUb)};
-    const auto [lb, ub] = std::minmax_element(bounds.begin(), bounds.end());
-    inputVarLb = std::max(inputVarLb + 1, *lb);
-    inputVarUb = std::min(inputVarUb - 1, *ub);
+    EXPECT_LE(coeffLb, 0);
+    EXPECT_GE(coeffUb, 0);
+
+    const Int range = std::min(-std::numeric_limits<Int>::max() / (2 * coeffLb * numInputVars),
+    std::numeric_limits<Int>::max() / (2 * coeffUb * numInputVars));
+    EXPECT_GE(range, 0);
+
+    const Int minLb = -(range / 2);
+    const Int maxUb = minLb + range - 1;
+
+    inputVarLb = std::max(inputVarLb, minLb);
+    inputVarUb = std::min(inputVarUb, maxUb);
+
+    EXPECT_LE(inputVarLb, inputVarUb);
+
+    Int diff, res;
+    EXPECT_FALSE(overflow::subOverflow(inputVarUb, inputVarLb, &diff)) << inputVarLb << " - " << inputVarUb;
+    EXPECT_LE(diff, range);
+    EXPECT_FALSE(overflow::mulOverflow(-diff, coeffLb, &res)) << -diff << " * " << coeffLb;
+    EXPECT_FALSE(overflow::mulOverflow(diff, coeffUb, &res)) << diff << " * " << coeffUb;
+
     inputVarDist = std::uniform_int_distribution<Int>(inputVarLb, inputVarUb);
 
     inputVars.clear();

--- a/test/propagation/invariants/tLinear.cpp
+++ b/test/propagation/invariants/tLinear.cpp
@@ -59,13 +59,13 @@ class LinearTest : public InvariantTest {
     }
 
     std::vector<Int> bounds{
-        (std::numeric_limits<Int>::min() / numInputVars) / coeffLb,
-        (std::numeric_limits<Int>::min() / numInputVars) / coeffUb,
-        (std::numeric_limits<Int>::max() / numInputVars) / coeffLb,
-        (std::numeric_limits<Int>::max() / numInputVars) / coeffUb};
+        std::numeric_limits<Int>::min() / (numInputVars * coeffLb),
+        std::numeric_limits<Int>::min() / (numInputVars * coeffUb),
+        std::numeric_limits<Int>::max() / (numInputVars * coeffLb),
+        std::numeric_limits<Int>::max() / (numInputVars * coeffUb)};
     const auto [lb, ub] = std::minmax_element(bounds.begin(), bounds.end());
-    inputVarLb = std::max(inputVarLb, *lb);
-    inputVarUb = std::min(inputVarUb, *ub);
+    inputVarLb = std::max(inputVarLb + 1, *lb);
+    inputVarUb = std::min(inputVarUb - 1, *ub);
     inputVarDist = std::uniform_int_distribution<Int>(inputVarLb, inputVarUb);
 
     inputVars.clear();
@@ -305,11 +305,48 @@ RC_GTEST_FIXTURE_PROP(LinearTest, rapidcheck, ()) {
   for (size_t c = 0; c < numCommits; ++c) {
     RC_ASSERT(_solver->committedValue(outputVar) == computeOutput(true));
 
+    std::vector<std::optional<Int>> vals(numInputVars, std::nullopt);
+
     for (size_t p = 0; p <= numProbes; ++p) {
-      _solver->beginMove();
-      for (const auto& var : inputVars) {
+      Int posSum = 0;
+      Int negSum = 0;
+      bool overflow = false;
+      for (Int i = 0; i < numInputVars; ++i) {
+        Int val;
         if (randBool()) {
-          _solver->setValue(var, inputVarDist(gen));
+          val = inputVarDist(gen);
+          vals.at(i) = val;
+        } else {
+          val = _solver->committedValue(inputVars.at(i));
+        }
+        Int prod;
+        const bool mulOverflow = overflow::mulOverflow(val, coeffs.at(i), &prod);
+        overflow |= mulOverflow;
+        EXPECT_FALSE(mulOverflow);
+        if (!mulOverflow) {
+          Int sum;
+          const bool addOverflow = prod > 0 ? overflow::addOverflow(posSum, prod, &sum) : overflow::addOverflow(negSum, prod, &sum);
+          overflow |= addOverflow;
+          EXPECT_FALSE(addOverflow);
+          if (!addOverflow) {
+            if (prod > 0) {
+              posSum = sum;
+            } else {
+              negSum = sum;
+            }
+          }
+        }
+        EXPECT_FALSE(overflow);
+      }
+
+      if (overflow) {
+        continue;
+      }
+
+      _solver->beginMove();
+      for (Int i = 0; i < numInputVars; ++i) {
+        if (vals.at(i).has_value()) {
+          _solver->setValue(inputVars.at(i), *vals.at(i));
         }
       }
       _solver->endMove();


### PR DESCRIPTION
The previous PR made `Linear` non-incremental and broke the topological ordering of `InvariantGraph`