### PR TITLE
Add a black box invariant that executes an external function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,7 +199,11 @@ message("GECODE_VERSION: ${GECODE_VERSION}")
 message("GECODE_INCLUDE_DIRS: ${GECODE_INCLUDE_DIRS}")
 message("GECODE_LIBRARIES: ${GECODE_LIBRARIES}")
 message("GECODE_TARGETS: ${GECODE_TARGETS}")
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}-Wl,--copy-dt-needed-entries")
+# --copy-dt-needed-entries is a GNU ld option; Apple's ld rejects it outright,
+# which breaks the compiler checks of every sub-project.
+if(NOT APPLE)
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--copy-dt-needed-entries")
+endif()
 
 include(FetchContent)
 FetchContent_Declare(
@@ -231,6 +235,47 @@ target_include_directories(${PROJECT_LIB}
   $<BUILD_INTERFACE:${COMMON_INCLUDES}>)
 
 target_link_libraries(${PROJECT_LIB} fznparser::fznparser fmt::fmt Gecode::Driver Gecode::Int Gecode::Kernel Gecode::Minimodel Gecode::Search Gecode::Support)
+
+# The blackbox interface loads propagator libraries at run time.
+if(CMAKE_DL_LIBS)
+  target_link_libraries(${PROJECT_LIB} ${CMAKE_DL_LIBS})
+endif()
+
+# Feature detection for the executable blackbox backend. Without a usable
+# posix_spawn the exec mode falls back to blackboxProcessNone.cpp, which
+# reports that the platform is unsupported.
+if(NOT WIN32)
+  include(CheckCXXSourceCompiles)
+  check_cxx_source_compiles("
+    #include <spawn.h>
+    int main() {
+      posix_spawn_file_actions_t a;
+      posix_spawn_file_actions_init(&a);
+      posix_spawn_file_actions_addinherit_np(&a, 2);
+      return POSIX_SPAWN_CLOEXEC_DEFAULT;
+    }" ATLANTIS_POSIX_SPAWN_CLOEXEC_DEFAULT_AND_ADDINHERIT)
+  check_cxx_source_compiles("
+    #include <spawn.h>
+    int main() {
+      posix_spawn_file_actions_t a;
+      posix_spawn_file_actions_init(&a);
+      posix_spawn_file_actions_addclosefrom_np(&a, 3);
+      return 0;
+    }" ATLANTIS_POSIX_SPAWN_ADDCLOSEFROM_NP)
+
+  if(ATLANTIS_POSIX_SPAWN_CLOEXEC_DEFAULT_AND_ADDINHERIT)
+    target_compile_definitions(${PROJECT_LIB} PUBLIC
+      ATLANTIS_HAS_POSIX_BLACKBOX_EXEC
+      ATLANTIS_HAS_POSIX_SPAWN_CLOEXEC_DEFAULT
+      ATLANTIS_HAS_POSIX_SPAWN_ADDINHERIT_NP)
+  elseif(ATLANTIS_POSIX_SPAWN_ADDCLOSEFROM_NP)
+    target_compile_definitions(${PROJECT_LIB} PUBLIC
+      ATLANTIS_HAS_POSIX_BLACKBOX_EXEC
+      ATLANTIS_HAS_POSIX_SPAWN_ADDCLOSEFROM_NP)
+  else()
+    message(STATUS "No suitable posix_spawn support found: executable blackbox propagators will be unavailable")
+  endif()
+endif()
 
 # Link the src library with the project
 target_link_libraries(${PROJECT_EXEC} ${PROJECT_LIB} cxxopts::cxxopts)

--- a/include/atlantis/invariantgraph/fzn/fzn_blackbox.hpp
+++ b/include/atlantis/invariantgraph/fzn/fzn_blackbox.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <fznparser/constraint.hpp>
+#include <fznparser/variables.hpp>
+#include <memory>
+
+#include "atlantis/invariantgraph/fznInvariantGraph.hpp"
+#include "atlantis/misc/blackboxFunction.hpp"
+
+namespace atlantis::invariantgraph::fzn {
+
+bool fzn_blackbox(FznInvariantGraph&,
+                  std::shared_ptr<blackbox::BlackBoxFn> blackboxFn,
+                  const std::shared_ptr<fznparser::IntVarArray>& int_in,
+                  const std::shared_ptr<fznparser::FloatVarArray>& float_in,
+                  const std::shared_ptr<fznparser::IntVarArray>& int_out,
+                  const std::shared_ptr<fznparser::FloatVarArray>& float_out);
+
+bool fzn_blackbox(FznInvariantGraph&, const fznparser::Constraint& constraint);
+
+}  // namespace atlantis::invariantgraph::fzn

--- a/include/atlantis/invariantgraph/invariantNodes/blackboxNode.hpp
+++ b/include/atlantis/invariantgraph/invariantNodes/blackboxNode.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "atlantis/invariantgraph/invariantGraph.hpp"
+#include "atlantis/invariantgraph/invariantNode.hpp"
+#include "atlantis/invariantgraph/types.hpp"
+#include "atlantis/misc/blackboxFunction.hpp"
+#include "atlantis/propagation/solverBase.hpp"
+
+namespace atlantis::invariantgraph {
+
+class BlackBoxNode : public InvariantNode {
+ private:
+  /// Shared rather than owned: the invariant graph is built once and then
+  /// constructed into one propagation solver per search thread, so every
+  /// thread's invariant refers to this same backend.
+  std::shared_ptr<blackbox::BlackBoxFn> _blackBoxFn;
+
+ public:
+  explicit BlackBoxNode(InvariantGraph&,
+                        std::shared_ptr<blackbox::BlackBoxFn> blackBoxFn,
+                        std::vector<VarNodeId>&& intIn,
+                        std::vector<VarNodeId>&& intOut);
+
+  void init(InvariantNodeId) override;
+
+  void registerOutputVars(propagation::SolverBase&,
+                          SolverMapping&) const override;
+
+  void registerNode(propagation::SolverBase&, SolverMapping&) const override;
+
+  [[nodiscard]] std::string dotLangIdentifier() const override;
+};
+
+}  // namespace atlantis::invariantgraph

--- a/include/atlantis/misc/blackboxFunction.hpp
+++ b/include/atlantis/misc/blackboxFunction.hpp
@@ -1,0 +1,125 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "atlantis/misc/blackboxProcess.hpp"
+#include "atlantis/types.hpp"
+#include "fznparser/annotation.hpp"
+
+namespace atlantis::blackbox {
+
+#ifdef _WIN32
+#define ATLANTIS_BLACKBOX_CALL __stdcall
+#else
+#define ATLANTIS_BLACKBOX_CALL
+#endif
+
+/// Abstract class implemented by the different methods of running a blackbox
+/// function.
+///
+/// A single instance is shared by every search thread, so implementations must
+/// be safe to call concurrently. They achieve this by handing each thread its
+/// own private resource (a cloned library instance or a dedicated child
+/// process) rather than by serialising the calls themselves.
+class BlackBoxFn {
+ public:
+  /// Create the backend described by a `blackbox_dll` / `blackbox_exec`
+  /// annotation.
+  static std::shared_ptr<BlackBoxFn> fromAnnotation(
+      const fznparser::Annotation&);
+
+  virtual ~BlackBoxFn() = default;
+
+  BlackBoxFn(const BlackBoxFn&) = delete;
+  BlackBoxFn& operator=(const BlackBoxFn&) = delete;
+
+  /// Evaluate the blackbox. The output vectors are sized by the caller and are
+  /// only written to by the blackbox.
+  virtual void run(const std::vector<Int>& intIn,
+                   const std::vector<double>& floatIn, std::vector<Int>& intOut,
+                   std::vector<double>& floatOut) = 0;
+
+ protected:
+  BlackBoxFn() = default;
+};
+
+/// A blackbox implemented by a dynamically loaded library.
+///
+/// The library must export `fzn_blackbox`. It may additionally export
+/// `fzn_init` to build a state object from the annotation arguments; a library
+/// that exports `fzn_init` must also export `fzn_clone`, which is used to give
+/// every search thread its own state. `fzn_free` is optional.
+class BlackBoxDLL : public BlackBoxFn {
+ public:
+  BlackBoxDLL(const std::string& name, const std::vector<std::string>& args);
+  ~BlackBoxDLL() override;
+
+  void run(const std::vector<Int>& intIn, const std::vector<double>& floatIn,
+           std::vector<Int>& intOut, std::vector<double>& floatOut) override;
+
+ private:
+  /// A library state object together with the thread that owns it.
+  struct Instance {
+    std::thread::id owner;
+    void* value;
+  };
+
+  void* _library{nullptr};
+  void*(ATLANTIS_BLACKBOX_CALL* _fznInit)(const char**, size_t){nullptr};
+  void*(ATLANTIS_BLACKBOX_CALL* _fznClone)(void*){nullptr};
+  void(ATLANTIS_BLACKBOX_CALL* _fznBlackbox)(void*, const int64_t*, size_t,
+                                             const double*, size_t, int64_t*,
+                                             size_t, double*, size_t){nullptr};
+  void(ATLANTIS_BLACKBOX_CALL* _fznFree)(void*){nullptr};
+
+  void* _rootInstance{nullptr};
+
+  /// Guards `_instances` only: the blackbox call itself runs unlocked, since
+  /// each thread has exclusive use of the instance it is handed.
+  std::mutex _mutex;
+  std::vector<Instance> _instances;
+
+  /// Return the calling thread's instance, cloning it on first use.
+  void* instance();
+};
+
+/// A blackbox implemented by a separate process, exchanging one request/response
+/// line per evaluation over its stdin/stdout.
+class BlackBoxExec : public BlackBoxFn {
+ public:
+  BlackBoxExec(std::string program, std::vector<std::string> args);
+  ~BlackBoxExec() override;
+
+  void run(const std::vector<Int>& intIn, const std::vector<double>& floatIn,
+           std::vector<Int>& intOut, std::vector<double>& floatOut) override;
+
+ private:
+  std::string _program;
+  std::vector<std::string> _args;
+
+  /// Guards `_sessions` only; `exchange` runs unlocked on the thread's own
+  /// session.
+  std::mutex _mutex;
+  std::vector<BlackBoxProcessSession*> _sessions;
+
+  /// Return the calling thread's session, spawning the process on first use.
+  BlackBoxProcessSession& session();
+};
+
+/// Encode a blackbox request: comma-separated integers, a semicolon, then
+/// comma-separated floats, terminated by a newline (e.g. "5,-7;2.5,1.125\n").
+std::string encodeBlackBoxRequest(const std::vector<Int>& intIn,
+                                  const std::vector<double>& floatIn);
+
+/// Parse a blackbox response into the (caller-sized) output vectors.
+void decodeBlackBoxResponse(const std::string& response,
+                            std::vector<Int>& intOut,
+                            std::vector<double>& floatOut);
+
+}  // namespace atlantis::blackbox

--- a/include/atlantis/misc/blackboxProcess.hpp
+++ b/include/atlantis/misc/blackboxProcess.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace atlantis::blackbox {
+
+/// Platform process session used by the executable blackbox backend.
+///
+/// A session owns exactly one child process and is owned by exactly one search
+/// thread. The backend keeps one session per thread, so `exchange` never needs
+/// to be serialised: the thread that created the session is the only one that
+/// ever talks to it.
+class BlackBoxProcessSession {
+ protected:
+  std::thread::id _owner;
+
+  BlackBoxProcessSession() : _owner(std::this_thread::get_id()) {}
+
+ public:
+  virtual ~BlackBoxProcessSession() = default;
+
+  BlackBoxProcessSession(const BlackBoxProcessSession&) = delete;
+  BlackBoxProcessSession& operator=(const BlackBoxProcessSession&) = delete;
+
+  [[nodiscard]] bool ownedByCurrentThread() const {
+    return _owner == std::this_thread::get_id();
+  }
+
+  /// Send \a request to the child process and return its response line.
+  virtual std::string exchange(const std::string& request) = 0;
+};
+
+/// Create the process implementation selected for the target platform.
+///
+/// Throws when the platform has no supported implementation.
+BlackBoxProcessSession* createBlackBoxProcess(
+    const std::string& program, const std::vector<std::string>& args);
+
+}  // namespace atlantis::blackbox

--- a/include/atlantis/propagation/invariants/blackbox.hpp
+++ b/include/atlantis/propagation/invariants/blackbox.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "atlantis/misc/blackboxFunction.hpp"
+#include "atlantis/propagation/invariants/invariant.hpp"
+#include "atlantis/propagation/solverBase.hpp"
+#include "atlantis/propagation/types.hpp"
+
+namespace atlantis::propagation {
+
+/**
+ * Invariant for outputs <- blackBoxFn(inputs)
+ *
+ * The blackbox function is shared with the equivalent invariant in every other
+ * search thread; it hands each thread its own private instance internally.
+ */
+class Blackbox : public Invariant {
+ private:
+  std::shared_ptr<blackbox::BlackBoxFn> _blackBoxFn;
+  std::vector<VarId> _outputs;
+  std::vector<VarViewId> _inputs;
+
+  // Buffers reused across invocations: recompute runs on every input change,
+  // so allocating them per call would dominate the cost of cheap blackboxes.
+  std::vector<Int> _intIn;
+  std::vector<double> _floatIn;
+  std::vector<Int> _intOut;
+  std::vector<double> _floatOut;
+
+ public:
+  Blackbox(SolverBase&, std::shared_ptr<blackbox::BlackBoxFn> blackBoxFn,
+           std::vector<VarId>&& outputs, std::vector<VarViewId>&& inputs);
+
+  void registerVars() override;
+  /// The range of a blackbox cannot be inferred, so the outputs keep the bounds
+  /// declared for them by the model.
+  void updateBounds(bool) override {}
+  void recompute(Timestamp) override;
+  void notifyInputChanged(Timestamp, LocalId) override;
+  VarViewId nextInput(Timestamp) override;
+  void notifyCurrentInputChanged(Timestamp) override;
+};
+
+}  // namespace atlantis::propagation

--- a/include/atlantis/search/neighborhoods/binaryLinLeNeighborhood.hpp
+++ b/include/atlantis/search/neighborhoods/binaryLinLeNeighborhood.hpp
@@ -33,7 +33,10 @@ class BinaryLinLeNeighborhood : public Neighborhood {
   }
 };
 
-template class BinaryLinLeNeighborhood<true>;
-template class BinaryLinLeNeighborhood<false>;
+// The explicit instantiations live at the end of binaryLinLeNeighborhood.cpp,
+// where the member definitions are visible; instantiating here would emit no
+// code for them.
+extern template class BinaryLinLeNeighborhood<true>;
+extern template class BinaryLinLeNeighborhood<false>;
 
 }  // namespace atlantis::search::neighborhoods

--- a/share/minizinc/atlantis/experimental/blackbox/fzn_blackbox.mzn
+++ b/share/minizinc/atlantis/experimental/blackbox/fzn_blackbox.mzn
@@ -1,0 +1,6 @@
+predicate fzn_blackbox(
+	array[int] of var int: int_input,
+	array[int] of var float: float_input,
+	array[int] of var int: int_output,
+	array[int] of var float: float_output
+);

--- a/src/invariantgraph/fzn/fzn_blackbox.cpp
+++ b/src/invariantgraph/fzn/fzn_blackbox.cpp
@@ -1,0 +1,74 @@
+#include "atlantis/invariantgraph/fzn/fzn_blackbox.hpp"
+
+#include <memory>
+#include <utility>
+
+#include "./fznHelper.hpp"
+#include "atlantis/exceptions/exceptions.hpp"
+#include "atlantis/invariantgraph/invariantNodes/blackboxNode.hpp"
+#include "atlantis/misc/blackboxFunction.hpp"
+#include "fznparser/annotation.hpp"
+#include "fznparser/variables.hpp"
+
+namespace atlantis::invariantgraph::fzn {
+
+bool fzn_blackbox(FznInvariantGraph& graph,
+                  std::shared_ptr<blackbox::BlackBoxFn> blackboxFn,
+                  const std::shared_ptr<fznparser::IntVarArray>& int_in,
+                  const std::shared_ptr<fznparser::FloatVarArray>& float_in,
+                  const std::shared_ptr<fznparser::IntVarArray>& int_out,
+                  const std::shared_ptr<fznparser::FloatVarArray>& float_out) {
+  if (float_in->size() > 0 || float_out->size() > 0) {
+    throw FznArgumentException(
+        "Blackbox constraint uses floating point variables, but this is "
+        "not yet supported");
+  }
+
+  graph.addInvariantNode(std::make_shared<BlackBoxNode>(
+      graph, std::move(blackboxFn), graph.retrieveVarNodes(int_in),
+      graph.retrieveVarNodes(int_out)));
+  return true;
+}
+
+bool fzn_blackbox(FznInvariantGraph& graph,
+                  const fznparser::Constraint& constraint) {
+  if (constraint.identifier() != "fzn_blackbox") {
+    return false;
+  }
+
+  FZN_CONSTRAINT_ARRAY_TYPE_CHECK(constraint, 0, fznparser::IntVarArray, true);
+  FZN_CONSTRAINT_ARRAY_TYPE_CHECK(constraint, 1, fznparser::FloatVarArray,
+                                  true);
+  FZN_CONSTRAINT_ARRAY_TYPE_CHECK(constraint, 2, fznparser::IntVarArray, true);
+  FZN_CONSTRAINT_ARRAY_TYPE_CHECK(constraint, 3, fznparser::FloatVarArray,
+                                  true);
+
+  // The annotation arguments themselves are validated by
+  // BlackBoxFn::fromAnnotation.
+  const fznparser::Annotation* methodAnn = nullptr;
+  for (const auto& ann : constraint.annotations()) {
+    if (ann.identifier() == "blackbox_dll" ||
+        ann.identifier() == "blackbox_exec") {
+      if (methodAnn != nullptr) {
+        throw FznArgumentException(
+            "Constraint " + constraint.identifier() +
+            " has multiple execution method annotations.");
+      }
+      methodAnn = &ann;
+    }
+  }
+  if (methodAnn == nullptr) {
+    throw FznArgumentException(
+        "Constraint " + constraint.identifier() +
+        " does not contain a execution method annotation.");
+  }
+
+  return fzn_blackbox(
+      graph, blackbox::BlackBoxFn::fromAnnotation(*methodAnn),
+      getArgArray<fznparser::IntVarArray>(constraint.arguments().at(0)),
+      getArgArray<fznparser::FloatVarArray>(constraint.arguments().at(1)),
+      getArgArray<fznparser::IntVarArray>(constraint.arguments().at(2)),
+      getArgArray<fznparser::FloatVarArray>(constraint.arguments().at(3)));
+}
+
+}  // namespace atlantis::invariantgraph::fzn

--- a/src/invariantgraph/fzn/int_lin_eq.cpp
+++ b/src/invariantgraph/fzn/int_lin_eq.cpp
@@ -64,7 +64,7 @@ bool int_lin_eq(FznInvariantGraph& graph, std::vector<Int>&& coeffs,
     // swapping lhs and rhs, moving the defined variable to the rhs. Then
     // reducing both lhs and rhs by all other variables, making the defined
     // variable the only variable on the rhs.
-    for (long& c : coeffs) {
+    for (Int& c : coeffs) {
       c = -c;
     }
   }  // otherwise (with definedVarCoeff = -1), add the defined variable to both

--- a/src/invariantgraph/fznInvariantGraph.cpp
+++ b/src/invariantgraph/fznInvariantGraph.cpp
@@ -30,6 +30,7 @@
 #include "atlantis/invariantgraph/fzn/bool_xor.hpp"
 #include "atlantis/invariantgraph/fzn/fzn_all_different_int.hpp"
 #include "atlantis/invariantgraph/fzn/fzn_all_equal_int.hpp"
+#include "atlantis/invariantgraph/fzn/fzn_blackbox.hpp"
 #include "atlantis/invariantgraph/fzn/fzn_circuit.hpp"
 #include "atlantis/invariantgraph/fzn/fzn_count_eq.hpp"
 #include "atlantis/invariantgraph/fzn/fzn_count_geq.hpp"
@@ -438,6 +439,7 @@ bool FznInvariantGraph::makeInvariantNode(
   MAKE_INVARIANT(fzn::bool_not)
   MAKE_INVARIANT(fzn::bool_or)
   MAKE_INVARIANT(fzn::bool_xor)
+  MAKE_INVARIANT(fzn::fzn_blackbox)
   MAKE_INVARIANT(fzn::fzn_count_eq)
   MAKE_INVARIANT(fzn::fzn_circuit)
   MAKE_INVARIANT(fzn::fzn_global_cardinality)

--- a/src/invariantgraph/invariantNodes/blackboxNode.cpp
+++ b/src/invariantgraph/invariantNodes/blackboxNode.cpp
@@ -1,0 +1,76 @@
+#include "atlantis/invariantgraph/invariantNodes/blackboxNode.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <iterator>
+#include <utility>
+
+#include "atlantis/invariantgraph/varNode.hpp"
+#include "atlantis/misc/blackboxFunction.hpp"
+#include "atlantis/propagation/invariants/blackbox.hpp"
+
+namespace atlantis::invariantgraph {
+
+BlackBoxNode::BlackBoxNode(InvariantGraph& graph,
+                           std::shared_ptr<blackbox::BlackBoxFn> blackBoxFn,
+                           std::vector<VarNodeId>&& intIn,
+                           std::vector<VarNodeId>&& intOut)
+    : InvariantNode(graph, std::move(intOut), std::move(intIn)),
+      _blackBoxFn(std::move(blackBoxFn)) {}
+
+void BlackBoxNode::init(const InvariantNodeId id) {
+  InvariantNode::init(id);
+  assert(std::ranges::all_of(
+      outputVarNodeIds().begin(), outputVarNodeIds().end(),
+      [&](const VarNodeId vId) {
+        return invariantGraphConst().varNodeConst(vId).isIntVar();
+      }));
+  assert(std::ranges::all_of(
+      staticInputVarNodeIds().begin(), staticInputVarNodeIds().end(),
+      [&](const VarNodeId vId) {
+        return invariantGraphConst().varNodeConst(vId).isIntVar();
+      }));
+}
+
+void BlackBoxNode::registerOutputVars(propagation::SolverBase& solver,
+                                      SolverMapping& mapping) const {
+  for (const auto& outputVarNodeId : outputVarNodeIds()) {
+    makeSolverVar(outputVarNodeId, solver, mapping);
+  }
+  assert(std::ranges::all_of(outputVarNodeIds().begin(),
+                             outputVarNodeIds().end(),
+                             [&](const VarNodeId vId) {
+                               return mapping.solverId(vId) !=
+                                      propagation::NULL_ID;
+                             }));
+}
+
+void BlackBoxNode::registerNode(propagation::SolverBase& solver,
+                                SolverMapping& mapping) const {
+  std::vector<propagation::VarViewId> inputVarIds;
+  inputVarIds.reserve(staticInputVarNodeIds().size());
+  std::ranges::transform(staticInputVarNodeIds(),
+                         std::back_inserter(inputVarIds),
+                         [&](const VarNodeId varNodeId) {
+                           assert(mapping.solverId(varNodeId) !=
+                                  propagation::NULL_ID);
+                           return mapping.solverId(varNodeId);
+                         });
+
+  std::vector<propagation::VarId> outputVarIds;
+  outputVarIds.reserve(outputVarNodeIds().size());
+  std::ranges::transform(outputVarNodeIds(), std::back_inserter(outputVarIds),
+                         [&](const VarNodeId varNodeId) {
+                           const propagation::VarViewId id =
+                               mapping.solverId(varNodeId);
+                           assert(id.isVar());
+                           return propagation::VarId{static_cast<size_t>(id)};
+                         });
+
+  solver.makeInvariant<propagation::Blackbox>(
+      solver, _blackBoxFn, std::move(outputVarIds), std::move(inputVarIds));
+}
+
+std::string BlackBoxNode::dotLangIdentifier() const { return "blackbox"; }
+
+}  // namespace atlantis::invariantgraph

--- a/src/invariantgraph/violationInvariantNodes/boolLinRelNode.cpp
+++ b/src/invariantgraph/violationInvariantNodes/boolLinRelNode.cpp
@@ -158,7 +158,7 @@ void BoolLinRelNode::updateState() {
       setState(InvariantNodeState::SUBSUMED);
       return;
     }
-    for (long& coeff : _coeffs) {
+    for (Int& coeff : _coeffs) {
       coeff /= c;
     }
     _rhs /= c;

--- a/src/invariantgraph/violationInvariantNodes/intLinRelNode.cpp
+++ b/src/invariantgraph/violationInvariantNodes/intLinRelNode.cpp
@@ -157,7 +157,7 @@ void IntLinRelNode::updateState() {
       setState(InvariantNodeState::SUBSUMED);
       return;
     }
-    for (long& coeff : _coeffs) {
+    for (Int& coeff : _coeffs) {
       coeff /= c;
     }
     _rhs /= c;

--- a/src/misc/blackboxFunction.cpp
+++ b/src/misc/blackboxFunction.cpp
@@ -1,0 +1,484 @@
+#include "atlantis/misc/blackboxFunction.hpp"
+
+#include <charconv>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <locale>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#ifdef _WIN32
+#define NOMINMAX  // Ensure the words min/max remain available
+#include <Windows.h>
+#else
+#include <dlfcn.h>
+#endif
+
+namespace atlantis::blackbox {
+
+namespace {
+
+/// fznparser hands string annotation arguments back with their quotes still
+/// attached; strip them, but only when they really are there.
+std::string stripQuotes(const std::string& s) {
+  if ((s.size() >= 2) && (s.front() == '"') && (s.back() == '"')) {
+    return s.substr(1, s.size() - 2);
+  }
+  return s;
+}
+
+/// A blackbox may only return finite floats inside the representable range.
+/// The byte copy through `volatile` keeps the bit test from being folded away
+/// by optimisers that assume NaN cannot occur.
+void checkFloat(double v, size_t i) {
+  static_assert(sizeof(double) == sizeof(std::uint64_t) &&
+                    std::numeric_limits<double>::is_iec559,
+                "blackbox floats must use IEEE-754 binary64");
+  std::uint64_t bits = 0;
+  const volatile unsigned char* raw =
+      reinterpret_cast<const volatile unsigned char*>(&v);
+  auto* target = reinterpret_cast<unsigned char*>(&bits);
+  for (size_t j = 0; j < sizeof(bits); ++j) {
+    target[j] = raw[j];
+  }
+  if ((bits & UINT64_C(0x7ff0000000000000)) == UINT64_C(0x7ff0000000000000)) {
+    throw std::runtime_error("BlackBox: blackbox output float " +
+                             std::to_string(i) + " is not a finite value");
+  }
+}
+
+#ifdef _WIN32
+
+void* openLibrary(const std::string& name, std::string& loadError) {
+  // Try the name as given, then the usual decorations.
+  std::vector<std::string> candidates{name};
+  if (name.size() < 4 ||
+      _stricmp(name.c_str() + name.size() - 4, ".dll") != 0) {
+    candidates.push_back(name + ".dll");
+  }
+  const size_t separator = name.find_last_of("\\/");
+  const std::string directory =
+      separator == std::string::npos ? "" : name.substr(0, separator + 1);
+  const std::string basename =
+      separator == std::string::npos ? name : name.substr(separator + 1);
+  if (basename.compare(0, 3, "lib") != 0) {
+    std::string prefixed = directory + "lib" + basename;
+    if (prefixed.size() < 4 ||
+        _stricmp(prefixed.c_str() + prefixed.size() - 4, ".dll") != 0) {
+      prefixed += ".dll";
+    }
+    candidates.push_back(prefixed);
+  }
+
+  DWORD err = ERROR_FILE_NOT_FOUND;
+  std::string failed = name;
+  for (const std::string& candidate : candidates) {
+    HMODULE handle = LoadLibraryA(candidate.c_str());
+    if (handle != nullptr) {
+      return reinterpret_cast<void*>(handle);
+    }
+    failed = candidate;
+    err = GetLastError();
+  }
+  loadError = "unable to locate library `" + name + "' (LoadLibrary failed for `" +
+              failed + "', Windows error " + std::to_string(err) + ")";
+  return nullptr;
+}
+
+void closeLibrary(void* library) {
+  if (library != nullptr) {
+    FreeLibrary(static_cast<HMODULE>(library));
+  }
+}
+
+/// Look up \a name, falling back to the 32-bit x86 stdcall decorations.
+template <class T>
+T librarySymbol(void* library, const char* name, unsigned int stdcallBytes) {
+  FARPROC symbol = GetProcAddress(static_cast<HMODULE>(library), name);
+#if defined(_M_IX86) || defined(__i386__)
+  if (symbol == nullptr) {
+    const std::string decorated =
+        std::string("_") + name + "@" + std::to_string(stdcallBytes);
+    symbol = GetProcAddress(static_cast<HMODULE>(library), decorated.c_str());
+  }
+  if (symbol == nullptr) {
+    const std::string decorated =
+        std::string(name) + "@" + std::to_string(stdcallBytes);
+    symbol = GetProcAddress(static_cast<HMODULE>(library), decorated.c_str());
+  }
+#else
+  (void)stdcallBytes;
+#endif
+  return reinterpret_cast<T>(symbol);
+}
+
+#else
+
+void* openLibrary(const std::string& name, std::string& loadError) {
+  void* loaded = dlopen(name.c_str(), RTLD_LAZY);
+  if (loaded == nullptr) {
+    const char* err = dlerror();
+    loadError = err == nullptr ? "unable to open library" : err;
+    loaded = dlopen((name + ".so").c_str(), RTLD_NOW);
+  }
+  if (loaded == nullptr) {
+    loaded = dlopen(("lib" + name + ".so").c_str(), RTLD_NOW);
+  }
+#ifdef __APPLE__
+  if (loaded == nullptr) {
+    loaded = dlopen((name + ".dylib").c_str(), RTLD_NOW);
+  }
+  if (loaded == nullptr) {
+    loaded = dlopen(("lib" + name + ".dylib").c_str(), RTLD_NOW);
+  }
+#endif
+  return loaded;
+}
+
+void closeLibrary(void* library) {
+  if (library != nullptr) {
+    dlclose(library);
+  }
+}
+
+template <class T>
+T librarySymbol(void* library, const char* name, unsigned int) {
+  T symbol = nullptr;
+  // Avoids the object->function pointer cast warning.
+  *reinterpret_cast<void**>(&symbol) = dlsym(library, name);
+  return symbol;
+}
+
+#endif
+
+}  // namespace
+
+std::shared_ptr<BlackBoxFn> BlackBoxFn::fromAnnotation(
+    const fznparser::Annotation& ann) {
+  if (ann.expressions().empty() || ann.expressions().front().empty()) {
+    throw std::runtime_error("BlackBox: annotation " + ann.identifier() +
+                             " is missing its target argument");
+  }
+  if (!std::holds_alternative<std::string>(ann.expressions().front().front())) {
+    throw std::runtime_error("BlackBox: annotation " + ann.identifier() +
+                             " expects a string as its first argument");
+  }
+  const std::string target =
+      stripQuotes(std::get<std::string>(ann.expressions().front().front()));
+
+  // The second argument, when present, is the argument array passed on to the
+  // blackbox (`blackbox_dll("lib.so", ["-v"])`).
+  std::vector<std::string> args;
+  if (ann.expressions().size() > 1) {
+    for (const auto& expr : ann.expressions()[1]) {
+      if (!std::holds_alternative<std::string>(expr)) {
+        throw std::runtime_error(
+            "BlackBox: annotation " + ann.identifier() +
+            " expects an array of strings as its second argument");
+      }
+      args.push_back(stripQuotes(std::get<std::string>(expr)));
+    }
+  }
+
+  if (ann.identifier() == "blackbox_dll") {
+    return std::make_shared<BlackBoxDLL>(target, args);
+  }
+  if (ann.identifier() == "blackbox_exec") {
+    return std::make_shared<BlackBoxExec>(target, std::move(args));
+  }
+  throw std::runtime_error("BlackBox: unknown blackbox annotation `" +
+                           ann.identifier() + "'");
+}
+
+BlackBoxDLL::BlackBoxDLL(const std::string& name,
+                         const std::vector<std::string>& args) {
+  std::string loadError;
+  void* loaded = openLibrary(name, loadError);
+  if (loaded == nullptr) {
+    throw std::runtime_error("BlackBox: unable to open dynamic library: " +
+                             loadError);
+  }
+
+  bool rootInitialized = false;
+  try {
+    // The stdcall byte counts are the 32-bit x86 argument stack sizes.
+    _fznBlackbox = librarySymbol<decltype(_fznBlackbox)>(
+        loaded, "fzn_blackbox", 36);
+    if (_fznBlackbox == nullptr) {
+      throw std::runtime_error(
+          "BlackBox: unable to find symbol `fzn_blackbox' in dynamic library `" +
+          name + "'");
+    }
+    _fznInit = librarySymbol<decltype(_fznInit)>(loaded, "fzn_init", 8);
+    _fznClone = librarySymbol<decltype(_fznClone)>(loaded, "fzn_clone", 4);
+    _fznFree = librarySymbol<decltype(_fznFree)>(loaded, "fzn_free", 4);
+
+    if ((_fznInit != nullptr) && (_fznClone == nullptr)) {
+      throw std::runtime_error(
+          "BlackBox: dynamic library `" + name +
+          "' exports `fzn_init' but not `fzn_clone'");
+    }
+
+    if (_fznInit != nullptr) {
+      std::vector<const char*> argv;
+      argv.reserve(args.size());
+      for (const std::string& arg : args) {
+        argv.push_back(arg.c_str());
+      }
+      _rootInstance = _fznInit(argv.data(), argv.size());
+      rootInitialized = true;
+    }
+    // Only claim ownership once the library is fully usable, so the destructor
+    // cannot double-free a partially constructed object.
+    _library = loaded;
+  } catch (...) {
+    if (rootInitialized && (_fznFree != nullptr)) {
+      try {
+        _fznFree(_rootInstance);
+      } catch (...) {
+      }
+    }
+    closeLibrary(loaded);
+    throw;
+  }
+}
+
+BlackBoxDLL::~BlackBoxDLL() {
+  if ((_fznInit != nullptr) && (_fznFree != nullptr)) {
+    for (const Instance& instance : _instances) {
+      try {
+        _fznFree(instance.value);
+      } catch (...) {
+      }
+    }
+    try {
+      _fznFree(_rootInstance);
+    } catch (...) {
+    }
+  }
+  closeLibrary(_library);
+}
+
+void* BlackBoxDLL::instance() {
+  const std::thread::id owner = std::this_thread::get_id();
+  const std::lock_guard lock(_mutex);
+  // Each live thread has exclusive access to its selected instance.
+  for (const Instance& instance : _instances) {
+    if (instance.owner == owner) {
+      return instance.value;
+    }
+  }
+  void* value = _fznClone(_rootInstance);
+  try {
+    _instances.push_back(Instance{owner, value});
+  } catch (...) {
+    if (_fznFree != nullptr) {
+      try {
+        _fznFree(value);
+      } catch (...) {
+      }
+    }
+    throw;
+  }
+  return value;
+}
+
+void BlackBoxDLL::run(const std::vector<Int>& intIn,
+                      const std::vector<double>& floatIn,
+                      std::vector<Int>& intOut, std::vector<double>& floatOut) {
+  static_assert(std::is_same_v<Int, int64_t>,
+                "the blackbox ABI passes atlantis::Int as int64_t");
+
+  // A library without `fzn_init` carries no state and is assumed reentrant, so
+  // it needs no per-thread instance and no locking at all.
+  void* state = _fznInit != nullptr ? instance() : nullptr;
+
+  _fznBlackbox(state, intIn.data(), intIn.size(), floatIn.data(),
+               floatIn.size(), intOut.data(), intOut.size(), floatOut.data(),
+               floatOut.size());
+
+  for (size_t i = 0; i < floatOut.size(); ++i) {
+    checkFloat(floatOut[i], i);
+  }
+}
+
+BlackBoxExec::BlackBoxExec(std::string program, std::vector<std::string> args)
+    : _program(std::move(program)), _args(std::move(args)) {}
+
+BlackBoxExec::~BlackBoxExec() {
+  const std::lock_guard lock(_mutex);
+  for (BlackBoxProcessSession* s : _sessions) {
+    delete s;
+  }
+  _sessions.clear();
+}
+
+BlackBoxProcessSession& BlackBoxExec::session() {
+  const std::lock_guard lock(_mutex);
+  for (BlackBoxProcessSession* s : _sessions) {
+    if (s->ownedByCurrentThread()) {
+      return *s;
+    }
+  }
+  std::unique_ptr<BlackBoxProcessSession> s(
+      createBlackBoxProcess(_program, _args));
+  BlackBoxProcessSession* r = s.get();
+  _sessions.push_back(r);
+  s.release();
+  return *r;
+}
+
+void BlackBoxExec::run(const std::vector<Int>& intIn,
+                       const std::vector<double>& floatIn,
+                       std::vector<Int>& intOut,
+                       std::vector<double>& floatOut) {
+  const std::string response =
+      session().exchange(encodeBlackBoxRequest(intIn, floatIn));
+  decodeBlackBoxResponse(response, intOut, floatOut);
+}
+
+std::string encodeBlackBoxRequest(const std::vector<Int>& intIn,
+                                  const std::vector<double>& floatIn) {
+  std::ostringstream out;
+  out.imbue(std::locale::classic());
+  out.precision(std::numeric_limits<double>::max_digits10);
+  for (size_t i = 0; i < intIn.size(); ++i) {
+    if (i != 0) {
+      out << ",";
+    }
+    out << intIn[i];
+  }
+  out << ";";
+  for (size_t i = 0; i < floatIn.size(); ++i) {
+    if (i != 0) {
+      out << ",";
+    }
+    out << floatIn[i];
+  }
+  out << "\n";
+  return out.str();
+}
+
+void decodeBlackBoxResponse(const std::string& response,
+                            std::vector<Int>& intOut,
+                            std::vector<double>& floatOut) {
+  if (response.find('\0') != std::string::npos) {
+    throw std::runtime_error(
+        "BlackBoxExec: blackbox process response contains NUL data");
+  }
+  // Parse the response in a single left-to-right pass.
+  const char* p = response.c_str();
+  auto skipWs = [](const char*& q) {
+    while (*q == ' ' || *q == '\t' || *q == '\r') {
+      ++q;
+    }
+  };
+  auto skipFinalWs = [](const char*& q) {
+    while (*q == ' ' || *q == '\t' || *q == '\r' || *q == '\n') {
+      ++q;
+    }
+  };
+  auto valueEnd = [](const char* q) {
+    while (*q != ',' && *q != ';' && *q != '\n' && *q != '\0') {
+      ++q;
+    }
+    return q;
+  };
+  auto checkIntegerTail = [](const char* q, const char* end) {
+    while (q != end) {
+      if (*q != ' ' && *q != '\t' && *q != '\r') {
+        return false;
+      }
+      ++q;
+    }
+    return true;
+  };
+  auto checkNumberTail = [](std::istringstream& in) {
+    char c = 0;
+    while (in.get(c)) {
+      if (c != ' ' && c != '\t' && c != '\r') {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  for (size_t i = 0; i < intOut.size(); ++i) {
+    skipWs(p);
+    const char* end = valueEnd(p);
+    const char* integer = p;
+    if (*integer == '+') {
+      ++integer;
+    }
+    int64_t value = 0;
+    const std::from_chars_result parsed = std::from_chars(integer, end, value);
+    if ((parsed.ptr == integer) || (parsed.ec != std::errc()) ||
+        !checkIntegerTail(parsed.ptr, end)) {
+      throw std::runtime_error(
+          "BlackBoxExec: failed to read output integer " + std::to_string(i) +
+          " from blackbox process output, " + std::to_string(intOut.size()) +
+          " integer values were expected");
+    }
+    intOut[i] = value;
+    p = end;
+    skipWs(p);
+    if (i + 1 < intOut.size()) {
+      if (*p != ',') {
+        throw std::runtime_error(
+            "BlackBoxExec: blackbox process response is missing an integer "
+            "output separator");
+      }
+      ++p;
+    }
+  }
+
+  skipWs(p);
+  if (*p != ';') {
+    throw std::runtime_error(
+        "BlackBoxExec: blackbox process response is missing the `;' separator "
+        "between the integer and floating point outputs");
+  }
+  ++p;
+
+  for (size_t i = 0; i < floatOut.size(); ++i) {
+    skipWs(p);
+    const char* end = valueEnd(p);
+    std::istringstream in(std::string(p, end));
+    in.imbue(std::locale::classic());
+    double v = 0.0;
+    if (!(in >> v) || !checkNumberTail(in)) {
+      throw std::runtime_error(
+          "BlackBoxExec: failed to read output float " + std::to_string(i) +
+          " from blackbox process output, " + std::to_string(floatOut.size()) +
+          " floating point values were expected");
+    }
+    checkFloat(v, i);
+    floatOut[i] = v;
+    p = end;
+    skipWs(p);
+    if (i + 1 < floatOut.size()) {
+      if (*p != ',') {
+        throw std::runtime_error(
+            "BlackBoxExec: blackbox process response is missing a floating "
+            "point output separator");
+      }
+      ++p;
+    }
+  }
+
+  skipFinalWs(p);
+  if (*p != '\0') {
+    throw std::runtime_error(
+        "BlackBoxExec: blackbox process response contains trailing data");
+  }
+}
+
+}  // namespace atlantis::blackbox

--- a/src/misc/blackboxProcessNone.cpp
+++ b/src/misc/blackboxProcessNone.cpp
@@ -1,0 +1,22 @@
+#include "atlantis/misc/blackboxProcess.hpp"
+
+// Fallback used when neither the POSIX nor the Windows implementation is
+// available for this platform.
+#if !defined(_WIN32) && !defined(ATLANTIS_HAS_POSIX_BLACKBOX_EXEC)
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace atlantis::blackbox {
+
+BlackBoxProcessSession* createBlackBoxProcess(
+    const std::string&, const std::vector<std::string>&) {
+  throw std::runtime_error(
+      "BlackBoxExec: executable blackbox propagators are not supported on this "
+      "platform");
+}
+
+}  // namespace atlantis::blackbox
+
+#endif

--- a/src/misc/blackboxProcessPosix.cpp
+++ b/src/misc/blackboxProcessPosix.cpp
@@ -1,0 +1,502 @@
+#include "atlantis/misc/blackboxProcess.hpp"
+
+#if defined(ATLANTIS_HAS_POSIX_BLACKBOX_EXEC) && !defined(_WIN32)
+
+#include <fcntl.h>
+#include <pthread.h>
+#include <signal.h>
+#include <spawn.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#ifdef __APPLE__
+#include <crt_externs.h>
+#define ATLANTIS_ENVIRON (*_NSGetEnviron())
+#else
+extern char** environ;
+#define ATLANTIS_ENVIRON environ
+#endif
+
+namespace atlantis::blackbox {
+namespace {
+
+/// Upper bound on a single response, so a runaway child cannot exhaust memory.
+constexpr size_t MAX_EXEC_RESPONSE_SIZE = 1024 * 1024;
+
+std::string lastError(const std::string& prefix) {
+  return "BlackBoxExec: " + prefix + " (errno " + std::to_string(errno) + ")";
+}
+
+int setCloexec(int fd) {
+  const int flags = fcntl(fd, F_GETFD);
+  if (flags == -1) {
+    return -1;
+  }
+  return fcntl(fd, F_SETFD, flags | FD_CLOEXEC);
+}
+
+int dupCloexec(int fd, int minFd) {
+  int nfd = -1;
+#ifdef F_DUPFD_CLOEXEC
+  nfd = fcntl(fd, F_DUPFD_CLOEXEC, minFd);
+  if (nfd != -1) {
+    return nfd;
+  }
+  if (errno != EINVAL) {
+    return -1;
+  }
+#endif
+  nfd = fcntl(fd, F_DUPFD, minFd);
+  if (nfd == -1) {
+    return -1;
+  }
+  if (setCloexec(nfd) != 0) {
+    const int e = errno;
+    ::close(nfd);
+    errno = e;
+    return -1;
+  }
+  return nfd;
+}
+
+/// Move \a fd above stderr so that the dup2 targets used while spawning cannot
+/// collide with the descriptors we are about to install.
+int moveFromStandardFd(int fd) {
+  if (fd > STDERR_FILENO) {
+    return fd;
+  }
+  const int nfd = dupCloexec(fd, STDERR_FILENO + 1);
+  if (nfd == -1) {
+    return -1;
+  }
+  ::close(fd);
+  return nfd;
+}
+
+class FileDescriptor {
+  int _fd;
+
+ public:
+  explicit FileDescriptor(int fd = -1) : _fd(fd) {}
+  ~FileDescriptor() { reset(); }
+
+  FileDescriptor(const FileDescriptor&) = delete;
+  FileDescriptor& operator=(const FileDescriptor&) = delete;
+
+  [[nodiscard]] int get() const { return _fd; }
+
+  int release() {
+    const int fd = _fd;
+    _fd = -1;
+    return fd;
+  }
+
+  void reset(int fd = -1) {
+    if (_fd != -1) {
+      ::close(_fd);
+    }
+    _fd = fd;
+  }
+};
+
+int moveAwayFromStandardFd(FileDescriptor& fd) {
+  const int old = fd.release();
+  const int nfd = moveFromStandardFd(old);
+  if (nfd == -1) {
+    fd.reset(old);
+  } else {
+    fd.reset(nfd);
+  }
+  return nfd;
+}
+
+class SpawnFileActions {
+  posix_spawn_file_actions_t _actions;
+  bool _initialized{false};
+
+ public:
+  SpawnFileActions() = default;
+  ~SpawnFileActions() {
+    if (_initialized) {
+      posix_spawn_file_actions_destroy(&_actions);
+    }
+  }
+
+  SpawnFileActions(const SpawnFileActions&) = delete;
+  SpawnFileActions& operator=(const SpawnFileActions&) = delete;
+
+  int init() {
+    const int err = posix_spawn_file_actions_init(&_actions);
+    _initialized = err == 0;
+    return err;
+  }
+  posix_spawn_file_actions_t* get() { return &_actions; }
+};
+
+class SpawnAttributes {
+  posix_spawnattr_t _attr;
+  bool _initialized{false};
+
+ public:
+  SpawnAttributes() = default;
+  ~SpawnAttributes() {
+    if (_initialized) {
+      posix_spawnattr_destroy(&_attr);
+    }
+  }
+
+  SpawnAttributes(const SpawnAttributes&) = delete;
+  SpawnAttributes& operator=(const SpawnAttributes&) = delete;
+
+  int init() {
+    const int err = posix_spawnattr_init(&_attr);
+    _initialized = err == 0;
+    return err;
+  }
+  posix_spawnattr_t* get() { return &_attr; }
+};
+
+int createSocketpair(int sv[2]) {
+#ifdef SOCK_CLOEXEC
+  if (socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, sv) == 0) {
+    return 0;
+  }
+  if (errno != EINVAL) {
+    return -1;
+  }
+#endif
+  if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) != 0) {
+    return -1;
+  }
+  if ((setCloexec(sv[0]) != 0) || (setCloexec(sv[1]) != 0)) {
+    const int e = errno;
+    ::close(sv[0]);
+    ::close(sv[1]);
+    errno = e;
+    return -1;
+  }
+  return 0;
+}
+
+/// Write without ever raising SIGPIPE in the solver process: a blackbox that
+/// dies must surface as an error, not as a fatal signal.
+ssize_t sendNoSigpipe(int fd, const char* data, size_t size) {
+#ifdef MSG_NOSIGNAL
+  return send(fd, data, size, MSG_NOSIGNAL);
+#elif defined(SO_NOSIGPIPE)
+  return send(fd, data, size, 0);
+#else
+  sigset_t block;
+  sigset_t old;
+  sigset_t pending;
+  sigemptyset(&block);
+  sigaddset(&block, SIGPIPE);
+  bool blocked = false;
+  bool wasPending = false;
+  if (pthread_sigmask(SIG_BLOCK, &block, &old) == 0) {
+    blocked = true;
+    if (sigpending(&pending) == 0) {
+      wasPending = sigismember(&pending, SIGPIPE) == 1;
+    }
+  }
+  const ssize_t n = send(fd, data, size, 0);
+  if ((n == -1) && (errno == EPIPE) && !wasPending) {
+    const struct timespec timeout = {0, 0};
+    sigtimedwait(&block, nullptr, &timeout);
+  }
+  if (blocked) {
+    pthread_sigmask(SIG_SETMASK, &old, nullptr);
+  }
+  return n;
+#endif
+}
+
+class PosixProcessSession : public BlackBoxProcessSession {
+  pid_t _child{-1};
+  int _pipeSend{-1};
+  FILE* _fileReceive{nullptr};
+
+  static void sleepGracePeriod() {
+    struct timespec remaining = {0, 10000000};
+    while ((nanosleep(&remaining, &remaining) == -1) && (errno == EINTR)) {
+    }
+  }
+
+  static bool childExited(pid_t pid) {
+    siginfo_t info;
+    do {
+      info.si_pid = 0;
+      if (waitid(P_PID, pid, &info, WEXITED | WNOHANG | WNOWAIT) == 0) {
+        return info.si_pid != 0;
+      }
+    } while (errno == EINTR);
+    return false;
+  }
+
+  static void signalGroup(pid_t pid, int sig) { kill(-pid, sig); }
+
+  static void waitGroup(pid_t pid, int attempts) {
+    for (int i = 0; i < attempts; ++i) {
+      if ((kill(-pid, 0) == -1) && (errno == ESRCH)) {
+        return;
+      }
+      if (childExited(pid)) {
+        return;
+      }
+      sleepGracePeriod();
+    }
+  }
+
+  static void terminateChild(pid_t pid) {
+    if (pid <= 0) {
+      return;
+    }
+    int status = 0;
+    // Keep the child unreaped until the group has received both signals.
+    signalGroup(pid, SIGTERM);
+    waitGroup(pid, 100);
+    signalGroup(pid, SIGKILL);
+    do {
+      if (waitpid(pid, &status, 0) != -1) {
+        return;
+      }
+    } while (errno == EINTR);
+  }
+
+  /// Reaping the child requires default SIGCHLD handling; refuse to start
+  /// rather than leak a zombie or block forever in waitpid.
+  static void checkSigchld() {
+    struct sigaction action{};
+    if (sigaction(SIGCHLD, nullptr, &action) != 0) {
+      throw std::runtime_error(lastError("SIGCHLD query failed"));
+    }
+    if ((action.sa_handler != SIG_DFL)
+#ifdef SA_NOCLDWAIT
+        || ((action.sa_flags & SA_NOCLDWAIT) != 0)
+#endif
+    ) {
+      throw std::runtime_error(
+          "BlackBoxExec: cannot start a blackbox process unless SIGCHLD uses "
+          "SIG_DFL without SA_NOCLDWAIT");
+    }
+  }
+
+  void openPosix(const std::string& program,
+                 const std::vector<std::string>& args);
+  void closePosix();
+
+ public:
+  PosixProcessSession(const std::string& program,
+                      const std::vector<std::string>& args) {
+    openPosix(program, args);
+  }
+
+  ~PosixProcessSession() override { closePosix(); }
+
+  std::string exchange(const std::string& request) override {
+    const char* p = request.c_str();
+    size_t remaining = request.size();
+    while (remaining > 0) {
+      const ssize_t n = sendNoSigpipe(_pipeSend, p, remaining);
+      if (n < 0) {
+        if (errno == EINTR) {
+          continue;
+        }
+        throw std::runtime_error(
+            lastError("writing blackbox process input failed"));
+      }
+      if (n == 0) {
+        throw std::runtime_error(
+            "BlackBoxExec: writing blackbox process input wrote zero bytes");
+      }
+      p += n;
+      remaining -= static_cast<size_t>(n);
+    }
+
+    std::string response;
+    while (true) {
+      errno = 0;
+      const int ch = fgetc(_fileReceive);
+      if (ch == EOF) {
+        if (feof(_fileReceive) != 0) {
+          throw std::runtime_error(
+              "BlackBoxExec: blackbox process provided an incomplete response");
+        }
+        const int err = errno;
+        if (err == EINTR) {
+          clearerr(_fileReceive);
+          continue;
+        }
+        errno = err;
+        throw std::runtime_error(
+            lastError("reading blackbox process output from pipe failed"));
+      }
+      response += static_cast<char>(ch);
+      if (response.size() > MAX_EXEC_RESPONSE_SIZE) {
+        throw std::runtime_error(
+            "BlackBoxExec: blackbox process response exceeds the size limit");
+      }
+      if (ch == '\n') {
+        break;
+      }
+    }
+    return response;
+  }
+};
+
+void PosixProcessSession::openPosix(const std::string& program,
+                                    const std::vector<std::string>& args) {
+  const int READ = 0;
+  const int WRITE = 1;
+
+  std::vector<char*> argv;
+  argv.reserve(args.size() + 2);
+  argv.push_back(const_cast<char*>(program.c_str()));
+  for (const std::string& a : args) {
+    argv.push_back(const_cast<char*>(a.c_str()));
+  }
+  argv.push_back(nullptr);
+
+  checkSigchld();
+
+  FileDescriptor childIn[2];
+  FileDescriptor childOut[2];
+  int fds[2];
+  if (createSocketpair(fds) != 0) {
+    throw std::runtime_error(lastError("stdin socket creation failed"));
+  }
+  childIn[READ].reset(fds[READ]);
+  childIn[WRITE].reset(fds[WRITE]);
+  if (createSocketpair(fds) != 0) {
+    throw std::runtime_error(lastError("stdout socket creation failed"));
+  }
+  childOut[READ].reset(fds[READ]);
+  childOut[WRITE].reset(fds[WRITE]);
+
+  FileDescriptor* sessionFds[] = {&childIn[READ], &childIn[WRITE],
+                                  &childOut[READ], &childOut[WRITE]};
+  for (FileDescriptor* fd : sessionFds) {
+    if (moveAwayFromStandardFd(*fd) == -1) {
+      throw std::runtime_error(
+          lastError("moving session descriptors away from stdio failed"));
+    }
+  }
+
+  SpawnFileActions actions;
+  int err = actions.init();
+  if (err != 0) {
+    errno = err;
+    throw std::runtime_error(lastError("spawn file action init failed"));
+  }
+
+  SpawnAttributes attr;
+  err = attr.init();
+  if (err != 0) {
+    errno = err;
+    throw std::runtime_error(lastError("spawn attribute init failed"));
+  }
+
+  // Put the child in its own process group so that teardown can signal the
+  // whole group without touching the solver process.
+  err = posix_spawnattr_setpgroup(attr.get(), 0);
+  if (err == 0) {
+    short flags = POSIX_SPAWN_SETPGROUP;
+#if defined(ATLANTIS_HAS_POSIX_SPAWN_CLOEXEC_DEFAULT) && \
+    defined(ATLANTIS_HAS_POSIX_SPAWN_ADDINHERIT_NP)
+    flags |= POSIX_SPAWN_CLOEXEC_DEFAULT;
+#endif
+    err = posix_spawnattr_setflags(attr.get(), flags);
+  }
+  if (err == 0) {
+    err = posix_spawn_file_actions_adddup2(actions.get(), childIn[READ].get(),
+                                           STDIN_FILENO);
+  }
+  if (err == 0) {
+    err = posix_spawn_file_actions_adddup2(actions.get(), childOut[WRITE].get(),
+                                           STDOUT_FILENO);
+  }
+#if defined(ATLANTIS_HAS_POSIX_SPAWN_CLOEXEC_DEFAULT) && \
+    defined(ATLANTIS_HAS_POSIX_SPAWN_ADDINHERIT_NP)
+  if (err == 0) {
+    err = posix_spawn_file_actions_addinherit_np(actions.get(), STDERR_FILENO);
+  }
+#elif defined(ATLANTIS_HAS_POSIX_SPAWN_ADDCLOSEFROM_NP)
+  if (err == 0) {
+    err =
+        posix_spawn_file_actions_addclosefrom_np(actions.get(),
+                                                 STDERR_FILENO + 1);
+  }
+#endif
+  if (err == 0) {
+    err = posix_spawnp(&_child, program.c_str(), actions.get(), attr.get(),
+                       argv.data(), ATLANTIS_ENVIRON);
+  }
+  if (err != 0) {
+    _child = -1;
+    errno = err;
+    throw std::runtime_error(
+        lastError("starting blackbox process `" + program + "' failed"));
+  }
+
+  childIn[READ].reset();
+  childOut[WRITE].reset();
+
+#ifdef SO_NOSIGPIPE
+  const int nosigpipe = 1;
+  if (setsockopt(childIn[WRITE].get(), SOL_SOCKET, SO_NOSIGPIPE, &nosigpipe,
+                 sizeof(nosigpipe)) != 0) {
+    const int e = errno;
+    terminateChild(_child);
+    _child = -1;
+    errno = e;
+    throw std::runtime_error(lastError("SO_NOSIGPIPE setup failed"));
+  }
+#endif
+
+  FILE* receive = fdopen(childOut[READ].get(), "r");
+  if (receive == nullptr) {
+    const int e = errno;
+    terminateChild(_child);
+    _child = -1;
+    errno = e;
+    throw std::runtime_error(lastError("fdopen failed"));
+  }
+  _fileReceive = receive;
+  childOut[READ].release();
+  _pipeSend = childIn[WRITE].release();
+}
+
+void PosixProcessSession::closePosix() {
+  if (_pipeSend != -1) {
+    ::close(_pipeSend);
+    _pipeSend = -1;
+  }
+  if (_fileReceive != nullptr) {
+    fclose(_fileReceive);
+    _fileReceive = nullptr;
+  }
+  if (_child > 0) {
+    terminateChild(_child);
+    _child = -1;
+  }
+}
+
+}  // namespace
+
+BlackBoxProcessSession* createBlackBoxProcess(
+    const std::string& program, const std::vector<std::string>& args) {
+  return new PosixProcessSession(program, args);
+}
+
+}  // namespace atlantis::blackbox
+
+#endif

--- a/src/misc/blackboxProcessWindows.cpp
+++ b/src/misc/blackboxProcessWindows.cpp
@@ -1,0 +1,413 @@
+#include "atlantis/misc/blackboxProcess.hpp"
+
+#ifdef _WIN32
+
+#define NOMINMAX  // Ensure the words min/max remain available
+#include <Windows.h>
+
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace atlantis::blackbox {
+namespace {
+
+/// Upper bound on a single response, so a runaway child cannot exhaust memory.
+constexpr size_t MAX_EXEC_RESPONSE_SIZE = 1024 * 1024;
+
+std::string windowsError(const std::string& prefix, DWORD err) {
+  return "BlackBoxExec: " + prefix + " (Windows error " + std::to_string(err) +
+         ")";
+}
+
+std::wstring utf8ToWide(const std::string& s) {
+  if (s.empty()) {
+    return {};
+  }
+  const int n = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, s.c_str(),
+                                    static_cast<int>(s.size()), nullptr, 0);
+  if (n == 0) {
+    throw std::runtime_error(
+        "BlackBox: invalid UTF-8 string in blackbox path or argument");
+  }
+  std::wstring w(static_cast<size_t>(n), L'\0');
+  if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, s.c_str(),
+                          static_cast<int>(s.size()), w.data(), n) == 0) {
+    throw std::runtime_error(
+        "BlackBox: invalid UTF-8 string in blackbox path or argument");
+  }
+  return w;
+}
+
+class WindowsHandle {
+  HANDLE _handle;
+
+ public:
+  explicit WindowsHandle(HANDLE handle = nullptr) : _handle(handle) {}
+  ~WindowsHandle() { reset(); }
+
+  WindowsHandle(const WindowsHandle&) = delete;
+  WindowsHandle& operator=(const WindowsHandle&) = delete;
+
+  [[nodiscard]] HANDLE get() const { return _handle; }
+
+  HANDLE* put() {
+    reset();
+    return &_handle;
+  }
+
+  HANDLE release() {
+    HANDLE h = _handle;
+    _handle = nullptr;
+    return h;
+  }
+
+  [[nodiscard]] bool valid() const {
+    return (_handle != nullptr) && (_handle != INVALID_HANDLE_VALUE);
+  }
+
+  void reset(HANDLE handle = nullptr) {
+    if (valid()) {
+      CloseHandle(_handle);
+    }
+    _handle = handle;
+  }
+};
+
+class WindowsAttributeList {
+  std::vector<char> _buffer;
+  LPPROC_THREAD_ATTRIBUTE_LIST _list{nullptr};
+  bool _initialized{false};
+
+ public:
+  WindowsAttributeList() = default;
+  ~WindowsAttributeList() {
+    if (_initialized) {
+      DeleteProcThreadAttributeList(_list);
+    }
+  }
+
+  WindowsAttributeList(const WindowsAttributeList&) = delete;
+  WindowsAttributeList& operator=(const WindowsAttributeList&) = delete;
+
+  void init() {
+    SIZE_T size = 0;
+    InitializeProcThreadAttributeList(nullptr, 1, 0, &size);
+    if (size == 0) {
+      throw std::runtime_error(windowsError(
+          "ProcThreadAttributeList size query failed", GetLastError()));
+    }
+    _buffer.resize(size);
+    _list = reinterpret_cast<LPPROC_THREAD_ATTRIBUTE_LIST>(_buffer.data());
+    if (InitializeProcThreadAttributeList(_list, 1, 0, &size) == 0) {
+      throw std::runtime_error(windowsError(
+          "InitializeProcThreadAttributeList failed", GetLastError()));
+    }
+    _initialized = true;
+  }
+
+  void setInheritedHandles(HANDLE* handles, DWORD count) {
+    if (UpdateProcThreadAttribute(_list, 0, PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
+                                  handles, sizeof(HANDLE) * count, nullptr,
+                                  nullptr) == 0) {
+      throw std::runtime_error(windowsError(
+          "PROC_THREAD_ATTRIBUTE_HANDLE_LIST failed", GetLastError()));
+    }
+  }
+
+  [[nodiscard]] LPPROC_THREAD_ATTRIBUTE_LIST get() const { return _list; }
+};
+
+bool qualifiedPath(const std::wstring& program) {
+  return (program.find_first_of(L"\\/") != std::wstring::npos) ||
+         ((program.size() > 1) && (program[1] == L':'));
+}
+
+/// Quote an argument following the MSVC command-line parsing rules.
+std::wstring quoteArgument(const std::wstring& arg) {
+  std::wstring q(L"\"");
+  unsigned int backslashes = 0;
+  for (const wchar_t ch : arg) {
+    if (ch == L'\\') {
+      ++backslashes;
+    } else if (ch == L'"') {
+      q.append(backslashes * 2 + 1, L'\\');
+      q += ch;
+      backslashes = 0;
+    } else {
+      q.append(backslashes, L'\\');
+      q += ch;
+      backslashes = 0;
+    }
+  }
+  q.append(backslashes * 2, L'\\');
+  q += L'"';
+  return q;
+}
+
+class WindowsProcessSession : public BlackBoxProcessSession {
+  HANDLE _job{nullptr};
+  HANDLE _process{nullptr};
+  HANDLE _pipeSend{nullptr};
+  HANDLE _pipeReceive{nullptr};
+
+  static std::string lastError(const std::string& prefix) {
+    return windowsError(prefix, GetLastError());
+  }
+
+  static void closeHandle(HANDLE& h) {
+    if (h != nullptr) {
+      CloseHandle(h);
+      h = nullptr;
+    }
+  }
+
+  void openWindows(const std::string& program,
+                   const std::vector<std::string>& args);
+  void closeWindows();
+
+ public:
+  WindowsProcessSession(const std::string& program,
+                        const std::vector<std::string>& args) {
+    openWindows(program, args);
+  }
+
+  ~WindowsProcessSession() override { closeWindows(); }
+
+  std::string exchange(const std::string& request) override {
+    size_t written = 0;
+    while (written < request.size()) {
+      DWORD count = 0;
+      const auto remaining = static_cast<DWORD>(request.size() - written);
+      const BOOL success = WriteFile(_pipeSend, request.data() + written,
+                                     remaining, &count, nullptr);
+      if ((success == 0) || (count == 0)) {
+        throw std::runtime_error(
+            lastError("writing blackbox process input failed"));
+      }
+      written += count;
+    }
+
+    char c[2] = {0, 0};
+    std::ostringstream oss;
+    size_t responseSize = 0;
+    while (c[0] != '\n') {
+      DWORD count = 0;
+      const BOOL success =
+          ReadFile(_pipeReceive, c, sizeof(c) - 1, &count, nullptr);
+      if (success == 0) {
+        if (GetLastError() == ERROR_BROKEN_PIPE) {
+          throw std::runtime_error(
+              "BlackBoxExec: blackbox process provided an incomplete response");
+        }
+        throw std::runtime_error(
+            lastError("failed to read blackbox process output from pipe"));
+      }
+      if (count == 0) {
+        throw std::runtime_error(
+            "BlackBoxExec: blackbox process provided an incomplete response");
+      }
+      if (++responseSize > MAX_EXEC_RESPONSE_SIZE) {
+        throw std::runtime_error(
+            "BlackBoxExec: blackbox process response exceeds the size limit");
+      }
+      oss << c[0];
+    }
+    return oss.str();
+  }
+};
+
+void WindowsProcessSession::openWindows(const std::string& program,
+                                        const std::vector<std::string>& args) {
+  // Build the command line before opening OS handles so allocation/conversion
+  // failures cannot leak partially constructed process state.
+  const std::wstring programW = utf8ToWide(program);
+  std::wstring prog = quoteArgument(programW);
+  for (const std::string& a : args) {
+    prog += L" ";
+    prog += quoteArgument(utf8ToWide(a));
+  }
+  std::vector<wchar_t> cmdline(prog.begin(), prog.end());
+  cmdline.push_back(L'\0');
+
+  SECURITY_ATTRIBUTES saAttr;
+  saAttr.nLength = sizeof(SECURITY_ATTRIBUTES);
+  saAttr.bInheritHandle = TRUE;
+  saAttr.lpSecurityDescriptor = nullptr;
+
+  WindowsHandle childStdinRead;
+  WindowsHandle childStdinWrite;
+  WindowsHandle childStdoutRead;
+  WindowsHandle childStdoutWrite;
+  WindowsHandle childStderrWrite;
+
+  if (CreatePipe(childStdoutRead.put(), childStdoutWrite.put(), &saAttr, 0) ==
+      0) {
+    throw std::runtime_error(lastError("stdout CreatePipe failed"));
+  }
+  if (SetHandleInformation(childStdoutRead.get(), HANDLE_FLAG_INHERIT, 0) == 0) {
+    throw std::runtime_error(lastError("stdout SetHandleInformation failed"));
+  }
+  if (CreatePipe(childStdinRead.put(), childStdinWrite.put(), &saAttr, 0) == 0) {
+    throw std::runtime_error(lastError("stdin CreatePipe failed"));
+  }
+  if (SetHandleInformation(childStdinWrite.get(), HANDLE_FLAG_INHERIT, 0) == 0) {
+    throw std::runtime_error(lastError("stdin SetHandleInformation failed"));
+  }
+
+  HANDLE parentStderr = GetStdHandle(STD_ERROR_HANDLE);
+  if ((parentStderr != nullptr) && (parentStderr != INVALID_HANDLE_VALUE)) {
+    if (DuplicateHandle(GetCurrentProcess(), parentStderr, GetCurrentProcess(),
+                        childStderrWrite.put(), 0, TRUE,
+                        DUPLICATE_SAME_ACCESS) == 0) {
+      throw std::runtime_error(lastError("stderr DuplicateHandle failed"));
+    }
+  } else {
+    HANDLE nul =
+        CreateFileW(L"NUL", GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                    &saAttr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (nul == INVALID_HANDLE_VALUE) {
+      throw std::runtime_error(lastError("stderr NUL CreateFile failed"));
+    }
+    childStderrWrite.reset(nul);
+  }
+
+  WindowsAttributeList attrList;
+  attrList.init();
+
+  PROCESS_INFORMATION piProcInfo;
+  STARTUPINFOEXW siStartInfo;
+  ZeroMemory(&piProcInfo, sizeof(PROCESS_INFORMATION));
+  ZeroMemory(&siStartInfo, sizeof(STARTUPINFOEXW));
+  siStartInfo.StartupInfo.cb = sizeof(STARTUPINFOEXW);
+  siStartInfo.StartupInfo.hStdOutput = childStdoutWrite.get();
+  siStartInfo.StartupInfo.hStdInput = childStdinRead.get();
+  siStartInfo.StartupInfo.hStdError = childStderrWrite.get();
+  siStartInfo.StartupInfo.dwFlags |= STARTF_USESTDHANDLES;
+
+  HANDLE inheritHandles[3] = {childStdinRead.get(), childStdoutWrite.get(),
+                              childStderrWrite.get()};
+  attrList.setInheritedHandles(inheritHandles, 3);
+  siStartInfo.lpAttributeList = attrList.get();
+
+  // A job object with KILL_ON_JOB_CLOSE guarantees the child cannot outlive
+  // the solver, even if the solver dies abruptly.
+  WindowsHandle processJob(CreateJobObjectW(nullptr, nullptr));
+  if (!processJob.valid()) {
+    throw std::runtime_error(lastError("CreateJobObject failed"));
+  }
+  JOBOBJECT_EXTENDED_LIMIT_INFORMATION jobInfo;
+  ZeroMemory(&jobInfo, sizeof(jobInfo));
+  jobInfo.BasicLimitInformation.LimitFlags =
+      JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+  if (SetInformationJobObject(processJob.get(),
+                              JobObjectExtendedLimitInformation, &jobInfo,
+                              sizeof(jobInfo)) == 0) {
+    throw std::runtime_error(lastError("SetInformationJobObject failed"));
+  }
+
+  const BOOL processStarted = CreateProcessW(
+      qualifiedPath(programW) ? programW.c_str() : nullptr, cmdline.data(),
+      nullptr,  // process security attributes
+      nullptr,  // primary thread security attributes
+      TRUE,     // handles from attribute list
+      EXTENDED_STARTUPINFO_PRESENT | CREATE_SUSPENDED,
+      nullptr,  // use parent's environment
+      nullptr,  // use parent's current directory
+      &siStartInfo.StartupInfo, &piProcInfo);
+
+  if (processStarted == 0) {
+    throw std::runtime_error(
+        windowsError("starting blackbox process failed for program `" +
+                         program + "'",
+                     GetLastError()));
+  }
+
+  WindowsHandle processHandle(piProcInfo.hProcess);
+  WindowsHandle threadHandle(piProcInfo.hThread);
+
+  if (AssignProcessToJobObject(processJob.get(), processHandle.get()) == 0) {
+    const DWORD err = GetLastError();
+    DWORD terminateErr = ERROR_SUCCESS;
+    if (TerminateProcess(processHandle.get(), 1) == 0) {
+      terminateErr = GetLastError();
+    }
+    const DWORD wait = WaitForSingleObject(processHandle.get(), 5000);
+    std::string message =
+        windowsError("unable to assign blackbox process to required job", err);
+    if (terminateErr != ERROR_SUCCESS) {
+      message +=
+          "; " + windowsError("TerminateProcess cleanup failed", terminateErr);
+    }
+    if (wait == WAIT_FAILED) {
+      message += "; " + lastError("process cleanup wait failed");
+    } else if (wait == WAIT_TIMEOUT) {
+      message += "; process cleanup timed out";
+    }
+    throw std::runtime_error(message);
+  }
+
+  if (ResumeThread(threadHandle.get()) == static_cast<DWORD>(-1)) {
+    const DWORD err = GetLastError();
+    DWORD terminateErr = ERROR_SUCCESS;
+    if (TerminateJobObject(processJob.get(), 1) == 0) {
+      terminateErr = GetLastError();
+    }
+    HANDLE assignedJob = processJob.release();
+    DWORD closeErr = ERROR_SUCCESS;
+    if (CloseHandle(assignedJob) == 0) {
+      closeErr = GetLastError();
+    }
+    const DWORD wait = WaitForSingleObject(processHandle.get(), 5000);
+    std::string message =
+        windowsError("ResumeThread failed for blackbox process", err);
+    if (terminateErr != ERROR_SUCCESS) {
+      message += "; " + windowsError("TerminateJobObject cleanup failed",
+                                     terminateErr);
+    }
+    if (closeErr != ERROR_SUCCESS) {
+      message += "; " + windowsError("job cleanup close failed", closeErr);
+    }
+    if (wait == WAIT_FAILED) {
+      message += "; " + lastError("process cleanup wait failed");
+    } else if (wait == WAIT_TIMEOUT) {
+      message += "; process cleanup timed out";
+    }
+    throw std::runtime_error(message);
+  }
+
+  _pipeSend = childStdinWrite.release();
+  _pipeReceive = childStdoutRead.release();
+  _process = processHandle.release();
+  _job = processJob.release();
+}
+
+void WindowsProcessSession::closeWindows() {
+  closeHandle(_pipeSend);
+  closeHandle(_pipeReceive);
+  if (_process != nullptr) {
+    const DWORD wait = WaitForSingleObject(_process, 1000);
+    if (wait == WAIT_TIMEOUT) {
+      if (_job != nullptr) {
+        TerminateJobObject(_job, 1);
+      } else {
+        TerminateProcess(_process, 1);
+      }
+      WaitForSingleObject(_process, 5000);
+    }
+    closeHandle(_process);
+  }
+  closeHandle(_job);
+}
+
+}  // namespace
+
+BlackBoxProcessSession* createBlackBoxProcess(
+    const std::string& program, const std::vector<std::string>& args) {
+  return new WindowsProcessSession(program, args);
+}
+
+}  // namespace atlantis::blackbox
+
+#endif

--- a/src/propagation/invariants/blackbox.cpp
+++ b/src/propagation/invariants/blackbox.cpp
@@ -1,0 +1,73 @@
+#include "atlantis/propagation/invariants/blackbox.hpp"
+
+#include <cassert>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include "atlantis/propagation/variables/committableInt.hpp"
+
+namespace atlantis::propagation {
+
+Blackbox::Blackbox(SolverBase& solver,
+                   std::shared_ptr<blackbox::BlackBoxFn> blackBoxFn,
+                   std::vector<VarId>&& outputs,
+                   std::vector<VarViewId>&& inputs)
+    : Invariant(solver),
+      _blackBoxFn(std::move(blackBoxFn)),
+      _outputs(std::move(outputs)),
+      _inputs(std::move(inputs)),
+      _intIn(_inputs.size()),
+      _intOut(_outputs.size()) {}
+
+void Blackbox::registerVars() {
+  assert(_id != NULL_ID);
+  for (size_t i = 0; i < _inputs.size(); ++i) {
+    _solver.registerInvariantInput(_id, _inputs[i], LocalId(i), false);
+  }
+  for (const VarId& output : _outputs) {
+    registerDefinedVar(output);
+  }
+}
+
+void Blackbox::recompute(Timestamp timestamp) {
+  for (size_t i = 0; i < _inputs.size(); ++i) {
+    _intIn[i] = _solver.value(timestamp, _inputs[i]);
+  }
+
+  _blackBoxFn->run(_intIn, _floatIn, _intOut, _floatOut);
+
+  // Note: the outputs are deliberately not checked against their declared
+  // domains. Unlike a CP propagator, a CBLS invariant legitimately takes
+  // values that violate the constraints on its outputs -- that violation is
+  // exactly what drives the search.
+  for (size_t i = 0; i < _outputs.size(); ++i) {
+    updateValue(timestamp, _outputs[i], _intOut[i]);
+  }
+}
+
+void Blackbox::notifyInputChanged(Timestamp timestamp, LocalId localId) {
+  assert(localId < _inputs.size());
+  const Int newValue = _solver.value(timestamp, _inputs[localId]);
+  const Int committedValue = _solver.committedValue(_inputs[localId]);
+  if (newValue == committedValue) {
+    return;
+  }
+  recompute(timestamp);
+}
+
+VarViewId Blackbox::nextInput(Timestamp timestamp) {
+  const auto index = static_cast<size_t>(_state.incValue(timestamp, 1));
+  assert(0 <= _state.value(timestamp));
+  if (index < _inputs.size()) {
+    return _inputs[index];
+  }
+  return VarViewId{NULL_ID};
+}
+
+void Blackbox::notifyCurrentInputChanged(Timestamp timestamp) {
+  assert(static_cast<size_t>(_state.value(timestamp)) < _inputs.size());
+  notifyInputChanged(timestamp, _state.value(timestamp));
+}
+
+}  // namespace atlantis::propagation

--- a/src/search/neighborhoods/binaryLinLeNeighborhood.cpp
+++ b/src/search/neighborhoods/binaryLinLeNeighborhood.cpp
@@ -128,4 +128,7 @@ void BinaryLinLeNeighborhood<Violation>::commitIf(
   assert(_curSum <= _bound);
 }
 
+template class BinaryLinLeNeighborhood<true>;
+template class BinaryLinLeNeighborhood<false>;
+
 }  // namespace atlantis::search::neighborhoods


### PR DESCRIPTION
Here is the current (recently updated) implementation of the experimental Blackbox interface that shipped in MiniZinc 2.10: https://docs.minizinc.dev/en/stable/blackbox.html

The main interesting part is the black box invariant that this adds into the Atlantis code base, which just calls the external function through the interface and sets the output values. However, most of the code actually concerns the managing of the DLL or (even worse) the external process. This logic was hardened together with the Gecode developers. It is a little verbose, but it is well tested and should be able to handle any invalid behaviour users might throw at it.

This also contains some small fixes that were either made by my LLM or that I needed to get the codebase to compile on my machine.

Please let me know whether there are any changes you would like to see before you'd consider merging this.

